### PR TITLE
Fix case of "GitHub"

### DIFF
--- a/templates/conduct/changes.html
+++ b/templates/conduct/changes.html
@@ -11,7 +11,7 @@
 associated documents the same way we track changes to code. All changes will
 proposed via a pull request to the
 <a href="http://github.com/django/djangoproject.com">djangoproject.com repository
-on Github</a>. Changes will be reviewed by the conduct committee first, and then
+on GitHub</a>. Changes will be reviewed by the conduct committee first, and then
 sent to the DSF, the Django core team, and the Django community for comment.
 We'll hold a comment period of at least one week,  and then each group will vote
 on the change using its normal process (a board for the DSF,
@@ -23,7 +23,7 @@ Approved changes will be merged, published, and noted below.</p>
 (typo fixes, re-wordings, etc.) can be made immediately.</p>
 
 <p>A complete list of changes can always be found
-<a href="https://github.com/django/djangoproject.com/commits/master/templates/conduct">on Github</a>;
+<a href="https://github.com/django/djangoproject.com/commits/master/templates/conduct">on GitHub</a>;
 major changes and releases are summarized below.</p>
 
 <h2>Changelog</h2>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -30,7 +30,7 @@
       <div class="col follow last-child">
         <h2>Follow Us</h2>
         <ul>
-          <li><a href="https://github.com/django">Github</a></li>
+          <li><a href="https://github.com/django">GitHub</a></li>
           <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
           <li><a href="/rss/weblog/">News RSS</a></li>
           <li><a href="https://groups.google.com/forum/#!forum/django-users">Django Users Mailing List</a></li>

--- a/templates/includes/footer_docs.html
+++ b/templates/includes/footer_docs.html
@@ -30,7 +30,7 @@
       <div class="col follow">
         <h2>Follow Us</h2>
         <ul>
-          <li><a href="http://github.com/django">Github</a></li>
+          <li><a href="http://github.com/django">GitHub</a></li>
           <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
           <li><a href="https://www.djangoproject.com/rss/weblog/">News RSS</a></li>
           <li><a href="https://groups.google.com/forum/#!forum/django-users">Django Users Mailing List</a></li>


### PR DESCRIPTION
:sparkles: I love the redesign! :sparkles: 

Just a little nitpick... GitHub has a capital "H".
