### PR TITLE
Reorder contents of the title html tags

### DIFF
--- a/django_website/templates/base.html
+++ b/django_website/templates/base.html
@@ -4,7 +4,7 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <meta http-equiv="Content-Language" content="en-us" />
-    <title>Django | {% block title %}The Web framework for perfectionists with deadlines{% endblock %}</title>
+    <title>{% block title %}The Web framework for perfectionists with deadlines{% endblock %} | Django</title>
     <meta name="ROBOTS" content="ALL" />
     <meta http-equiv="imagetoolbar" content="no" />
     <meta name="MSSmartTagsPreventParsing" content="true" />

--- a/django_website/templates/blog/entry_archive_day.html
+++ b/django_website/templates/blog/entry_archive_day.html
@@ -1,6 +1,6 @@
 {% extends "base_weblog.html" %}
 
-{% block title %}Weblog | {{ day|date:"F j" }}{% endblock %}
+{% block title %}{{ day|date:"F j" }} | Weblog{% endblock %}
 
 {% block content %}
 

--- a/django_website/templates/blog/entry_archive_month.html
+++ b/django_website/templates/blog/entry_archive_month.html
@@ -1,6 +1,6 @@
 {% extends "base_weblog.html" %}
 
-{% block title %}Weblog | {{ month|date:"F" }}{% endblock %}
+{% block title %}{{ month|date:"F" }} | Weblog{% endblock %}
 
 {% block content %}
 

--- a/django_website/templates/blog/entry_archive_year.html
+++ b/django_website/templates/blog/entry_archive_year.html
@@ -1,6 +1,6 @@
 {% extends "base_weblog.html" %}
 
-{% block title %}Weblog | {{ year }}{% endblock %}
+{% block title %}{{ year }} | Weblog{% endblock %}
 
 {% block content %}
 

--- a/django_website/templates/blog/entry_detail.html
+++ b/django_website/templates/blog/entry_detail.html
@@ -1,6 +1,6 @@
 {% extends "base_weblog.html" %}
 
-{% block title %}Weblog | {{ object.headline|escape }}{% endblock %}
+{% block title %}{{ object.headline|escape }} | Weblog{% endblock %}
 
 {% block content %}
 <h1>{{ object.headline|safe }}</h1>


### PR DESCRIPTION
This is useful for people on small screens or for those with many tabs open, eg
Django | The File object | Django Documentation
becomes
The File object | Django Documentation | Django
now.
