### PR TITLE
Don't reveal heart pixel until pixel subgoal complete

### DIFF
--- a/djangoproject/static/js/mod/heart.js
+++ b/djangoproject/static/js/mod/heart.js
@@ -73,7 +73,7 @@ define([
 		},
 		fadePixels: function () {
 			var percent = this.heart.data('percent');
-			var fadedCount = Math.floor(this.pixels.length * (100 - percent) / 100);
+			var fadedCount = Math.ceil(this.pixels.length * (100 - percent) / 100);
 			for (var i = 0; i < fadedCount; i++) {
 				getRandomElement(this.visiblePixels()).hide();
 			}


### PR DESCRIPTION
Problem:

- 1% was filling in 1 heart instead of 0 hearts (it rounded up)
- 99% was filling in all 27 hearts instead of just 26 (also rounded up)

Now instead 1% fills in 0 hearts and 99% fills in all but one heart.