### PR TITLE
Add note, and fix a typo.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ To run locally, do the usual::
    If you only need to deploy, and don't need to test any changes,
    you can use local-requirements.txt only.
 
-3. Create a 'secrets.json' file in the directoy above the checkout, containing
+3. Create a 'secrets.json' file in the directory above the checkout, containing
    something like::
 
     { "secret_key": "xyz",
@@ -33,6 +33,7 @@ To run locally, do the usual::
    and::
 
     ./manage.py syncdb --docs
+    ./manage.py migrate --docs
 
    if you want to run docs site.
 


### PR DESCRIPTION
Running `./manage.py syncdb --docs` says:

```
Not synced (use migrations):
 - docs
```

So I added a `./manage.py migrate --docs` to the set of instructions, just as in the `syncdb`/`migrate` command right above this step.

Also, fixed a typo in the said README.
