### PR TITLE
Propagate the fragment identifier to the documentation version switcher.

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -22,24 +22,24 @@
   This is only needed because we want to show the developement version
   warning on top.
   {% endcomment %}
-  $(document).ready(function(){
+  $(document).ready(function () {
     // First handle the case in which someone clicks on a link
-    $('a[href*=#]').click(function(event) {
+    $('a[href*=#]').click(function () {
       // check to see if this is an internal link, sigh.
-      if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'')
+      if (location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '')
           && location.hostname == this.hostname) {
         // get the link target, use the weird id= query since it escapes dots
         var target = $("[id='" + this.hash.slice(1) + "']");
         // calculate the offset
         var targetOffset = target.offset().top - $('#dev-warning').height() - 20;
         // scroll to the place, there is probably a better way
-        setTimeout(function() {
+        setTimeout(function () {
           $('html,body').scrollTop(targetOffset);
         }, 50);
       }
     });
     // this is the janky thing, there is probably a better way
-    setTimeout(function() {
+    setTimeout(function () {
       // is there a hash in the current window's location?
       if (window.location.hash) {
         // again, get the target
@@ -55,7 +55,7 @@
   
   // Propagate the fragment identifier to the links in the version switcher
   if (window.location.hash) {
-    $('#doc-versions a').each(function(){
+    $('#doc-versions a').each(function () {
       var anchor = $(this);
       anchor.attr('href', anchor.attr('href') + window.location.hash);
     });


### PR DESCRIPTION
Since the URL fragment identifier (the stuff afer a `#` in the URL) is not passed to the server, the version switcher loses this information when the links are generated in the template engine.

This means that when you follow a link that contains a fragment identifier and want to switch versions, you either:
- switch versions in the URL manually and keep the fragment
- use the version switcher and have to find where you were in the page

This PR uses some javascript to go and append `window.location.hash` to all the links inside the version switcher.

If an older version doesn't have a paragraph associated with the fragment identifier, then nothing happens (which is consistent with the previous behavior).
