### PR TITLE
Fixed #247 -- Yearly blog archive pages don't work

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -34,7 +34,7 @@ class BlogArchiveIndexView(BlogViewMixin, ArchiveIndexView):
 
 
 class BlogYearArchiveView(BlogViewMixin, YearArchiveView):
-    pass
+    make_object_list = True
 
 
 class BlogMonthArchiveView(BlogViewMixin, MonthArchiveView):

--- a/templates/blog/entry_archive_month.html
+++ b/templates/blog/entry_archive_month.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<h1>{{ month|date:"F" }} archive</h1>
+<h1>{{ month|date:"F Y" }} archive</h1>
 
 <ul class="list-news">
 

--- a/templates/blog/entry_archive_year.html
+++ b/templates/blog/entry_archive_year.html
@@ -1,10 +1,10 @@
 {% extends "base_weblog.html" %}
 
-{% block title %}{{ year }} | Weblog{% endblock %}
+{% block title %}{{ year|date:"Y" }} | Weblog{% endblock %}
 
 {% block content %}
 
-<h1>{{ year }} archive</h1>
+<h1>{{ year|date:"Y" }} archive</h1>
 
 <ul class="list-news">
 

--- a/templates/blog/month_links_snippet.html
+++ b/templates/blog/month_links_snippet.html
@@ -3,7 +3,7 @@
   <ul class="list-collapsing active">
   {% for month in dates_by_year %}
     <li id="year{{ month.grouper }}"{% if forloop.first %} class="active"{% endif %}>
-      <h2>{{ month.grouper }} <i class="collapsing-icon icon icon-plus"></i></h2>
+      <h2><a href="/weblog/{{ month.grouper }}/">{{ month.grouper }}</a> <i class="collapsing-icon icon icon-plus"></i></h2>
       <div class="collapsing-content">
         <ul class="list-links-small">
           {% for d in month.list %}


### PR DESCRIPTION
Related issue: #247 

I also made year headers clickable (but you can still collapse/expand them).
