### PR TITLE
Clean docs destdir before Spginx renders them

### DIFF
--- a/django_website/docs/management/commands/update_docs.py
+++ b/django_website/docs/management/commands/update_docs.py
@@ -54,9 +54,11 @@ class Command(NoArgsCommand):
             # Use Sphinx to build the release docs into JSON and HTML documents.
             #
             for builder in ('json', 'html'):
+                build_dir = destdir.child('_build', builder)
+                # Remove old renderized versions of the docs
+                build_dir.rmtree(parents=False)
                 # Make the directory for the built files - sphinx-build doesn't
                 # do it for us, apparently.
-                build_dir = destdir.child('_build', builder)
                 if not build_dir.exists():
                     build_dir.mkdir(parents=True)
 
@@ -102,7 +104,7 @@ class Command(NoArgsCommand):
             # Walk the tree we've just built looking for ".fjson" documents
             # (just JSON, but Sphinx names them weirdly). Each one of those
             # documents gets a corresponding Document object created which
-            # we'll then ask Sphinx to reindex.
+            # we'll then ask Haystack to reindex.
             #
             # We have to be a bit careful to reverse-engineer the correct
             # relative path component, especially for "index" documents,


### PR DESCRIPTION
A simple change so the docs.djangoproject.com site doens't contain outdated documents. Seems like people is still reaching them through search engines or old links (e.g. https://code.djangoproject.com/ticket/17352)

AFAICT this also affects the downloadable HTML tarballs.
