### PR TITLE
Added a non-permanent redirect for /overview/.

### DIFF
--- a/django_www/urls.py
+++ b/django_www/urls.py
@@ -22,8 +22,10 @@ sitemaps = {
 
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='homepage.html'), name="homepage"),
-    url(r'^overview/$', TemplateView.as_view(template_name='overview.html'), name="overview"),
+    url(r'^start/overview/$', TemplateView.as_view(template_name='overview.html'), name="overview"),
     url(r'^start/$', TemplateView.as_view(template_name='start.html'), name="start"),
+    # to work around a permanent redirect stored in the db that existed before the redesign:
+    url(r'^overview/$', RedirectView.as_view(url='/start/overview/', permanent=False)),
     url(r'^accounts/', include('accounts.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^community/', include('aggregator.urls')),


### PR DESCRIPTION
This tries to overcome the fact that there was permanent redirect set up in the database that went from `/overview/` to `https://docs.djangoproject.com/en/1.7/intro/overview/`.

Since permanent redirects are cached in browsers all we can do is at least provide the redirect for those who have bookmarked that page and come back after they've reset their browser.

For the rest we have to move that page to a different URL endpoint. I choose `/start/overview/` in the hope that there will be more "start" pages at some point.
