### PR TITLE
Fixed #23472 -- Added links to Code of Conduct and Foundation pages

### DIFF
--- a/templates/base_community.html
+++ b/templates/base_community.html
@@ -43,4 +43,19 @@
 <li><strong>Ask questions</strong> on the <a href="http://groups.google.com/group/django-users">django-users mailing list</a>.</li>
 <li><strong>Report potential security issues in Django via private email to security@djangoproject.com, </strong>and not via Django's Trac instance or the django-developers mailing list</li>
 </ul>
+
+<h2>Code of Conduct</h2>
+
+<ul>
+<li><strong><a href="/conduct/">Read the Django Code of Conduct</a></strong> &mdash; a guide to make it easier to enrich Django community members</li>
+<li><a href="/foundation/committees/">Code of Conduct Committee</a> &mdash; deals with violations in the Django Code of Conduct</li>
+</ul>
+
+<h2>Django Software Foundation</h2>
+
+<ul>
+<li><a href="/foundation/">Learn about the Django Software Foundation</a></li>
+<li><strong><a href="/foundation/donate/">Support the Foundation</a></strong> &mdash; donate to support future Django framework development</li>
+<li><a href="/contact/foundation/">Contact the Django Software Foundation</a></li>
+</ul>
 {% endblock %}


### PR DESCRIPTION
This is a solution to this ticket: https://code.djangoproject.com/ticket/23472#ticket
