### PR TITLE
Fix JS selector for fundraising heart

### DIFF
--- a/djangoproject/static/js/mod/fundraising-heart.js
+++ b/djangoproject/static/js/mod/fundraising-heart.js
@@ -129,5 +129,5 @@ define([
 	};
 
 	// Export a single instance of our module:
-	return new Heart('.heart');
+	return new Heart('.fundraising-heart');
 });


### PR DESCRIPTION
The class change got missed in one spot.

Related possible future improvement:

I think a JS-specific class (maybe with a `js-` prefix or something) might be better here it decouples the JS/CSS.  It looks like the `main.js` file is setup to handle classes which are not obviously JS-specific so such a change should probably be made all at once.