### PR TITLE
Fix #doc-versions block background

### DIFF
--- a/djangoproject/static/scss/_style.scss
+++ b/djangoproject/static/scss/_style.scss
@@ -2143,7 +2143,6 @@ h2 + .list-link-soup {
 
 	li {
 		display: none;
-		background: $white;
 		margin: 0 3px;
 		@include sans-serif;
 		color: $text;
@@ -2151,6 +2150,7 @@ h2 + .list-link-soup {
 
 		&.current {
 			display: inline-block;
+			background: $white;
 			padding: 8px 15px;
 			border: 1px solid $gray-line;
 			@include border-radius(4px);
@@ -2158,6 +2158,7 @@ h2 + .list-link-soup {
 
 		a {
 			display: inline-block;
+			background: $white;
 			color: $green-medium;
 			text-decoration: none;
 			font-weight: 700;


### PR DESCRIPTION
In versions block switcher every link has border-radius but background is set to `li` items so on dark background we can see an issue (see screenshot).

![doc-versions](https://cloud.githubusercontent.com/assets/1363841/6330083/7fb4fc9c-bb86-11e4-94ff-17334bef8588.png)