### PR TITLE
Add flat theme.

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -52,6 +52,26 @@ DEFAULT_FROM_EMAIL = "noreply@djangoproject.com"
 FIXTURE_DIRS = [PROJECT_PACKAGE.child('fixtures')]
 
 INSTALLED_APPS = [
+    'accounts',
+    'aggregator',
+    'blog',
+    'cla',
+    'contact',
+    'dashboard',
+    'docs.apps.DocsConfig',
+    'legacy',
+    'releases',
+    'svntogit',
+    'tracdb',
+    'fundraising',
+
+    'flat',
+    'djangosecure',
+    'registration',
+    'django_pygments',
+    'django_hosts',
+    'sorl.thumbnail',
+
     'django.contrib.sites',
     'django.contrib.auth',
     'django.contrib.admin',
@@ -65,24 +85,6 @@ INSTALLED_APPS = [
     'django.contrib.sitemaps',
     'django_push.subscriber',
 
-    'djangosecure',
-    'registration',
-    'django_pygments',
-    'django_hosts',
-    'sorl.thumbnail',
-
-    'accounts',
-    'aggregator',
-    'blog',
-    'cla',
-    'contact',
-    'dashboard',
-    'docs.apps.DocsConfig',
-    'legacy',
-    'releases',
-    'svntogit',
-    'tracdb',
-    'fundraising',
 ]
 
 LANGUAGE_CODE = 'en-us'

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,6 +2,7 @@ akismet==0.2.0
 certifi==14.05.14
 Django==1.7.7
 django-contact-form==1.0
+django-flat-theme==0.9.3
 django-hosts==1.1
 django-push==0.6.1
 django-registration-redux==1.1


### PR DESCRIPTION
Also reorder installed apps. From Django 1.7 onwards, apps higher up the
list take priority for everything, so django core apps should appear
last.

![](https://www.dropbox.com/s/aadvby8vkv8qt32/Screenshot%202015-04-01%2022.26.39.png?dl=1)

_Obligatory emoji for @bmispelon :+1: :sparkles: :fireworks: :snowman: :space_invader: :footprints:_