### PR TITLE
Fix #469, Add validation of reST fields in blog entry

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from .forms import EntryForm
 from .models import Entry, Event
 
 
@@ -8,6 +9,7 @@ class EntryAdmin(admin.ModelAdmin):
     list_filter = ('is_active',)
     exclude = ('summary_html', 'body_html')
     prepopulated_fields = {"slug": ("headline",)}
+    form = EntryForm
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         formfield = super(EntryAdmin, self).formfield_for_dbfield(db_field, **kwargs)

--- a/blog/forms.py
+++ b/blog/forms.py
@@ -1,0 +1,58 @@
+import re
+
+from django import forms
+from docutils.core import publish_parts
+
+from blog.models import BLOG_DOCUTILS_SETTINGS, Entry
+
+RE_RST = {
+    'warning': r'System Message: WARNING/\d+ \([^\)]+(line \d+)\)</p>\s<p>([^<]+)</p>',
+    'error': r'System Message: ERROR/\d+ \([^\)]+(line \d+)\)</p>\s<p>([^<]+)</p>',
+}
+
+
+class EntryForm(forms.ModelForm):
+    class Meta:
+        model = Entry
+        fields = (
+            'headline',
+            'slug',
+            'is_active',
+            'pub_date',
+            'content_format',
+            'summary',
+            'body',
+            'author',
+        )
+
+    def add_rst_error(self, field, level, position, message):
+        return self.add_error(
+            field,
+            'reStructuredText {} at {}: {}'.format(level, position, message)
+        )
+
+    def check_for_rst_error(self, field, level, html):
+        if re.search(RE_RST[level], html):
+            for match in re.findall(RE_RST[level], html):
+                self.add_rst_error(field, level, *match)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get('content_format') == 'reST':
+            summary_html = publish_parts(
+                source=cleaned_data.get('summary'),
+                writer_name='html',
+                settings_overrides=BLOG_DOCUTILS_SETTINGS
+            )['fragment']
+
+            self.check_for_rst_error('summary', 'error', summary_html)
+            self.check_for_rst_error('summary', 'warning', summary_html)
+
+            body_html = publish_parts(
+                source=cleaned_data.get('body'),
+                writer_name='html',
+                settings_overrides=BLOG_DOCUTILS_SETTINGS
+            )['fragment']
+
+            self.check_for_rst_error('body', 'error', body_html)
+            self.check_for_rst_error('body', 'warning', body_html)

--- a/blog/tests/__init__.py
+++ b/blog/tests/__init__.py
@@ -1,0 +1,9 @@
+from datetime import timedelta
+from django.utils import timezone
+
+
+class DateTimeMixin(object):
+    def setUp(self):
+        self.now = timezone.now()
+        self.yesterday = self.now - timedelta(days=1)
+        self.tomorrow = self.now + timedelta(days=1)

--- a/blog/tests/test_forms.py
+++ b/blog/tests/test_forms.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+from django.utils.timezone import now
+
+from blog.forms import EntryForm
+
+
+class EntryFormTests(TestCase):
+    def generate_data(self, rst):
+        return {
+            'headline': 'TestEntry',
+            'slug': 'testentry',
+            'content_format': 'reST',
+            'summary': rst,
+            'body': rst,
+            'pub_date': now(),
+            'author': 'Django developer',
+        }
+
+    def test_validation_of_rst_errors(self):
+        form = EntryForm(self.generate_data('.. tag::'))
+        self.assertFalse(form.is_valid())
+        self.assertIn('summary', form.errors)
+        self.assertEqual(
+            form.errors['summary'][0],
+            'reStructuredText error at line 1: Unknown directive type &quot;tag&quot;.'
+        )
+        self.assertIn('body', form.errors)
+        self.assertEqual(
+            form.errors['body'][0],
+            'reStructuredText error at line 1: Unknown directive type &quot;tag&quot;.'
+        )
+
+    def test_validation_of_rst_warnings(self):
+        form = EntryForm(self.generate_data('Heading\n===='))
+        form.is_valid()
+        self.assertFalse(form.is_valid())
+        self.assertIn('summary', form.errors)
+        self.assertEqual(
+            form.errors['summary'][0],
+            'reStructuredText warning at line 2: Title underline too short.'
+        )
+        self.assertIn('body', form.errors)
+        self.assertEqual(
+            form.errors['body'][0],
+            'reStructuredText warning at line 2: Title underline too short.'
+        )

--- a/blog/tests/test_models.py
+++ b/blog/tests/test_models.py
@@ -1,21 +1,10 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import captured_stderr
-from django.utils import timezone
-from django.utils.timezone import now
 
-from blog.forms import EntryForm
-
-from .models import Entry, Event
-
-
-class DateTimeMixin(object):
-    def setUp(self):
-        self.now = timezone.now()
-        self.yesterday = self.now - timedelta(days=1)
-        self.tomorrow = self.now + timedelta(days=1)
+from . import DateTimeMixin
+from ..models import Entry, Event
 
 
 class EntryTestCase(DateTimeMixin, TestCase):
@@ -86,59 +75,3 @@ class EventTestCase(DateTimeMixin, TestCase):
 
         self.assertQuerysetEqual(Event.objects.future(), ['c', 'd'], transform=lambda event: event.headline)
         self.assertQuerysetEqual(Event.objects.past(), ['b', 'a'], transform=lambda event: event.headline)
-
-
-class ViewsTestCase(DateTimeMixin, TestCase):
-    def test_no_past_upcoming_events(self):
-        """
-        Make sure there are no past event in the "upcoming events" sidebar (#399)
-        """
-        # We need a published entry on the index page so that it doesn't return a 404
-        Entry.objects.create(pub_date=self.yesterday, is_active=True)
-        Event.objects.create(date=self.yesterday, pub_date=self.now, is_active=True, headline='Jezdezcon')
-        response = self.client.get(reverse('weblog:index'))
-        self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(response.context['events'], [])
-
-
-class EntryFormTests(TestCase):
-
-    def generate_data(self, rst):
-        return {
-            'headline': 'TestEntry',
-            'slug': 'testentry',
-            'content_format': 'reST',
-            'summary': rst,
-            'body': rst,
-            'pub_date': now(),
-            'author': 'Django developer',
-        }
-
-    def test_validation_of_rst_errors(self):
-        form = EntryForm(self.generate_data('.. tag::'))
-        self.assertFalse(form.is_valid())
-        self.assertIn('summary', form.errors)
-        self.assertEqual(
-            form.errors['summary'][0],
-            'reStructuredText error at line 1: Unknown directive type &quot;tag&quot;.'
-        )
-        self.assertIn('body', form.errors)
-        self.assertEqual(
-            form.errors['body'][0],
-            'reStructuredText error at line 1: Unknown directive type &quot;tag&quot;.'
-        )
-
-    def test_validation_of_rst_warnings(self):
-        form = EntryForm(self.generate_data('Heading\n===='))
-        form.is_valid()
-        self.assertFalse(form.is_valid())
-        self.assertIn('summary', form.errors)
-        self.assertEqual(
-            form.errors['summary'][0],
-            'reStructuredText warning at line 2: Title underline too short.'
-        )
-        self.assertIn('body', form.errors)
-        self.assertEqual(
-            form.errors['body'][0],
-            'reStructuredText warning at line 2: Title underline too short.'
-        )

--- a/blog/tests/test_views.py
+++ b/blog/tests/test_views.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from django_hosts import reverse
+
+from . import DateTimeMixin
+from ..models import Entry, Event
+
+
+class ViewsTestCase(DateTimeMixin, TestCase):
+    def test_no_past_upcoming_events(self):
+        """
+        Make sure there are no past event in the "upcoming events" sidebar (#399)
+        """
+        # We need a published entry on the index page so that it doesn't return a 404
+        Entry.objects.create(pub_date=self.yesterday, is_active=True)
+        Event.objects.create(date=self.yesterday, pub_date=self.now, is_active=True, headline='Jezdezcon')
+        response = self.client.get(reverse('weblog:index'))
+        self.assertEqual(response.status_code, 200)
+        self.assertQuerysetEqual(response.context['events'], [])


### PR DESCRIPTION
This checks the html output of the reST parser for warnings and errors and adds a form error if one is present.

This uses regex to find the error messages, because docutils fails silently.

<img width="831" alt="screenshot 2015-08-04 16 04 29" src="https://cloud.githubusercontent.com/assets/476364/9062555/6f439aaa-3ac3-11e5-9817-0c20a132577d.png">
