### PR TITLE
Renamed "CoC Working Group" to "Committee" and added a link

### DIFF
--- a/templates/conduct/enforcement.html
+++ b/templates/conduct/enforcement.html
@@ -6,33 +6,33 @@
 <h1>Django Code of Conduct - Enforcement Manual</h1>
 
 <h2 class="deck">This is the enforcement manual followed by Django's Code of
-Conduct Working Group. It's used when we respond to an issue to make sure we're
+Conduct Committee. It's used when we respond to an issue to make sure we're
 consistent and fair. It should be considered an internal document, but we're
 publishing it publicly in the interests of transparency.<h2>
 
-<h3>The Conduct Working Group</h3>
+<h3>The Code of Conduct Committee</h3>
 
-<p>All responses to reports of conduct violations will be managed by a Code of
-Conduct Working Group ("the working group").</p>
+<p>All responses to reports of conduct violations will be managed by a
+<a href="/foundation/committees/">Code of Conduct Committee</a> ("the committee").</p>
 
 <p>The Django Software Foundation's Board of Directors ("the board") will establish
-this working group, compromised of at least three members. One member will be
+this committee, compromised of at least three members. One member will be
 designated chair of the group and will be responsible for all reports back to
 the board. The board will review membership on a regular basis.</p>
 
-<h3>How the working group will respond to reports</h3>
+<h3>How the committee will respond to reports</h3>
 
-<p>When a report is sent to the working group they will immediately reply to the
+<p>When a report is sent to the committee they will immediately reply to the
 report to confirm receipt. This reply must be sent within 24 hours, and the
 group should strive to respond much quicker than that.</p>
 
 <p>See the <a href="/conduct/reporting/">reporting guidelines</a> for details of
 what reports should contain. If a report doesn't contain enough information, the
-working group will obtain all relevant data before acting. The working group is
+committee will obtain all relevant data before acting. The committee is
 empowered to act on the DSF's behalf in contacting any individuals involved to
 get a more complete account of events.</p>
 
-<p>The working group will then review the incident and determine, to the best of their ability:
+<p>The committee will then review the incident and determine, to the best of their ability:
 <ul>
     <li>what happened</li>
     <li>whether this event constitutes a code of conduct violation</li>


### PR DESCRIPTION
The (flat)page that lists the composition of the CoC working group
calls it a "committee".
I added a link to that page and changed "working group" to "committee"
for consistency.