### PR TITLE
Add more monospace font options.

### DIFF
--- a/static/scss/_utils.scss
+++ b/static/scss/_utils.scss
@@ -70,7 +70,7 @@ $old-ie: false !default;
 	font-family: "Roboto", Corbel, Avenir, "Lucida Grande", "Lucida Sans", sans-serif;
 }
 @mixin monospace {
-	font-family: Consolas, Inconsolata, Menlo, Monaco, "Courier New", Courier, monospace;
+	font-family: Inconsolata, Consolas, Menlo, Monaco, "Courier New", Courier, monospace;
 }
 
 // Font Sizing Mixin (http://css-tricks.com/snippets/css/less-mixin-for-rem-font-sizing/)


### PR DESCRIPTION
I added a few commonly-available monospace fonts to the monospace stack so fewer users should end up resorting to Courier New. Apparently, there was also some trailing whitespace that my editor cleaned up.
