### PR TITLE
Added zip code and street checks to Stripe integration

### DIFF
--- a/djangoproject/static/js/mod/stripe-custom-checkout.js
+++ b/djangoproject/static/js/mod/stripe-custom-checkout.js
@@ -56,7 +56,9 @@ define([
             description: $donationForm.data('campaignName'),
             amount: amountCents,
             currency: 'USD',
-            bitcoin: true
+            bitcoin: true,
+            zipCode: true,
+            billingAddress: true
         });
     });
 });


### PR DESCRIPTION
We're having lots of fraudulent payments and chargebacks, which is costing money. This change will require people to give address in Stripe payment form and hopefully will decrease an amount of payments like that.