### PR TITLE
Added handler to include #id on document version link click.

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -51,6 +51,21 @@
       }
     // use a delay that should work on all modern computers. should, not will.
     }, 50);
+    // Make sure doc version links retain #id in url.
+    var get_id_in_url = function() {
+      var href = window.location.href;
+      if (href.indexOf('#') == -1) {
+        return '';
+      } else {
+        return '#' + href.split('#').pop();
+      }
+    };
+    $('.docurl').on('click', function(e) {
+      e.preventDefault();
+      var id = get_id_in_url(),
+          href = $(this).attr('href');
+      window.location = href + id;
+    });
   });
   </script>
   {% endif %}
@@ -76,7 +91,7 @@
         {% if version != v %}
           <li class="other">
           {% if docurl %}
-            <a href="{% url 'document-detail' lang=lang version=v url=docurl %}">{{ v }}</a>
+            <a class="docurl" href="{% url 'document-detail' lang=lang version=v url=docurl %}">{{ v }}</a>
           {% else %}
             <a href="{% url 'document-index' lang=lang version=v %}">{{ v }}</a>
           {% endif %}


### PR DESCRIPTION
When you change document versions while on a page you lose the # anchor in the url.  This JavaScript handler ensures that the # anchor is retained.
