### PR TITLE
Fixed #21702 - Added nested list different bullet styles

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -331,11 +331,9 @@ ul li {
 }
 ul ul li {
     list-style-type:disc;
-    margin-bottom:.4em;
 }
 ul ul ul li {
     list-style-type:circle;
-    margin-bottom:.4em;
 }
 ul ul {
     padding-left:1.2em;


### PR DESCRIPTION
This creates three levels of visual indentation with the order square > disc > circle. It should make quickly scanning through lists easier. A similar patch has been submitted alongside to the main django repository.
