### PR TITLE
Moved static/media/docs build directories out of the repository root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
+__pycache__
 *.pyc
 *.db
-djangodocs
-static_root
-media_root
 docs/locale/*/LC_MESSAGES/django.mo
-secrets.json
 .sass-cache/
 .coverage
 .tox

--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,17 @@ To run locally, do the usual:
 
     make install
 
-#. Create a 'secrets.json' file in a folder named 'conf' in the directory
-   above your cloned repo, containing something like::
+#. Make a directory to store the project's data (MEDIA_ROOT, DOC_BUILDS_ROOT,
+   etc.). We'll use ~/.djangoproject for example purposes.
+
+   Create a 'secrets.json' file in a folder named 'conf' in that directory,
+   containing something like::
 
     { "secret_key": "xyz",
       "superfeedr_creds": ["any@email.com", "some_string"] }
+
+   Add `export DJANGOPROJECT_DATA_DIR=~/.djangoproject` (without the backticks)
+   to your ~/.bashrc file and then run `source ~/.bashrc` to load the changes.
 
 #. Create databases::
 

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -1,5 +1,6 @@
 # Settings for www.djangoproject.com
 import json
+import os
 from pathlib import Path
 
 # Utilities
@@ -8,9 +9,11 @@ PROJECT_PACKAGE = Path(__file__).resolve().parent.parent
 # The full path to the repository root.
 BASE_DIR = PROJECT_PACKAGE.parent
 
-# It's a secret to everybody
+data_dir_key = 'DJANGOPROJECT_DATA_DIR'
+DATA_DIR = Path(os.environ[data_dir_key]) if data_dir_key in os.environ else BASE_DIR.parent
+
 try:
-    with BASE_DIR.parent.joinpath('conf', 'secrets.json').open() as handle:
+    with DATA_DIR.joinpath('conf', 'secrets.json').open() as handle:
         SECRETS = json.load(handle)
 except IOError:
     SECRETS = {
@@ -119,8 +122,6 @@ LOGGING = {
     }
 }
 
-MEDIA_ROOT = str(BASE_DIR.joinpath('media_root'))
-
 MEDIA_URL = '/m/'
 
 MIDDLEWARE_CLASSES = [
@@ -153,8 +154,6 @@ SILENCED_SYSTEM_CHECKS = ['1_6.W001']
 SITE_ID = 1
 
 STATICFILES_DIRS = [str(PROJECT_PACKAGE.joinpath('static'))]
-
-STATIC_ROOT = str(BASE_DIR.joinpath('static_root'))
 
 STATIC_URL = '/s/'
 

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -21,10 +21,14 @@ CSRF_COOKIE_SECURE = False
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+MEDIA_ROOT = str(DATA_DIR.joinpath('media_root'))
+
 SESSION_COOKIE_SECURE = False
 
+STATIC_ROOT = str(DATA_DIR.joinpath('static_root'))
+
 # Docs settings
-DOCS_BUILD_ROOT = BASE_DIR.joinpath('djangodocs')
+DOCS_BUILD_ROOT = DATA_DIR.joinpath('djangodocs')
 
 # django-hosts settings
 

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -33,7 +33,7 @@ LOGGING["handlers"]["syslog"] = {
 }
 LOGGING["loggers"]["django.request"]["handlers"].append("syslog")
 
-MEDIA_ROOT = str(BASE_DIR.parent.joinpath('media'))
+MEDIA_ROOT = str(DATA_DIR.joinpath('media'))
 
 MIDDLEWARE_CLASSES = (['django.middleware.cache.UpdateCacheMiddleware'] +
                       MIDDLEWARE_CLASSES +
@@ -43,7 +43,7 @@ SESSION_COOKIE_SECURE = True
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
-STATIC_ROOT = str(BASE_DIR.parent.joinpath('static'))
+STATIC_ROOT = str(DATA_DIR.joinpath('static'))
 
 # django-secure settings
 
@@ -52,7 +52,7 @@ SECURE_HSTS_SECONDS = 31536000  # 1 year
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 
 # Docs settings
-DOCS_BUILD_ROOT = BASE_DIR.parent.joinpath('data', 'docbuilds')
+DOCS_BUILD_ROOT = DATA_DIR.joinpath('data', 'docbuilds')
 
 # django-hosts settings
 


### PR DESCRIPTION
This is more consistent with production and removes the need to
exclude djangodocs directory when grepping.