### PR TITLE
Add the ability to use scm = git

### DIFF
--- a/django_website/docs/management/commands/update_docs.py
+++ b/django_website/docs/management/commands/update_docs.py
@@ -150,3 +150,7 @@ class Command(NoArgsCommand):
 
     def update_svn(self, url, destdir):
         subprocess.call(['svn', 'checkout', '-q', url, destdir])
+
+    def update_git(self, url, destdir):
+        repo_url, branch = url.rsplit("@", 1)
+        subprocess.call(['git', 'clone', '-q', '--branch', branch, repo_url, destdir])


### PR DESCRIPTION
Looking at the file, it appears that the url, destdir, and scm is controlled in the models, so I added a new update_git method that will take a git clone url and build the docs from it.

The only gotcha is in order to specify the branch, i've hijacked the pip like syntax of @, so all git scm urls _must_ contain a branch, e.g. https://github.com/django/django.git@master or https://github.com/django/django.git@1.4.X (they can also be tags).

I wasn't able to test this since the migrations were broken.
