### PR TITLE
Fixes #406 - Add help text to the top of the foundation contact form.

### DIFF
--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -4,6 +4,12 @@
 
 {% block content %}
 <h1>Contact the Django Software Foundation</h1>
+<p>This contact form is for the Django Software Foundation - the legal and fundraising arm of the Django project.</p>
+<p>If you want to report a bug in Django, use the <a href="https://code.djangoproject.com">ticket tracker</a>.</p>
+<p>If you want to report a problem with this website, use the
+  <a href="https://github.com/django/djangoproject.com">Github repo</a>.</p>
+<p>If you've got questions about how to use Django, use the
+  <a href="https://groups.google.com/forum/#!forum/django-users">django-users mailing list</a>.</p>
 <form action="." method="post" accept-charset="utf-8" class="form-input">
 {% csrf_token %}
   <p>


### PR DESCRIPTION
This is for #406

![2015-03-22 at 13 38](https://cloud.githubusercontent.com/assets/81891/6769560/d1815bb6-d098-11e4-9479-a0ceaab4c332.png)
