### PR TITLE
Fix a 404 link on documentation index page

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -186,7 +186,7 @@ $(document).ready(function () {
             <dt><a href="{{ faq_url }}">FAQ</a></dt>
             <dd>{% blocktrans %}Try the FAQ — it's got answers to many common questions.{% endblocktrans %}</dd>
 
-            <dt><a href="/en/stable/genindex/">{% trans "Index" %}</a>, <a href="/en/stable/py-modindex/">{% trans "Model Index" %}</a> or <a href="/en/stable/context/">{% trans "Table of Contents" %}</a></dt>
+            <dt><a href="/en/stable/genindex/">{% trans "Index" %}</a>, <a href="/en/stable/py-modindex/">{% trans "Model Index" %}</a> or <a href="/en/stable/contents/">{% trans "Table of Contents" %}</a></dt>
             <dd>{% blocktrans %}Handy when looking for specific information.{% endblocktrans %}</dd>
 
             <dt><a href="http://groups.google.com/group/django-users/">django-users mailing list</a></dt>


### PR DESCRIPTION
"Table of Contents" link was pointing to /context, a 404 - should be /contents instead.
