### PR TITLE
Fixed copyright statement: contributors retain copyright

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,7 +44,7 @@
     <div id="footer">
       <p>&copy; 2005-{% now "Y" %}
         <a href="https://www.djangoproject.com/foundation/"> Django Software
-        Foundation</a> unless otherwise noted. Django is a
+        Foundation</a> and individual contributors. Django is a
         <a href="https://www.djangoproject.com/trademarks/">registered
         trademark</a> of the Django Software Foundation.
         <a href="http://mediatemple.net/">Linux Web hosting</a> graciously


### PR DESCRIPTION
The copyright for the docs is not held solely by the DSF, but by each individual contributor. Django does not use copyright assignment.
