### PR TITLE
disallow search engine indexing of trunk documentation

### DIFF
--- a/media/robots.txt
+++ b/media/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /en/dev/
+


### PR DESCRIPTION
The end result of this data being indexed confuses newbies and is the source of an increasing number of invalid tickets in trac. More specifically:
1. User searches to find info on a specific feature.
2. Said feature is backwards incompatible with previous versions of Django.
3. User does not know better, assumes Django has a bug.
4. Invalid bug is filed in trac.

Hopefully, removing the dev documentation pages from search engines will help solve this issue, since those who want to read the dev docs can just click through to them by using the version navigation at the bottom of the docs pages.
