### PR TITLE
#9382

### DIFF
--- a/django_website/templates/registration/registration_form.html
+++ b/django_website/templates/registration/registration_form.html
@@ -54,4 +54,7 @@ as much as you do.</p>
 
 <p>This account will let you log into the ticket tracker, claim tickets,
 and be exempt from spam filtering.</p>
+
+<p>Your username can only consist of alphanumeric characters and
+underscores and may be up to 30 characters long.</p>
 {% endblock %}


### PR DESCRIPTION
Updating sidebar of the registration page to include information about what constitutes a valid username. Seems less invasive than editing errors for django-registration.
