### PR TITLE
Typo in password_reset_email.html

### DIFF
--- a/django_website/templates/registration/password_reset_email.html
+++ b/django_website/templates/registration/password_reset_email.html
@@ -4,7 +4,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url auth_password_reset_confim uidb36=uid, token=token %}
+{{ protocol }}://{{ domain }}{% url auth_password_reset_confirm uidb36=uid, token=token %}
 {% endblock %}
 {% trans "Your username, in case you've forgotten:" %} {{ user.username }}
 


### PR DESCRIPTION
Typo gives error on reverse of url, change: "auth_password_reset_confim" => "auth..._password_reset_confirm"
