### PR TITLE
Fixed #23124 -- Added touch support for version chooser in docs

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -17,6 +17,12 @@
       this.href = hrefWithoutFragment + window.location.hash;
       // do nothing and let the event bubble up
     });
+
+    // Make version switcher clickable for touch devices
+    $('#doc-versions li.current').on('click hover', function () {
+      $('#doc-versions li.other').toggle();
+    });
+
   });
   </script>
 {% if version_is_dev %}


### PR DESCRIPTION
I added a small fix that makes switching docs version on touch devices posible. You can now hover (on desktops) or click (on touch devices and desktops) to see a list of available versions. 
