### PR TITLE
Improve documentation footer display

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3009,8 +3009,6 @@ hr {
 		padding-right: 1em;
 	}
 }
-
-}
 form .footnote {
 	margin-top: 10px;
 	text-align: left;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3003,11 +3003,22 @@ hr {
 	@include font-size(14);
 	margin-top: 20px;
 	text-align: center;
+	/* The IDs in documentation footnotes should stay as table cells */
+	.label {
+		display: table-cell;
+		padding-right: 1em;
+	}
+}
+
 }
 form .footnote {
 	margin-top: 10px;
 	text-align: left;
 }
+.footnote.docutils {
+	text-align: left;
+}
+
 .heros-section {
 	overflow: hidden;
 	.heros {


### PR DESCRIPTION
This aligns the footnote numbers with the start of the footnote, and left aligns the text.
This improves footnotes on pages such as https://docs.djangoproject.com/en/1.8/ref/contrib/gis/geoquerysets/
Hope that's useful :)

[The footnote class is used both by documentation and the fundraising pages, which is where I think the centring came from; I thought this was simpler than renaming one of them.]