### PR TITLE
Fix clunky grammar

### DIFF
--- a/djangoproject/templates/fundraising/donation_snippet.html
+++ b/djangoproject/templates/fundraising/donation_snippet.html
@@ -14,7 +14,7 @@
           {% firstof donation.name "Someone" %} donated
           {% if donation.is_amount_displayed %}US&nbsp;${{ donation.donated_amount|intcomma }}{% endif %}
           for the Django Fellowship program to support Django development.
-          Join them today!
+          Donate today!
         </a></li>
       </ul>
     </div>


### PR DESCRIPTION
I understand the gender-neutrality requirement, but "Join them today" when referring to a singular person is not good english. "Donate today" reads better and covers all bases.