### PR TITLE
Center page container

### DIFF
--- a/media/css/base.css
+++ b/media/css/base.css
@@ -16,6 +16,7 @@ body, th, td {
     font:12px/1.4em Verdana,sans-serif;
 }
 #container {
+    margin:0 auto;
     position:relative;
     min-width:55em;
     max-width:100em;


### PR DESCRIPTION
Centered looks much better than left aligned on widescreen monitors, in my opinion.

code.djangoproject.com seems to be using a different style sheet, so the same change will need to be performed there as well (under #django-container).
