### PR TITLE
Remove django-registration from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ django-contact-form==1.0
 django-haystack==1.2.7
 django-push==0.6.1
 django-pygments==0.1
-django-registration==1.0
 django-registration-redux==1.1
 django-secure==1.0
 docutils==0.11


### PR DESCRIPTION
django-registration-redux is the maintained fork. That's what's listed in deploy-requirements.txt
