### PR TITLE
Remove space at end of link

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -117,9 +117,9 @@
           {% if donor.url %}</a>{% endif %}
         </div>
         <div class="hero-name">
-          {% if donor.url %}<a href="{{ donor.url }}" rel="nofollow">{% endif %}
+          {% if donor.url %}<a href="{{ donor.url }}" rel="nofollow">{% endif %}{% spaceless %}
             {{ donor.name }}
-          {% if donor.url %}</a>{% endif %}
+          {% endspaceless %}{% if donor.url %}</a>{% endif %}
           {% if donor.is_amount_displayed %}
             <br/><em>${{ donor.donated_amount|intcomma }}</em>
           {% endif %}
@@ -130,9 +130,9 @@
   <div class="heros">
     {% for donor in other_donors %}
       <div class="no-logo-hero">
-        {% if donor.url %}<a href="{{ donor.url }}" rel="nofollow">{% endif %}
+        {% if donor.url %}<a href="{{ donor.url }}" rel="nofollow">{% endif %}{% spaceless %}
         <span>{{ donor.name }}</span>
-        {% if donor.url %}</a>{% endif %}
+        {% endspaceless %}{% if donor.url %}</a>{% endif %}
         {% if donor.is_amount_displayed %}
           <br/><em>${{ donor.donated_amount|intcomma }}</em>
         {% endif %}


### PR DESCRIPTION
I see the space in Chrome on Ubuntu.  This change fixes it on my browser.

I think a CSS-based solution would be more elegant, but I'm not aware of one currently.