### PR TITLE
Blog RSS feed improvements

### DIFF
--- a/django_website/blog/feeds.py
+++ b/django_website/blog/feeds.py
@@ -13,3 +13,9 @@ class WeblogEntryFeed(Feed):
 
     def item_pubdate(self, item):
         return item.pub_date
+
+    def item_author_name(self, item):
+        return item.author
+
+    def item_description(self, item):
+        return item.body_html


### PR DESCRIPTION
The blog RSS feed isn't friendly to readers because it doesn't include the body. The default behaviour of `django.contrib.syndication.views.Feed` uses the title instead.

I've added `item_description()` to `WeblogEntryFeed` using the body rather than summary field because the majority of posts are short. This places escaped HTML into the feed, which all readers should understand. Also added `item_author_name()` because, well, why not.
