### PR TITLE
Style definition terms in glossaries

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -71,6 +71,12 @@ dl {
 			margin-bottom: 0;
 		}
 	}
+
+	&.glossary {
+		dt {
+			font-weight: 600;
+		}
+	}
 }
 h1,
 h2,


### PR DESCRIPTION
Hello again,

As mentionned in #470, definition terms (`<dt>` tags) are not styled in glossaries. So, you have a "hard" time reading them and guessing which one is the term and which one is the definition. Currently, it means that they look like this on the current website:
![screen shot 2015-06-04 at 14 08 09](https://cloud.githubusercontent.com/assets/1058901/7984779/65c7f384-0ac3-11e5-8324-954424130725.png)

After applying some very basic styling, they become more apparent:
![screen shot 2015-06-04 at 14 07 37](https://cloud.githubusercontent.com/assets/1058901/7984814/adda6076-0ac3-11e5-812e-6dc83cf459d2.png)

Please note that I have been very careful. So, the CSS rule only applies to definition terms in glossaries (elements using the class `glossary`) and it does not affect all other definition terms like those in the right sidebar.

Voilà, and feel free to ask for modifications. I am not too familiar with the design rules for djangoproject.com. :)