### PR TITLE
Fix #349: Add link to tax info to fundraising page.

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -88,9 +88,9 @@
    {% endif %}
 
 <p><b>If you use Django on a daily basis and care about the development of Django
-   itself, you should donate today.</b> Only with your support can we make sure
-   that the Web framework you base your work on can grow to be even better in
-   the coming years.</p>
+   itself, you should donate today</b> (may be <a href="/foundation/donate/#tax-deductible">tax deductible</a>). 
+   Only with your support can we make sure that the Web framework you base your work on 
+   can grow to be even better in the coming years.</p>
 
 <p>The weekly cost of the program is about US&nbsp;${{ weekly_goal|intcomma }}. <b>We're
    trying to raise an initial US&nbsp;${{ goal_amount|intcomma }} to renew the program


### PR DESCRIPTION
Not yet sure of wording or placement, but this is a start. I'll update the link when/if the "donate" flatpage is updated with IDs for the headings.