### PR TITLE
The django community is welcoming and supportive of all people

### DIFF
--- a/templates/conduct/index.html
+++ b/templates/conduct/index.html
@@ -41,10 +41,10 @@ For more details please see our
 
   <li><strong>Be welcoming.</strong> We strive to be a community that welcomes
   and supports people of all backgrounds and identities. This includes, but
-  is not limited to members of any race, ethnicity, culture, national origin, colour,
-  immigration status, social and economic class, sex, sexual orientation,
-  gender identity and expression, age, size, family status, political belief,
-  religion, and mental and physical ability.</li>
+  is not limited to members of any race, ethnicity, culture, national origin,
+  colour, immigration status, social and economic class, educational level, sex,
+  sexual orientation, gender identity and expression, age, size, family status,
+  political belief, religion, and mental and physical ability.</li>
 
   <li><strong>Be considerate.</strong> Your work will be used by other people, and you in turn will
   depend on the work of others. Any decision you take will affect users and


### PR DESCRIPTION
It's hard enough to avoid thinking and acting in discriminatory
ways when you're aware of your conscious and unconscious tendencies
to do so. It's impossible when you're unaware. Explicitly spelling out a
more comprehensive list of social identities that make us unique helps
us be more cognizant of ways we may accidentally discriminate and make
others feel unwelcome. When others feel unwelcome, the Django
community loses an important perspective. As Daniele Procida so
eloquently reminded us in his keynote address at Djangocon 2014, the
health of our community hinges on our ability to welcome and support
folks who come from a wide variety of backgrounds and situations. He
warned us against the tendency of the software development tribe to be
exlusionary. Let's help prove that it doesn't have to be that way by
publicly stating our goal of being welcoming to all people (and being
explicit about how broadly we define "all people").

FWIW, I showed my list of "discrimination categories" to @evildmp earlier
today and we edited it together. I then decided it would be preferable
to couch the whole statement in the positive. This is why I placed the
statement in the list item about being welcoming rather than placing it
in the list of language and discriminatory behavior in which _not_
to engage.
