### PR TITLE
Fixed #23856 -- Warn about downloading development version

### DIFF
--- a/templates/releases/download.html
+++ b/templates/releases/download.html
@@ -34,7 +34,7 @@
 
 <h2>Option {% cycle options %}. Get the latest development version</h2>
 
-<p>The latest and greatest Django version is the one that's in our Git repository (our revision-control system). Get it using this shell command, which requires <a href="http://git-scm.com/">Git</a>:</p>
+<p>The latest development version is the one that's in our Git repository (our revision-control system). This is only for experienced users who want to try out incoming changes and help identify any bugs prior to a release. Get it using this shell command, which requires <a href="http://git-scm.com/">Git</a>:</p>
 
 <p class="literal-block"><code>git clone https://github.com/django/django.git</code></p>
 


### PR DESCRIPTION
Replicated the warning from
https://docs.djangoproject.com/en/1.7/intro/install/ about how the
development version is best used by those with experience looking to
test.
