### PR TITLE
Added the gettext target for default version

### DIFF
--- a/docs/urls.py
+++ b/docs/urls.py
@@ -54,4 +54,8 @@ urlpatterns = patterns('',
         views.document,
         name='document-detail',
     ),
+    url(
+        r'^pots/(?P<pot_name>\w+\.pot)$',
+        views.pot_file,
+    ),
 )

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -2,11 +2,11 @@ from django.conf import settings
 from django.http import Http404
 from unipath import FSPath as Path
 
-def get_doc_root(lang, version):
-    return Path(settings.DOCS_BUILD_ROOT).child(lang, version, "_built", "json")
+def get_doc_root(lang, version, subroot='json'):
+    return Path(settings.DOCS_BUILD_ROOT).child(lang, version, "_built", subroot)
 
-def get_doc_root_or_404(lang, version):
-    docroot = get_doc_root(lang, version)
+def get_doc_root_or_404(lang, version, subroot='json'):
+    docroot = get_doc_root(lang, version, subroot)
     if not docroot.exists():
         raise Http404(docroot)
     return docroot

--- a/docs/views.py
+++ b/docs/views.py
@@ -73,6 +73,16 @@ def document(request, lang, version, url):
     return render(request, template_names, context)
 
 
+def pot_file(request, pot_name):
+    version = DocumentRelease.objects.current().version
+    doc_root = get_doc_root_or_404('en', version, subroot='gettext').child('locale')
+    return django.views.static.serve(
+        request,
+        document_root=doc_root,
+        path=pot_name,
+    )
+
+
 class SphinxStatic(object):
     """
     Serve Sphinx static assets from a subdir of the build location.


### PR DESCRIPTION
This allows us to point Transifex to these files instead of having
to statically commit the produced pot files in some repo (used to
be in django-docs-translations).
