### PR TITLE
Added id to "Getting Help" heading for linking purposes.

### DIFF
--- a/djangoproject/templates/docs/doc.html
+++ b/djangoproject/templates/docs/doc.html
@@ -128,7 +128,7 @@
   {% endblock breadcrumbs-wrapper %}
 
   {% block help-wrapper %}
-  <h2>{% trans "Getting help" %}</h2>
+  <h2 id="getting-help-sidebar">{% trans "Getting help" %}</h2>
   <dl class="list-links">
     <dt><a href="{% url 'document-detail' lang=lang version=version url="faq" host 'docs' %}">FAQ</a></dt>
     <dd>{% blocktrans %}Try the FAQ — it's got answers to many common questions.{% endblocktrans %}</dd>


### PR DESCRIPTION
The link at https://code.djangoproject.com/wiki/TicketClosingReasons/UseSupportChannels doesn't work because the "getting-help" box that was on the index page is hidden. We could switch it to this ID.