### PR TITLE
Refs #23334 -- changed some /newticket links

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -6,7 +6,7 @@
 
 <h2>Page not found</h2>
 
-<p>Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/newticket/">let us know</a>.</p>
+<p>Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/">let us know</a>.</p>
 
 <p>Here's a link to the <a href="/">homepage</a>. You know, just in case.</p>
 

--- a/templates/base_community.html
+++ b/templates/base_community.html
@@ -11,7 +11,7 @@
 
 <ul>
 <li><a href="irc://irc.freenode.net/django">#django IRC channel</a> -- chat with other Django users</li>
-<li><a href="https://code.djangoproject.com/newticket">Ticket system</a> -- report bugs and make feature requests</li>
+<li><a href="https://code.djangoproject.com/">Ticket system</a> -- report bugs and make feature requests</li>
 </ul>
 
 <h2>Mailing lists</h2>
@@ -38,7 +38,7 @@
 <h2>Get help</h2>
 
 <ul>
-<li><strong><a href="https://docs.djangoproject.com/en/{{ DOCS_VERSION }}/faq/">Check our FAQ</a> first</strong>. If you have a basic question that's not answered by the FAQ, <a href="https://code.djangoproject.com/newticket">file a ticket</a> to tell us you think it should be in there.</li>
+<li><strong><a href="https://docs.djangoproject.com/en/{{ DOCS_VERSION }}/faq/">Check our FAQ</a> first</strong>. If you have a basic question that's not answered by the FAQ, <a href="https://code.djangoproject.com/">file a ticket</a> to tell us you think it should be in there.</li>
 <li><strong>Chat live with other Django users</strong> in the <a href="irc://irc.freenode.net/django">#django IRC channel on irc.freenode.net</a>.</li>
 <li><strong>Ask questions</strong> on the <a href="http://groups.google.com/group/django-users">django-users mailing list</a>.</li>
 <li><strong>Report potential security issues in Django via private email to security@djangoproject.com, </strong>and not via Django's Trac instance or the django-developers mailing list</li>


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23334
/newticket currently has an unfriendly "forbidden" error if you are
logged out. Send them to wiki home page instead.
