### PR TITLE
Ensures icons flip when they are in view

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1751,6 +1751,11 @@ h2 + .list-link-soup {
 
 					-webkit-transform: rotate(0.5turn);
 					transform: rotate(0.5turn);
+
+					&.inview {
+						-webkit-transform: rotate(0turn);
+						transform: rotate(0turn);
+					}
 				}
 			}
 


### PR DESCRIPTION
This fixes #431, which seems to be a result of a CSS specificity issue. Basically, the transform for the icons on the homepage was overriding the default flip. Eventually this stuff should be refactored as there is too much nesting; it's hard to follow.

Here's how it works now:

https://dl.dropboxusercontent.com/u/1451974/fix431.mov