### PR TITLE
Fix homepage

### DIFF
--- a/django_website/templates/homepage.html
+++ b/django_website/templates/homepage.html
@@ -57,7 +57,7 @@
 	<dt><a href="http://www.torontolife.com/">Toronto Life</a></dt>
 	<dd>Toronto's city magazine.</dd>
 </dl>
-<p><a href="https://code.djangoproject.com/wiki/DjangoPoweredSites">See more sites...</a></p>
+<p><a href="http://www.djangosites.org/">See more sites...</a></p>
 {% endblock %}
 
 {% block content-extra %}


### PR DESCRIPTION
I was looking sites using Django and found bad link, so why not contribute :)
- Remove tabblo because the site is down
- Change link of "See more sites..." to djangosites.org because the Wiki page is officially retired
