### PR TITLE
Added compression to docs zip downloads.

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -122,7 +122,7 @@ class Command(NoArgsCommand):
             def zipfile_inclusion_filter(f):
                 return f.isfile() and '.doctrees' not in f.components()
 
-            with closing(zipfile.ZipFile(zipfile_path, 'w')) as zf:
+            with closing(zipfile.ZipFile(zipfile_path, 'w', compression=zipfile.ZIP_DEFLATED)) as zf:
                 for f in html_build_dir.walk(filter=zipfile_inclusion_filter):
                     zf.write(f, html_build_dir.rel_path_to(f))
 


### PR DESCRIPTION
As reported in Trac [#24393](https://code.djangoproject.com/ticket/24393). In manual testing, decreased the size of an archive from 23MB to 6MB.