### PR TITLE
Update to a properly packaged django-push

### DIFF
--- a/deploy-requirements.txt
+++ b/deploy-requirements.txt
@@ -3,6 +3,7 @@
 akismet == 0.2.0
 Django >= 1.3, < 1.4
 django-haystack == 1.1.0
+django-push == 0.4
 django-registration == 0.7
 docutils >= 0.6, < 0.7
 FeedParser >= 5.0, <= 5.1
@@ -19,6 +20,3 @@ http://bitbucket.org/ubernostrum/django-contact-form/get/tip.bz2
 # xapian-haystack has a bug in 1.1.5beta fixed in trunk. So this
 # can go back to a packaged release as soon as there's a newer release.
 -e git://github.com/notanumber/xapian-haystack.git@dc11c14542c0137831e5#egg=xapian-haystack
-
-# django_push has a number of bugs in 0.3 fixed on trunk.
--e git://github.com/brutasse/django-push.git@7ebbb23a0acc74750763#egg=django_push

--- a/django_website/aggregator/admin.py
+++ b/django_website/aggregator/admin.py
@@ -22,10 +22,3 @@ admin.site.register(FeedItem,
 admin.site.register(FeedType,
     prepopulated_fields = {'slug': ('name',)},
 )
-
-# Register an admin for django_push.subscriber - it hasn't got one, and I'd
-# like to use it for debugging purposes.
-from django_push.subscriber.models import Subscription
-admin.site.register(Subscription, 
-    list_display = ['topic', 'verified', 'lease_expiration'],
-)


### PR DESCRIPTION
I just released django-push 0.4, it registers a proper admin and integrates all the fixes and improvements that were only available with the git branch. Should be cleaner this way :)
