### PR TITLE
Handled anonymous donors on the fundraising index page

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -123,7 +123,7 @@
         </div>
         <div class="hero-name">
           {% if donor.url %}<a href="{{ donor.url }}" rel="nofollow">{% endif %}{% spaceless %}
-            {{ donor.name }}
+            {{ donor.name_with_fallback }}
           {% endspaceless %}{% if donor.url %}</a>{% endif %}
           {% if donor.is_amount_displayed %}
             <br/><em>${{ donor.donated_amount|intcomma }}</em>
@@ -136,7 +136,7 @@
     {% for donor in other_donors %}
       <div class="no-logo-hero">
         {% if donor.url %}<a href="{{ donor.url }}" rel="nofollow">{% endif %}{% spaceless %}
-        <span>{{ donor.name }}</span>
+        <span>{{ donor.name_with_fallback }}</span>
         {% endspaceless %}{% if donor.url %}</a>{% endif %}
         {% if donor.is_amount_displayed %}
           <br/><em>${{ donor.donated_amount|intcomma }}</em>

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -81,6 +81,10 @@ class DjangoHero(FundraisingModel):
     def thumbnail(self):
         return get_thumbnail(self.logo, '170x170', quality=100)
 
+    @property
+    def name_with_fallback(self):
+        return self.name if self.name else 'Anonymous Hero'
+
 
 @receiver(post_save, sender=DjangoHero)
 def create_thumbnail_on_save(sender, **kwargs):

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -42,6 +42,18 @@ class TestIndex(TestCase):
         response = self.client.get(reverse('fundraising:index'))
         self.assertEqual(response.context['total_donors'], 1)
 
+    def test_anonymous_donor(self):
+        hero = DjangoHero.objects.create(is_visible=True, approved=True)
+        Donation.objects.create(donor=hero, amount='5')
+        response = self.client.get(reverse('fundraising:index'))
+        self.assertContains(response, 'Anonymous Hero')
+
+    def test_anonymous_donor_with_logo(self):
+        hero = DjangoHero.objects.create(is_visible=True, approved=True, logo='yes')  # We don't need an actual image
+        Donation.objects.create(donor=hero, amount='5')
+        response = self.client.get(reverse('fundraising:index'))
+        self.assertContains(response, 'Anonymous Hero')
+
     def test_hide_campaign_input(self):
         # Checking if rendered output contains campaign form field
         # to not generate ugly URLs
@@ -256,6 +268,12 @@ class TestDjangoHero(TestCase):
 
     def test_thumbnail_no_logo(self):
         self.assertIsNone(self.h2.thumbnail)
+
+    def test_name_with_fallback(self):
+        hero = DjangoHero()
+        self.assertEqual(hero.name_with_fallback, 'Anonymous Hero')
+        hero.name = 'Batistek'
+        self.assertEqual(hero.name_with_fallback, 'Batistek')
 
 
 class TestPaymentForm(TestCase):


### PR DESCRIPTION
If someone opted to appear in the list but didn't provide
a name, "Anonymous Hero" will be used instead.