### PR TITLE
Fixed #23886 -- Displaying 410 page instead of 500 on outdated docs sites

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -46,6 +46,9 @@ def document(request, lang, version, url):
     docroot = get_doc_root_or_404(lang, version)
     doc_path = get_doc_path_or_404(docroot, url)
 
+    if not docroot.child('globalcontext.json').exists():
+        return render(request, '410.html', status=410)
+
     if version == 'dev':
         rtd_version = 'latest'
     elif version >= '1.5':


### PR DESCRIPTION
I fixed an error that caused [exceptions on outdated docs pages](https://code.djangoproject.com/ticket/23886). 

I also tested this on the new redesign branch, it works there if you're wondering. Should I write some tests for that bug fix? This view doesn't have any tests yet as far as I can see.

> (Happy [24pullrequests.com](http://24pullrequests.com/)! :gift:)
