### PR TITLE
Fixed #248 - weblog heading levels are now in sequence

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 
 BLOG_DOCUTILS_SETTINGS = getattr(settings, 'BLOG_DOCUTILS_SETTINGS', {
     'doctitle_xform': False,
-    'initial_header_level': 4,
+    'initial_header_level': 3,
     'id_prefix': 's-',
 })
 

--- a/templates/blog/entry_detail.html
+++ b/templates/blog/entry_detail.html
@@ -3,7 +3,7 @@
 {% block title %}{{ object.headline|escape }} | Weblog{% endblock %}
 
 {% block content %}
-<h1>{{ object.headline|safe }}</h1>
+<h2>{{ object.headline|safe }}</h2>
 
 <span class="meta">Posted by <strong>{{ object.author }}</strong> on {{ object.pub_date|date:"F j, Y" }} {% comment %}in <a href="#">Release Announcements</a>{% endcomment %}</span>
 


### PR DESCRIPTION
Title heading is now `<h2>`; first entry body heading is `<h3>`.
