### PR TITLE
Fixed #21610 -- Removed broken link on Community page

### DIFF
--- a/templates/base_community.html
+++ b/templates/base_community.html
@@ -16,19 +16,10 @@
 
 <h2>Mailing lists</h2>
 
-<p><strong><a href="http://groups.google.com/group/django-users">django-users</a></strong>: The main list for help and announcements.</p>
-
-<form action="http://groups.google.com/group/django-users/boxsubscribe">
-<p>Subscribe: <input type="text" name="email" size="15" /> <input type="submit" value="Go" /></p>
-</form>
-
-<p><strong><a href="http://groups.google.com/group/django-developers">django-developers</a></strong>: Where the developers of Django itself discuss new features.</p>
-
-<form action="http://groups.google.com/group/django-developers/boxsubscribe">
-<p>Subscribe: <input type="text" name="email" size="15" /> <input type="submit" value="Go" /></p>
-</form>
-
-<p>Problems subscribing? See this <a href="http://groups.google.com/support/bin/answer.py?answer=19870">FAQ answer</a> about non-Gmail addresses.</p>
+<ul>
+<li><strong><a href="https://docs.djangoproject.com/en/dev/internals/mailing-lists/#django-users">django-users</a></strong>: The main list for help and announcements.</li>
+<li><strong><a href="https://docs.djangoproject.com/en/dev/internals/mailing-lists/#django-developers">django-developers</a></strong>: Where the developers of Django itself discuss new features.</li>
+</ul>
 
 <h2>Tell the world</h2>
 <ul>


### PR DESCRIPTION
Removed subscribing form and FAQ link and updated link for django-users
and django-developers to go to 'Mailing lists' webpage.

Thanks bmispelon for the report and claudep and anubhav9042 for the
review.
