### PR TITLE
Actually fork sphinx-build to keep Sphinx from leaking state.

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -11,7 +11,6 @@ import optparse
 import shutil
 import subprocess
 import zipfile
-import sphinx.cmdline
 from contextlib import closing
 from django.conf import settings
 from django.core.management.base import NoArgsCommand


### PR DESCRIPTION
This solves [#21400](https://code.djangoproject.com/ticket/21400) (tested locally) (and possibly [#20469](https://code.djangoproject.com/ticket/20469) ?)
