### PR TITLE
Handling webhooks for recurring payments

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1127,6 +1127,11 @@ blockquote {
 		color: $gray-medium;
 		font-weight: 400;
 
+		&.inline {
+			display: inline;
+			margin-right: 1em;
+		}
+
 		em {
 			color: $green-dark;
 		}

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -83,5 +83,9 @@ define(function() {
 		mods.push('mod/stripe-custom-checkout');
 	}
 
+	if (hasClass('django-hero-form')) {
+		mods.push('mod/stripe-change-card');
+	}
+
 	require(mods);
 });

--- a/djangoproject/static/js/mod/stripe-change-card.js
+++ b/djangoproject/static/js/mod/stripe-change-card.js
@@ -1,8 +1,8 @@
 define([
     'jquery', //requires jquery
     'stripe-checkout'
-], function ($) {
-    var $heroForm = $('.django-hero-form')
+], function($) {
+    var $heroForm = $('.django-hero-form');
     $heroForm.on('click', '.change-card', function() {
         $this = $(this);
         var donationId = $this.data('donationId');

--- a/djangoproject/static/js/mod/stripe-change-card.js
+++ b/djangoproject/static/js/mod/stripe-change-card.js
@@ -3,9 +3,9 @@ define([
     'stripe-checkout'
 ], function ($) {
     var $heroForm = $('.django-hero-form')
-    $('.django-hero-form').on('click', '.change-card', function() {
+    $heroForm.on('click', '.change-card', function() {
         $this = $(this);
-        var donation_id = $this.data('donation_id');
+        var donationId = $this.data('donationId');
         var handler = StripeCheckout.configure({
             key: $heroForm.data('stripeKey'),
             image: $heroForm.data('stripeIcon'),
@@ -14,7 +14,7 @@ define([
                 var csrfToken = $heroForm.find('[name=csrfmiddlewaretoken]').val();
                 var data = {
                     'stripe_token': token.id,
-                    'donation_id': donation_id,
+                    'donation_id': donationId,
                     'csrfmiddlewaretoken': csrfToken
                 };
                 $.ajax({

--- a/djangoproject/static/js/mod/stripe-change-card.js
+++ b/djangoproject/static/js/mod/stripe-change-card.js
@@ -1,0 +1,43 @@
+define([
+    'jquery', //requires jquery
+    'stripe-checkout'
+], function ($) {
+    var $heroForm = $('.django-hero-form')
+    $('.django-hero-form').on('click', '.change-card', function() {
+        $this = $(this);
+        var donation_id = $this.data('donation_id');
+        var handler = StripeCheckout.configure({
+            key: $heroForm.data('stripeKey'),
+            image: $heroForm.data('stripeIcon'),
+            panelLabel: 'Update',
+            token: function (token) {
+                var csrfToken = $heroForm.find('[name=csrfmiddlewaretoken]').val();
+                var data = {
+                    'stripe_token': token.id,
+                    'donation_id': donation_id,
+                    'csrfmiddlewaretoken': csrfToken
+                };
+                $.ajax({
+                    type: "POST",
+                    url: $heroForm.data('update-card-url'),
+                    data: data,
+                    dataType: 'json',
+                    success: function (data) {
+                        if (data.success) {
+                            $this.parent().find('.change-card-result').text('Card updated');
+                        } else {
+                            alert(data.error);
+                        }
+                    },
+                });
+            }
+        });
+
+        handler.open({
+            name: 'Django Software Foundation',
+            currency: 'USD',
+            bitcoin: true,
+            email: $this.data('donor-email')
+        });
+    });
+})

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -106,6 +106,7 @@
             "mod/version-switcher": extless("{% static 'js/mod/version-switcher.js' %}"),
             "mod/search-key": extless("{% static 'js/mod/search-key.js' %}"),
             "mod/stripe-custom-checkout": extless("{% static 'js/mod/stripe-custom-checkout.js' %}"),
+            "mod/stripe-change-card": extless("{% static 'js/mod/stripe-change-card.js' %}"),
             "stripe-checkout": "https://checkout.stripe.com/checkout",
             "stripe": "https://js.stripe.com/v2/?"  // ? needed due to require.js
         }

--- a/djangoproject/templates/fundraising/email/payment_failed.txt
+++ b/djangoproject/templates/fundraising/email/payment_failed.txt
@@ -1,0 +1,13 @@
+Hi {{ donation.donor.name_with_fallback }},
+
+This is to let you know that payment for your recurring donation to the Django 
+Software Foundation has failed. This might be because your payment card has 
+expired.
+
+Please go to {{ current_site }}{% url 'fundraising:manage-donations' donation.donor.pk %} to add a new card. We won't be able to take any payments in the mean time.
+
+Thanks very much for your support.
+
+Regards,
+The Django Project
+

--- a/djangoproject/templates/fundraising/email/payment_failed.txt
+++ b/djangoproject/templates/fundraising/email/payment_failed.txt
@@ -4,10 +4,9 @@ This is to let you know that payment for your recurring donation to the Django
 Software Foundation has failed. This might be because your payment card has 
 expired.
 
-Please go to {{ current_site }}{% url 'fundraising:manage-donations' donation.donor.pk %} to add a new card. We won't be able to take any payments in the mean time.
+Please go to {% url 'fundraising:manage-donations' donation.donor.pk %} to add a new card. We won't be able to take any payments in the mean time.
 
 Thanks very much for your support.
 
 Regards,
-The Django Project
-
+Django Software Foundation

--- a/djangoproject/templates/fundraising/email/subscription_cancelled.txt
+++ b/djangoproject/templates/fundraising/email/subscription_cancelled.txt
@@ -5,7 +5,7 @@ Foundation has been cancelled. No further payments will be made.
 
 If you didn't intend to do this, please go back to the fundraising page and
 recreate your payment subscription:
-{{ current_site }}{% url 'fundraising:donate' %}
+{% url 'fundraising:donate' %}
 
 Thanks very much for your support.
 

--- a/djangoproject/templates/fundraising/email/subscription_cancelled.txt
+++ b/djangoproject/templates/fundraising/email/subscription_cancelled.txt
@@ -1,0 +1,13 @@
+Hi {{ donation.donor.name_with_fallback }},
+
+This is to let you know that your recurring payment to the Django Software
+Foundation has been cancelled. No further payments will be made.
+
+If you didn't intend to do this, please go back to the fundraising page and
+recreate your payment subscription:
+{{ current_site }}{% url 'fundraising:donate' %}
+
+Thanks very much for your support.
+
+Regards,
+Django Software Foundation

--- a/djangoproject/templates/fundraising/manage-donations.html
+++ b/djangoproject/templates/fundraising/manage-donations.html
@@ -26,7 +26,7 @@
       <h3>{{ form.instance.campaign }}</h3>
       {% include 'fundraising/includes/_form.html' %}
       <div class="change-card-container">
-        <input type="button" value="Change card details" class="change-card" data-donation_id="{{ form.instance.id }}" data-donor-email="{{ hero.email }}"> <span class="change-card-result"></span>
+        <input type="button" value="Change card details" class="change-card" data-donation-id="{{ form.instance.id }}" data-donor-email="{{ hero.email }}"> <span class="change-card-result"></span>
       </div>
     {% endfor %}
     {{ modify_donations_formset.management_form }}

--- a/djangoproject/templates/fundraising/manage-donations.html
+++ b/djangoproject/templates/fundraising/manage-donations.html
@@ -7,7 +7,9 @@
   of Django and helps the <strong>Django Fellowship</strong> program in particular.
   Thank you!</p>
 
-<form enctype="multipart/form-data" action="" method="post" class="form-input django-hero-form" data-stripe-key="{{ stripe_publishable_key }}" data-stripe-icon="{% static 'img/dj-stripe-icon.jpg' %}" data-update-card-url="{% url 'fundraising:update-card' %}">
+<form enctype="multipart/form-data" action="" method="post" class="form-input django-hero-form"
+    data-stripe-key="{{ stripe_publishable_key }}" data-stripe-icon="{% static 'img/dj-stripe-icon.jpg' %}"
+    data-update-card-url="{% url 'fundraising:update-card' %}">
   <h2>Manage your presence in the fundraising campaigns</h2>
   <p>Information entered below will be visible on all of your donations to Django Project.</p>
   {% csrf_token %}
@@ -26,7 +28,9 @@
       <h3>{{ form.instance.campaign }}</h3>
       {% include 'fundraising/includes/_form.html' %}
       <div class="change-card-container">
-        <input type="button" value="Change card details" class="change-card" data-donation-id="{{ form.instance.id }}" data-donor-email="{{ hero.email }}"> <span class="change-card-result"></span>
+        <input type="button" value="Change card details" class="change-card cta outline inline"
+            data-donation-id="{{ form.instance.id }}" data-donor-email="{{ hero.email }}">
+        <span class="change-card-result"></span>
       </div>
     {% endfor %}
     {{ modify_donations_formset.management_form }}

--- a/djangoproject/templates/fundraising/manage-donations.html
+++ b/djangoproject/templates/fundraising/manage-donations.html
@@ -37,7 +37,7 @@
     <ul>
     {% for donation in recurring_donations %}
       <li>
-        Your {{ donation.interval }} recurring donation of ${{ donation.amount }} to {{ donation.campaign.name }}:
+        Your {{ donation.interval }} recurring donation of ${{ donation.subscription_amount }} to {{ donation.campaign.name }}:
         <a href="{% url 'fundraising:cancel-donation' hero.pk donation.pk %}">cancel this donation</a>
       </li>
     {% endfor %}

--- a/djangoproject/templates/fundraising/manage-donations.html
+++ b/djangoproject/templates/fundraising/manage-donations.html
@@ -1,4 +1,5 @@
 {% extends 'fundraising/index.html' %}
+{% load staticfiles %}
 
 {% block content %}
 <h1>Manage your donations to Django Software Foundation</h1>
@@ -6,7 +7,7 @@
   of Django and helps the <strong>Django Fellowship</strong> program in particular.
   Thank you!</p>
 
-<form enctype="multipart/form-data" action="" method="post" class="form-input django-hero-form">
+<form enctype="multipart/form-data" action="" method="post" class="form-input django-hero-form" data-stripe-key="{{ stripe_publishable_key }}" data-stripe-icon="{% static 'img/dj-stripe-icon.jpg' %}" data-update-card-url="{% url 'fundraising:update-card' %}">
   <h2>Manage your presence in the fundraising campaigns</h2>
   <p>Information entered below will be visible on all of your donations to Django Project.</p>
   {% csrf_token %}
@@ -24,6 +25,9 @@
     {% for form in modify_donations_formset %}
       <h3>{{ form.instance.campaign }}</h3>
       {% include 'fundraising/includes/_form.html' %}
+      <div class="change-card-container">
+        <input type="button" value="Change card details" class="change-card" data-donation_id="{{ form.instance.id }}" data-donor-email="{{ hero.email }}"> <span class="change-card-result"></span>
+      </div>
     {% endfor %}
     {{ modify_donations_formset.management_form }}
     <p class="submit">

--- a/fundraising/admin.py
+++ b/fundraising/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
+from django.db.models import Sum
 from sorl.thumbnail.admin import AdminImageMixin
 
-from .models import Campaign, DjangoHero, Donation, Testimonial
+from .models import Campaign, DjangoHero, Donation, Payment, Testimonial
 
 
 @admin.register(DjangoHero)
@@ -12,13 +13,28 @@ class DjangoHeroAdmin(AdminImageMixin, admin.ModelAdmin):
     ordering = ['-created']
 
 
+class PaymentInline(admin.TabularInline):
+    model = Payment
+
+
 @admin.register(Donation)
 class Donation(admin.ModelAdmin):
     raw_id_fields = ['donor']
-    list_display = ['id', 'amount', 'donor', 'stripe_charge_id',
-                    'created', 'modified']
+    list_display = ['id', 'amount', 'donor', 'created', 'modified']
     list_filter = ['created', 'modified']
     ordering = ['-created']
+    inlines = [PaymentInline]
+
+    def get_queryset(self, request):
+        """Annotate the sum of related payments to every donation."""
+        qs = super(Donation, self).get_queryset(request)
+        return qs.annotate(amount=Sum('payment__amount'))
+
+    def amount(self, obj):
+        # Since amount is an annotated field, it is not recognized as a property
+        # of the model for list_display so we need an actual method that
+        # references it.
+        return obj.amount
 
 
 @admin.register(Testimonial)

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -265,11 +265,11 @@ class PaymentForm(forms.Form):
                 donation_params['subscription_amount'] = amount
             donation = Donation.objects.create(**donation_params)
 
-            Payment.objects.create(**{
-                'amount': amount,
-                'stripe_charge_id': charge_id,
-                'donation': donation,
-            })
+            Payment.objects.create(
+                amount=amount,
+                stripe_charge_id=charge_id,
+                donation=donation,
+            )
 
             # Send an email message about managing your donation
             message = render_to_string(

--- a/fundraising/migrations/0028_auto_20150419_0758.py
+++ b/fundraising/migrations/0028_auto_20150419_0758.py
@@ -6,6 +6,8 @@ from django.utils import crypto
 
 
 def copy_stripe_id_to_hero(apps, schema_editor):
+    if not schema_editor.connection.alias == 'default':
+        return
     Donation = apps.get_model("fundraising", "Donation")
     DjangoHero = apps.get_model("fundraising", "DjangoHero")
 

--- a/fundraising/migrations/0030_auto_20150604_0608.py
+++ b/fundraising/migrations/0030_auto_20150604_0608.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fundraising', '0029_donation_interval'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Payment',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, verbose_name='ID', serialize=False)),
+                ('amount', models.DecimalField(null=True, max_digits=9, decimal_places=2)),
+                ('stripe_charge_id', models.CharField(null=True, max_length=100)),
+                ('date', models.DateTimeField(auto_now_add=True)),
+                ('donation', models.ForeignKey(to='fundraising.Donation')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/fundraising/migrations/0031_auto_20150604_0813.py
+++ b/fundraising/migrations/0031_auto_20150604_0813.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def convert_amount(apps, schema_editor):
+    # Django 1.7 doesn't check the router.allow_migrate on RunSQL or RunPython
+    # operations. So even though we just need to run some SQL we need to run it
+    # inside a RunPython function and check the connection alias manually.
+    if not schema_editor.connection.alias == 'default':
+        return
+    cursor = schema_editor.connection.cursor()
+    cursor.execute(
+        "INSERT INTO fundraising_payment (amount, stripe_charge_id, date, donation_id) "
+        "(SELECT amount, stripe_charge_id, created, id FROM fundraising_donation);"
+    ),
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fundraising', '0030_auto_20150604_0608'),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_amount),
+    ]

--- a/fundraising/migrations/0032_auto_20150604_0813.py
+++ b/fundraising/migrations/0032_auto_20150604_0813.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fundraising', '0031_auto_20150604_0813'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='donation',
+            old_name='amount',
+            new_name='subscription_amount',
+        ),
+        migrations.AlterField(
+            model_name='donation',
+            name='subscription_amount',
+            field=models.DecimalField(blank=True, null=True, decimal_places=2, max_digits=9),
+            preserve_default=True,
+        ),
+        migrations.RemoveField(
+            model_name='donation',
+            name='stripe_charge_id',
+        ),
+    ]

--- a/fundraising/migrations/0033_auto_20150611_0750.py
+++ b/fundraising/migrations/0033_auto_20150611_0750.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def update_onetime_subscriptions(apps, schema_editor):
+    if not schema_editor.connection.alias == 'default':
+        return
+    Donation = apps.get_model("fundraising", "Donation")
+    Donation.objects.filter(interval="onetime").update(subscription_amount=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fundraising', '0032_auto_20150604_0813'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_onetime_subscriptions),
+    ]

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -123,6 +123,9 @@ class Donation(FundraisingModel):
     def get_absolute_url(self):
         return reverse('fundraising:thank-you', kwargs={'donation': self.id})
 
+    def total_payments(self):
+        return self.payment_set.aggregate(models.Sum('amount'))['amount__sum']
+
 
 class Payment(models.Model):
     donation = models.ForeignKey(Donation)

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -23,7 +23,7 @@ class DjangoHeroManager(models.Manager):
             donation__campaign=campaign,
             is_visible=True,
             approved=True,
-        ).annotate(donated_amount=models.Sum('donation__amount'))
+        ).annotate(donated_amount=models.Sum('donation__payment__amount'))
 
         if hero_type:
             donors = donors.filter(hero_type=hero_type)

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -109,20 +109,29 @@ class Campaign(models.Model):
 
 
 class Donation(FundraisingModel):
-    amount = models.DecimalField(max_digits=9, decimal_places=2, null=True)
     interval = models.CharField(max_length=20, choices=INTERVAL_CHOICES, null=True)
+    subscription_amount = models.DecimalField(max_digits=9, decimal_places=2, null=True, blank=True)
     donor = models.ForeignKey(DjangoHero, null=True)
     campaign = models.ForeignKey(Campaign, null=True, blank=True)
-    stripe_charge_id = models.CharField(max_length=100, null=True)
     stripe_subscription_id = models.CharField(max_length=100, null=True)
     stripe_customer_id = models.CharField(max_length=100, null=True)
     receipt_email = models.EmailField(null=True)
 
     def __str__(self):
-        return '${}'.format(self.amount)
+        return '{} from {}'.format(self.get_interval_display(), self.donor)
 
     def get_absolute_url(self):
         return reverse('fundraising:thank-you', kwargs={'donation': self.id})
+
+
+class Payment(models.Model):
+    donation = models.ForeignKey(Donation)
+    amount = models.DecimalField(max_digits=9, decimal_places=2, null=True)
+    stripe_charge_id = models.CharField(max_length=100, null=True)
+    date = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return '${}'.format(self.amount)
 
 
 class Testimonial(models.Model):

--- a/fundraising/templatetags/fundraising_extras.py
+++ b/fundraising/templatetags/fundraising_extras.py
@@ -28,7 +28,7 @@ def as_percentage(part, total):
 def donation_snippet():
     try:
         donation = DjangoHero.objects.filter(approved=True, is_visible=True).order_by('?')[:1]
-        donation = donation.annotate(donated_amount=models.Sum('donation__amount')).get()
+        donation = donation.annotate(donated_amount=models.Sum('donation__payment__amount')).get()
     except DjangoHero.DoesNotExist:
         donation = None
 
@@ -38,7 +38,7 @@ def donation_snippet():
 @register.inclusion_tag('fundraising/includes/donation_form_with_heart.html', takes_context=True)
 def donation_form_with_heart(context, campaign):
     user = context['user']
-    donated_amount = Donation.objects.filter(campaign=campaign).aggregate(models.Sum('amount'))
+    donated_amount = Donation.objects.filter(campaign=campaign).aggregate(models.Sum('payment__amount'))
     total_donors = DjangoHero.objects.filter(donation__campaign=campaign).count()
     form = DonateForm(initial={
         'amount': DEFAULT_DONATION_AMOUNT,
@@ -47,7 +47,7 @@ def donation_form_with_heart(context, campaign):
 
     return {
         'campaign': campaign,
-        'donated_amount': donated_amount['amount__sum'] or 0,
+        'donated_amount': donated_amount['payment__amount__sum'] or 0,
         'total_donors': total_donors,
         'form': form,
         'display_logo_amount': DISPLAY_LOGO_AMOUNT,

--- a/fundraising/test_data/invoice_succeeded.json
+++ b/fundraising/test_data/invoice_succeeded.json
@@ -1,0 +1,71 @@
+{
+  "id": "evt_103MXP2kbIgHtIBFeIFqPxp7",
+  "created": 1390486769,
+  "livemode": false,
+  "type": "invoice.payment_succeeded",
+  "data": {
+    "object": {
+      "date": 1390486769,
+      "id": "in_103MXP2kbIgHtIBFmaa4U4Xq",
+      "period_start": 1390486769,
+      "period_end": 1390486769,
+      "lines": {
+        "object": "list",
+        "count": 1,
+        "url": "/v1/invoices/in_103MXP2kbIgHtIBFmaa4U4Xq/lines",
+        "data": [
+          {
+            "id": "sub_3MXPaZGXvVZSrS",
+            "object": "line_item",
+            "type": "subscription",
+            "livemode": false,
+            "amount": 1000,
+            "currency": "usd",
+            "proration": false,
+            "period": {
+              "start": 1390486769,
+              "end": 1391091569
+            },
+            "quantity": 1,
+            "plan": {
+              "interval": "week",
+              "name": "Test $10 Plan",
+              "created": 1389926836,
+              "amount": 1000,
+              "currency": "usd",
+              "id": "test_10",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "description": null,
+            "metadata": null
+          }
+        ]
+      },
+      "subtotal": 1000,
+      "total": 1000,
+      "customer": "cus_3MXPY5pvYMWTBf",
+      "object": "invoice",
+      "attempted": true,
+      "closed": true,
+      "paid": true,
+      "livemode": false,
+      "attempt_count": 0,
+      "amount_due": 1000,
+      "currency": "usd",
+      "starting_balance": 0,
+      "ending_balance": 0,
+      "next_payment_attempt": null,
+      "charge": "ch_103MXP2kbIgHtIBF6eblAb1t",
+      "discount": null,
+      "application_fee": null,
+      "subscription": "sub_3MXPaZGXvVZSrS"
+    }
+  },
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": "iar_3MXPlBDPK90rso"
+}

--- a/fundraising/test_data/payment_failed.json
+++ b/fundraising/test_data/payment_failed.json
@@ -1,0 +1,71 @@
+{
+  "id": "evt_103Nig2kbIgHtIBFw1zEh0CF",
+  "created": 1390759349,
+  "livemode": false,
+  "type": "invoice.payment_failed",
+  "data": {
+    "object": {
+      "date": 1390755657,
+      "id": "in_103Nhg2kbIgHtIBFWGKygiPW",
+      "period_start": 1390668828,
+      "period_end": 1390755521,
+      "lines": {
+        "object": "list",
+        "count": 1,
+        "url": "/v1/invoices/in_103Nhg2kbIgHtIBFWGKygiPW/lines",
+        "data": [
+          {
+            "id": "sub_3NKLRPGIoiUnxe",
+            "object": "line_item",
+            "type": "subscription",
+            "livemode": false,
+            "amount": 1000,
+            "currency": "usd",
+            "proration": false,
+            "period": {
+              "start": 1390755521,
+              "end": 1391360321
+            },
+            "quantity": 1,
+            "plan": {
+              "interval": "week",
+              "name": "Test $10 Plan",
+              "amount": 1000,
+              "currency": "usd",
+              "id": "test_10",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "description": null,
+            "metadata": null
+          }
+        ]
+      },
+      "subtotal": 1000,
+      "total": 1000,
+      "customer": "cus_3MXPY5pvYMWTBf",
+      "object": "invoice",
+      "attempted": true,
+      "closed": false,
+      "paid": false,
+      "livemode": false,
+      "attempt_count": 1,
+      "amount_due": 1000,
+      "currency": "usd",
+      "starting_balance": 0,
+      "ending_balance": 0,
+      "next_payment_attempt": 1391018549,
+      "charge": "ch_103Nig2kbIgHtIBFLMBGkRCV",
+      "discount": null,
+      "application_fee": null,
+      "subscription": "sub_3MXPaZGXvVZSrS"
+    }
+  },
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": null
+}
+

--- a/fundraising/test_data/subscription_cancelled.json
+++ b/fundraising/test_data/subscription_cancelled.json
@@ -1,0 +1,43 @@
+{
+  "id": "evt_103Nig2kbIgHtIBFu9mfdSuZ",
+  "created": 1390759349,
+  "livemode": false,
+  "type": "customer.subscription.deleted",
+  "data": {
+    "object": {
+      "id": "sub_3MXPaZGXvVZSrS",
+      "plan": {
+        "interval": "week",
+        "name": "Test $10 Plan",
+        "amount": 1000,
+        "currency": "usd",
+        "id": "test_10",
+        "object": "plan",
+        "livemode": false,
+        "interval_count": 1,
+        "trial_period_days": null,
+        "metadata": {}
+      },
+      "object": "subscription",
+      "start": 1390669124,
+      "status": "canceled",
+      "customer": "cus_3MXPY5pvYMWTBf",
+      "cancel_at_period_end": false,
+      "current_period_start": 1390755521,
+      "current_period_end": 1391360321,
+      "ended_at": null,
+      "trial_start": null,
+      "trial_end": null,
+      "canceled_at": null,
+      "quantity": 1,
+      "application_fee_percent": null,
+      "discount": null
+    },
+    "previous_attributes": {
+      "status": "active"
+    }
+  },
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": null
+}

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -392,13 +392,15 @@ class TestWebhooks(TestCase):
         )
 
     def post_data(self, filename):
-        with open('fundraising/test_data/{}.json'.format(filename)) as f:
-            response = self.client.post(
+        file_path = os.path.join(
+            settings.BASE_DIR,
+            'fundraising/test_data/{}.json'.format(filename))
+        with open(file_path) as f:
+            return self.client.post(
                 reverse('fundraising:receive-webhook'),
                 data=f.read(),
                 content_type='application/json'
             )
-        return response
 
     def test_record_payment(self):
         response = self.post_data('invoice_succeeded')

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -311,7 +311,6 @@ class TestPaymentForm(TestCase):
         self.assertEqual(hero, donation.donor)
         self.assertEqual(hero.stripe_customer_id, donation.stripe_customer_id)
 
-
     @patch('stripe.Customer.create')
     @patch('stripe.Charge.create')
     def test_make_donation_exception(self, charge_create, customer_create):
@@ -398,6 +397,7 @@ class TestThankYou(TestCase):
         expected_url = reverse('fundraising:campaign', args=[campaign.slug])
         self.assertRedirects(response, expected_url)
 
+
 class TestWebhooks(TestCase):
     def setUp(self):
         self.hero = DjangoHero.objects.create(email='hero@djangoproject.com')
@@ -433,4 +433,3 @@ class TestWebhooks(TestCase):
     def test_payment_failed(self):
         self.post_data('payment_failed')
         self.assertEqual(len(mail.outbox), 1)
-

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -407,7 +407,7 @@ class TestWebhooks(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.donation.payment_set.count(), 1)
         payment = self.donation.payment_set.first()
-        self.assertEqual(payment.amount, 1000)
+        self.assertEqual(payment.amount, 10)
 
     def test_subscription_cancelled(self):
         self.post_data('subscription_cancelled')

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -112,7 +112,7 @@ class TestCampaign(TestCase):
         donations = Donation.objects.all()
         self.assertEqual(donations.count(), 1)
         self.assertEqual(donations[0].subscription_amount, None)
-        self.assertEqual(donations[0].payment_set.first().amount, 100)
+        self.assertEqual(donations[0].total_payments(), 100)
         self.assertEqual(donations[0].receipt_email, 'test@example.com')
         self.assertEqual(donations[0].stripe_subscription_id, '')
 
@@ -129,7 +129,7 @@ class TestCampaign(TestCase):
         donations = Donation.objects.all()
         self.assertEqual(donations.count(), 1)
         self.assertEqual(donations[0].subscription_amount, 100)
-        self.assertEqual(donations[0].payment_set.first().amount, 100)
+        self.assertEqual(donations[0].total_payments(), 100)
         self.assertEqual(donations[0].receipt_email, 'test@example.com')
         self.assertEqual(donations[0].payment_set.first().stripe_charge_id, '')
 
@@ -146,7 +146,7 @@ class TestCampaign(TestCase):
         })
         donations = Donation.objects.all()
         self.assertEqual(donations.count(), 1)
-        self.assertEqual(donations[0].payment_set.first().amount, 100)
+        self.assertEqual(donations[0].total_payments(), 100)
         self.assertEqual(donations[0].campaign, self.campaign)
 
     @patch('stripe.Customer.create')

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -2,7 +2,6 @@ import json
 import os
 from datetime import date
 from functools import partial
-from operator import attrgetter
 from unittest.mock import patch
 
 import stripe
@@ -16,7 +15,6 @@ from .exceptions import DonationError
 from .forms import PaymentForm
 from .models import Campaign, DjangoHero, Donation, Payment
 from .templatetags.fundraising_extras import donation_form_with_heart
-from .utils import shuffle_donations
 
 
 def _fake_random(*results):
@@ -227,21 +225,6 @@ class TestDjangoHero(TestCase):
         d3 = Donation.objects.create(donor=self.h3, campaign=self.campaign)
         Payment.objects.create(donation=d3, amount='10')
         self.today = date.today()
-
-    def test_donation_shuffling(self):
-        queryset = DjangoHero.objects.for_campaign(self.campaign)
-
-        for random, expected in [
-            (lambda: 1, [15, 10, 5]),
-            (lambda: -1, [5, 10, 15]),
-            (_fake_random(1, 0, 1), [15, 5, 10]),
-        ]:
-            with patch('fundraising.utils.random', side_effect=random):
-                self.assertQuerysetEqual(
-                    shuffle_donations(queryset),
-                    expected,
-                    attrgetter('donated_amount')
-                )
 
     def test_thumbnail(self):
         try:

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -430,3 +430,7 @@ class TestWebhooks(TestCase):
         self.assertEqual(donation.stripe_subscription_id, '')
         self.assertEqual(len(mail.outbox), 1)
 
+    def test_payment_failed(self):
+        self.post_data('payment_failed')
+        self.assertEqual(len(mail.outbox), 1)
+

--- a/fundraising/urls.py
+++ b/fundraising/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     url(r'^thank-you/(?P<donation>[\w]+)/$', views.thank_you, name='thank-you'),
     url(r'^manage-donations/(?P<hero>[\w]+)/$', views.manage_donations, name='manage-donations'),
     url(r'^manage-donations/(?P<hero>[\w]+)/cancel/(?P<donation>[\w]+)$', views.cancel_donation, name='cancel-donation'),
+    url(r'^receive_webhook/', views.receive_webhook, name='receive-webhook'),
 ]

--- a/fundraising/urls.py
+++ b/fundraising/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     url(r'^manage-donations/(?P<hero>[\w]+)/$', views.manage_donations, name='manage-donations'),
     url(r'^manage-donations/(?P<hero>[\w]+)/cancel/(?P<donation>[\w]+)$', views.cancel_donation, name='cancel-donation'),
     url(r'^receive_webhook/', views.receive_webhook, name='receive-webhook'),
-    url(r'^update_card/', views.update_card, name='update-card'),
+    url(r'^update-card/', views.update_card, name='update-card'),
 ]

--- a/fundraising/urls.py
+++ b/fundraising/urls.py
@@ -9,6 +9,6 @@ urlpatterns = [
     url(r'^thank-you/(?P<donation>[\w]+)/$', views.thank_you, name='thank-you'),
     url(r'^manage-donations/(?P<hero>[\w]+)/$', views.manage_donations, name='manage-donations'),
     url(r'^manage-donations/(?P<hero>[\w]+)/cancel/(?P<donation>[\w]+)$', views.cancel_donation, name='cancel-donation'),
-    url(r'^receive_webhook/', views.receive_webhook, name='receive-webhook'),
-    url(r'^update-card/', views.update_card, name='update-card'),
+    url(r'^receive-webhook/$', views.receive_webhook, name='receive-webhook'),
+    url(r'^update-card/$', views.update_card, name='update-card'),
 ]

--- a/fundraising/urls.py
+++ b/fundraising/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'^manage-donations/(?P<hero>[\w]+)/$', views.manage_donations, name='manage-donations'),
     url(r'^manage-donations/(?P<hero>[\w]+)/cancel/(?P<donation>[\w]+)$', views.cancel_donation, name='cancel-donation'),
     url(r'^receive_webhook/', views.receive_webhook, name='receive-webhook'),
+    url(r'^update_card/', views.update_card, name='update-card'),
 ]

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -161,7 +161,11 @@ def cancel_donation(request, hero, donation):
 @csrf_exempt
 def receive_webhook(request):
     data = json.loads(request.body.decode())
-    event = stripe.resource.convert_to_stripe_object(data, stripe.api_key)
+    # For security, re-request the event object from Stripe.
+    try:
+        event = stripe.Event.retrieve(data['id'])
+    except stripe.error.InvalidRequestError:
+        return HttpResponse(422)
 
     return WebhookHandler(event).handle()
 

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -86,6 +86,8 @@ def manage_donations(request, hero):
     hero = get_object_or_404(DjangoHero, pk=hero)
     recurring_donations = hero.donation_set.filter(
         stripe_subscription_id__isnull=False
+    ).exclude(
+        stripe_subscription_id=''
     )
 
     ModifyDonationsFormset = modelformset_factory(Donation, form=DonationForm, extra=0)

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -1,3 +1,4 @@
+import decimal
 import json
 import stripe
 from django.contrib import messages
@@ -186,8 +187,9 @@ class WebhookHandler(object):
             return HttpResponse()
         donation = get_object_or_404(
             Donation, stripe_subscription_id=invoice.subscription)
+        amount = decimal.Decimal(invoice.total) / 100
         Payment.objects.create(
-            donation=donation, amount=invoice.total, stripe_charge_id=invoice.charge)
+            donation=donation, amount=amount, stripe_charge_id=invoice.charge)
         return HttpResponse(status=201)
 
     def subscription_cancelled(self):

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -175,7 +175,7 @@ class WebhookHandler(object):
             'invoice.payment_failed': self.payment_failed,
             'customer.subscription.deleted': self.subscription_cancelled,
         }
-        handler = handlers.get(self.event.type, lambda: HttpResponse(404))
+        handler = handlers.get(self.event.type, lambda: HttpResponse(422))
         return handler()
 
     def payment_succeeded(self):

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -160,8 +160,12 @@ def cancel_donation(request, hero, donation):
 @require_POST
 @csrf_exempt
 def receive_webhook(request):
-    data = json.loads(request.body.decode())
-    # For security, re-request the event object from Stripe.
+    try:
+        data = json.loads(request.body.decode())
+    except ValueError:
+        return HttpResponse(422)
+
+   # For security, re-request the event object from Stripe.
     try:
         event = stripe.Event.retrieve(data['id'])
     except stripe.error.InvalidRequestError:

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -144,8 +144,8 @@ def update_card(request):
 
 def cancel_donation(request, hero, donation):
     hero = get_object_or_404(DjangoHero, pk=hero)
-    donation = get_object_or_404(Donation, pk=donation, donor=hero,
-        stripe_subscription_id__isnull=False)
+    donation = get_object_or_404(
+        Donation, pk=donation, donor=hero, stripe_subscription_id__isnull=False)
 
     customer = stripe.Customer.retrieve(donation.stripe_customer_id)
     customer.subscriptions.retrieve(donation.stripe_subscription_id).delete()
@@ -200,7 +200,7 @@ class WebhookHandler(object):
         mail_text = render_to_string(
             'fundraising/email/subscription_cancelled.txt', {'donation': donation})
         send_mail('Payment cancelled', mail_text,
-            settings.DEFAULT_FROM_EMAIL, [donation.donor.email])
+                  settings.DEFAULT_FROM_EMAIL, [donation.donor.email])
 
         return HttpResponse(status=204)
 
@@ -212,7 +212,6 @@ class WebhookHandler(object):
         mail_text = render_to_string(
             'fundraising/email/payment_failed.txt', {'donation': donation})
         send_mail('Payment failed', mail_text,
-            settings.DEFAULT_FROM_EMAIL, [donation.donor.email])
+                  settings.DEFAULT_FROM_EMAIL, [donation.donor.email])
 
         return HttpResponse(status=204)
-


### PR DESCRIPTION
* Refactor models to separate Payment from Donation, to allow for multiple payments in a single donation.
* Add support for handling webhooks: payment succeeded, subscription cancelled, payment failed.
* Allow users to change card details on recurring payments, for when payment fails because of an expired card.

Refs #386.