### PR TITLE
Improve Bower integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ djangoproject/static/css/*.css
 djangoproject/static/js/lib/unveil/jquery-1.9.1.min.js
 djangoproject/static/js/lib/unveil/index.html
 djangoproject/static/js/lib/unveil/img
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ run:
 
 install:
 	pip install -r requirements/dev.txt
+	npm install
 
 test:
 	@coverage run --source=. manage.py test -v2 $(APP_LIST)
@@ -42,4 +43,4 @@ $(JQUERY_FLOT)/jquery.flot.min.js: $(JQUERY_FLOT)
 	yuicompressor $(JQUERY_FLOT)/jquery.flot.concat.js -o $(JQUERY_FLOT)/jquery.flot.min.js
 
 $(JQUERY_FLOT)/:
-	bower install
+	npm run bower install

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ To run locally, do the usual:
 #. Install dependencies::
 
     pip install -r requirements/dev.txt
+    npm install
 
    Alternatively use the make task::
 
@@ -207,12 +208,23 @@ Check out the ``Procfile`` file for all the process names.
 JavaScript libraries
 --------------------
 
-This project uses `Bower <http://bower.io/>`_ for managing JS library
-dependencies. See its documentation for how to use it. Here's the gist:
+This project uses `Bower <http://bower.io/>`_ to manage JavaScript libraries.
 
-To update any of the dependencies, edit the ``bower.json`` file accordingly
-and then run ``bower install`` to download the appropriate files to the
-static directory. Commit the downloaded files to git (vendoring).
+At any time, you can run it to install a new library (e.g., ``jquery-ui``)::
+
+    npm run bower install jquery-ui --save
+
+or check if there are newer versions of the libraries that we use::
+
+    npm run bower ls
+
+If you need to update an existing library, the easiest way is to change the
+version requirement in ``bower.json``, and then to run
+``npm run bower install`` again.
+
+Also, please note that we commit the libraries to the repository. So, if
+you add, update, or remove a library from ``bower.json``, you will need to
+commit the changes in ``djangoproject/static`` too.
 
 Documentation search
 --------------------

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "Django Project",
-  "private": "true",
+  "name": "djangoproject",
+  "private": true,
   "dependencies": {
     "jquery": "<2.0",
     "jquery.inview": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "djangoproject",
+  "private": true,
+  "dependencies": {
+    "bower": "^1.4.1"
+  },
+  "scripts": {
+    "bower": "bower"
+  }
+}


### PR DESCRIPTION
Hello,

As I was trying to set up the project on my laptop, I noticed some inconsistencies with how Bower was integrated. So, I took some time to work on it:
1. Bower is installed locally from now on. A folder called `node_modules` is created when `npm install` is run and it contains all modules specific to the project (in our case, only Bower). This solution is a lot more clean since it takes some of the good ways from virtual environments (like installing things per project).
2. `npm install` is now run automatically via `make install`. So, it ensures Bower is always installed.
3. The package name in `bower.json` has been renamed from `Django Project` to `djangoproject`. My main concern was that such name is not permitted in Node.js modules. So, I had to stick with something consistent among all files and `djangoproject` seemed to be a good name.
4. However, installing things locally creates an issue. Local binaries are not found any more and so, you need to find an alternative. The first solution is to append the `PATH` with `node_modules/.bin` but you have to run Bower from the root directory... The second solution is to use the `scripts` section from Npm. Commands like Bower could be run like this after that: `npm run bower install`. It chose that solution.

I think that is all. If you have any question, feel free to ask. If you want some modifications to the pull request or spot any mistake, I am listening.