### PR TITLE
Fix #495, Add search form on the 404 page

### DIFF
--- a/djangoproject/templates/404.html
+++ b/djangoproject/templates/404.html
@@ -1,14 +1,21 @@
 {% extends 'base_error.html' %}
+{% load i18n docs %}
 
 {% block title %}Page not found{% endblock %}
 
 {% block header %}<h1>404</h1>{% endblock %}
 
 {% block content %}
-<h2>Page not found</h2>
+  <h2>Page not found</h2>
 
-<p>Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/">let us know</a>.</p>
+  <p>Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/">let us know</a>.</p>
 
-<p>Here's a link to the <a href="{% url 'homepage' %}">homepage</a>. You know, just in case.</p>
+  <p>Here's a link to the <a href="{% url 'homepage' %}">homepage</a>. You know, just in case.</p>
+
+  <h3>{% trans 'Search the documentation' %}</h3>
+  {% trans 'If you were looking for a part of the Django documentation. Try searching for it below.' %}
+  {% with lang='en' version='stable' %}
+    {% search_form %}
+  {% endwith %}
 
 {% endblock %}

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -14,7 +14,11 @@ register = template.Library()
 @register.inclusion_tag('docs/search_form.html', takes_context=True)
 def search_form(context):
     request = context['request']
-    release = DocumentRelease.objects.get(version=context['version'], lang=context['lang'])
+    version = context['version']
+    if version == 'stable':
+        version = DocumentRelease.objects.current_version()
+
+    release = DocumentRelease.objects.get(version=version, lang=context['lang'])
     return {
         'form': DocSearchForm(request.GET, release=release),
         'version': context['version'],

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import set_urlconf
+from django.http.request import HttpRequest
 from django.template import Context, Template
 from django.test import TestCase
 
@@ -26,6 +27,13 @@ class SearchFormTestCase(TestCase):
         response = self.client.get('/en/dev/search/',
                                    HTTP_HOST='docs.djangoproject.dev:8000')
         self.assertEqual(response.status_code, 200)
+
+    def test_search_form_templatetag(self):
+        template = Template('{% load docs %}{% search_form %}')
+        self.assertIn(
+            '1.4',
+            template.render(Context({'lang': 'en', 'version': 'stable', 'request': HttpRequest()})),
+        )
 
 
 class TemplateTagTests(TestCase):

--- a/svntogit/tests.py
+++ b/svntogit/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 
 class SvnToGitTests(TestCase):
+    fixtures = ['doc_test_fixtures']
 
     def test_redirect(self):
         response = self.client.get('/svntogit/1/', follow=False)


### PR DESCRIPTION
This add the search form by using the templatetag on the 404 page.

<img width="926" alt="screenshot 2015-08-03 19 36 32" src="https://cloud.githubusercontent.com/assets/476364/9043616/09182432-3a17-11e5-99b2-8e1e0d8e6d46.png">
