### PR TITLE
Make donate header link go to fundraising homepage

### DIFF
--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -27,7 +27,7 @@
           <a href="{% url 'homepage' %}foundation/">About</a>
         </li>
         <li{% if section == 'fundraising' %} class="active"{% endif %}>
-          <a href="{% url 'fundraising:donate' %}">&#9829; Donate</a>
+          <a href="{% url 'fundraising:index' %}">&#9829; Donate</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Go to https://www.djangoproject.com/fundraising/, not https://www.djangoproject.com/fundraising/donate/