### PR TITLE
Update Travis and Coveralls badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 djangoproject.com source code
 =============================
 
-.. image:: https://img.shields.io/travis/django/djangoproject.com.svg
-    :target: http://travis-ci.org/django/djangoproject.com
+.. image:: https://travis-ci.org/django/djangoproject.com.svg?branch=master
+    :target: https://travis-ci.org/django/djangoproject.com
 
-.. image:: https://img.shields.io/coveralls/django/djangoproject.com.svg
-   :target: https://coveralls.io/r/django/djangoproject.com
+.. image:: https://coveralls.io/repos/django/djangoproject.com/badge.svg?branch=master
+    :target: https://coveralls.io/r/django/djangoproject.com?branch=master
 
 To run locally, do the usual:
 


### PR DESCRIPTION
Hello again,

I have updated the badges for Travis-CI and Coveralls in the README. There are two reasons to that:
1. The minor reason is that URLs have been changed. And even if the old ones are still working, it needs to be changed.
2. The major reason is that the badges (in particular the one for Travis) report *the results for the last build*, not *the results for the last build on the master branch*. So, if any pull request introduces some changes that break the source code, then the badge reports a broken build, even if the master branch is fine.

EDIT : This is what the README looks like at the moment:
![screen shot 2015-06-04 at 10 30 13](https://cloud.githubusercontent.com/assets/1058901/7982389/add456aa-0aae-11e5-8183-45186e59f011.png)
and this is what it looks like with the fix:
![screen shot 2015-06-04 at 11 42 29](https://cloud.githubusercontent.com/assets/1058901/7982402/cd1ab090-0aae-11e5-8467-875436b70fc7.png)
