### PR TITLE
Improve docs releases

### DIFF
--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.test import SimpleTestCase, TestCase
 
 from docs.models import DocumentRelease
+from releases.models import Release
 
 from . import models
 from .forms import FeedModelForm
@@ -20,9 +21,13 @@ class AggregatorTests(TestCase):
     def setUp(self, mocker):
         mocker.register_uri('POST', settings.PUSH_HUB, status_code=202)
         # document release necessary to fetch main page
-        DocumentRelease.objects.get_or_create(
+        release, _ = Release.objects.get_or_create(
             version="1.4",
-            is_default=True,
+        )
+        DocumentRelease.objects.update_or_create(
+            release=release,
+            lang='en',
+            defaults={'is_default': True},
         )
 
         # Set up users who will get emailed

--- a/djangoproject/templates/docs/doc.html
+++ b/djangoproject/templates/docs/doc.html
@@ -18,11 +18,11 @@
 {% endblock head_extra %}
 
 {% block body_extra %}
-{% if version_is_dev %}
+{% if release.is_dev %}
 <div id="dev-warning" class="doc-floating-warning">
   {% trans "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
 </div>
-{% elif version_is_unsupported %}
+{% elif not release.is_supported %}
 <div id="outdated-warning" class="doc-floating-warning">
   {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
 </div>
@@ -43,8 +43,8 @@
   </li>
   {% endif %}
   {% endfor %}
-  <li class="current{% if version_is_dev %} dev{% endif %}"
-  title="{% if version_is_dev %}{% blocktrans trimmed %}
+  <li class="current{% if release.is_dev %} dev{% endif %}"
+  title="{% if release.is_dev %}{% blocktrans trimmed %}
     This document is for Django's development version, which can be significantly different from previous releases.
   {% endblocktrans %}{% else %}{% blocktrans trimmed %}
     This document describes Django {{ version }}.
@@ -52,7 +52,7 @@
     Click on the links on the left to see other versions.
   {% endblocktrans %}">
   <span>{% trans "Documentation version:" %}
-    <strong>{% if version_is_dev %}
+    <strong>{% if release.is_dev %}
       development{% else %}{{ version }}
       {% endif %}</strong>
     </span>

--- a/docs/admin.py
+++ b/docs/admin.py
@@ -4,7 +4,7 @@ from .models import DocumentRelease
 
 admin.site.register(
     DocumentRelease,
-    list_display=['version', 'lang', 'is_default'],
+    list_display=['release', 'lang', 'is_default'],
     list_editable=['is_default'],
     list_filter=['lang'],
 )

--- a/docs/fixtures/doc_releases.json
+++ b/docs/fixtures/doc_releases.json
@@ -3,7 +3,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "dev"
+    "release": null
   },
   "model": "docs.documentrelease",
   "pk": 1
@@ -12,16 +12,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.3"
-  },
-  "model": "docs.documentrelease",
-  "pk": 5
-},
-{
-  "fields": {
-    "lang": "en",
-    "is_default": false,
-    "version": "1.4"
+    "release": "1.4"
   },
   "model": "docs.documentrelease",
   "pk": 6
@@ -30,7 +21,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.5"
+    "release": "1.5"
   },
   "model": "docs.documentrelease",
   "pk": 7
@@ -39,7 +30,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.5"
+    "release": "1.5"
   },
   "model": "docs.documentrelease",
   "pk": 8
@@ -48,7 +39,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.6"
+    "release": "1.6"
   },
   "model": "docs.documentrelease",
   "pk": 9
@@ -57,7 +48,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.6"
+    "release": "1.6"
   },
   "model": "docs.documentrelease",
   "pk": 10
@@ -66,7 +57,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.7"
+    "release": "1.7"
   },
   "model": "docs.documentrelease",
   "pk": 11
@@ -75,7 +66,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.7"
+    "release": "1.7"
   },
   "model": "docs.documentrelease",
   "pk": 12
@@ -84,7 +75,7 @@
   "fields": {
     "lang": "en",
     "is_default": true,
-    "version": "1.8"
+    "release": "1.8"
   },
   "model": "docs.documentrelease",
   "pk": 13
@@ -93,7 +84,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.8"
+    "release": "1.8"
   },
   "model": "docs.documentrelease",
   "pk": 14

--- a/docs/fixtures/doc_test_fixtures.json
+++ b/docs/fixtures/doc_test_fixtures.json
@@ -1,92 +1,157 @@
 [
-  {
-    "pk": 1,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "dev"
-    }
-  },
-  {
-    "pk": 2,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.0"
-    }
-  },
-  {
-    "pk": 3,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.1"
-    }
-  },
-  {
-    "pk": 4,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.2"
-    }
-  },
-  {
-    "pk": 5,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.3"
-    }
-  },
-  {
-    "pk": 6,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.4"
-    }
-  },
-  {
-    "pk": 7,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.5"
-    }
-  },
-  {
-    "pk": 8,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "fr",
-      "is_default": false,
-      "version": "1.5"
-    }
-  },
-  {
-    "pk": 9,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": true,
-      "version": "1.6"
-    }
-  },
-  {
-    "pk": 10,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "fr",
-      "is_default": false,
-      "version": "1.6"
-    }
+{
+  "model": "releases.release",
+  "pk": "1.4",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2012-03-23",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 4,
+    "status": "f"
   }
+},
+{
+  "model": "releases.release",
+  "pk": "1.5",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-02-26",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 5,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.6",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-11-06",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 6,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.7",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2014-09-02",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 7,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.8",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2015-04-01",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 8,
+    "status": "f"
+  }
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": null
+  },
+  "model": "docs.documentrelease",
+  "pk": 1
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.4"
+  },
+  "model": "docs.documentrelease",
+  "pk": 6
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.5"
+  },
+  "model": "docs.documentrelease",
+  "pk": 7
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.5"
+  },
+  "model": "docs.documentrelease",
+  "pk": 8
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.6"
+  },
+  "model": "docs.documentrelease",
+  "pk": 9
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.6"
+  },
+  "model": "docs.documentrelease",
+  "pk": 10
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.7"
+  },
+  "model": "docs.documentrelease",
+  "pk": 11
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.7"
+  },
+  "model": "docs.documentrelease",
+  "pk": 12
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": true,
+    "release": "1.8"
+  },
+  "model": "docs.documentrelease",
+  "pk": 13
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.8"
+  },
+  "model": "docs.documentrelease",
+  "pk": 14
+}
 ]

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         # building newer versions first works. I suspect Sphinx is hanging onto
         # some global state. Anyway, we can work around it by making sure that
         # "dev" builds before "1.0". This is ugly, but oh well.
-        for release in DocumentRelease.objects.order_by('-version'):
+        for release in DocumentRelease.objects.order_by('-release'):
             if verbosity >= 1:
                 self.stdout.write("Updating %s..." % release)
 

--- a/docs/migrations/0003_add_fk_to_release.py
+++ b/docs/migrations/0003_add_fk_to_release.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('releases', '0001_initial'),
+        ('docs', '0002_simplify_documentrelease'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='documentrelease',
+            name='release',
+            field=models.ForeignKey(null=True, to='releases.Release'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='documentrelease',
+            unique_together=set([('lang', 'release'), ('lang', 'version')]),
+        ),
+    ]

--- a/docs/migrations/0004_populate_fk_to_release.py
+++ b/docs/migrations/0004_populate_fk_to_release.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def set_release(apps, schema_editor):
+    DocumentRelease = apps.get_model('docs', 'DocumentRelease')
+    Release = apps.get_model('releases', 'Release')
+    for dr in DocumentRelease.objects.all():
+        if dr.version == 'dev':
+            continue
+        dr.release = Release.objects.get(pk=dr.version)
+        dr.save()
+
+
+def unset_release(apps, schema_editor):
+    DocumentRelease = apps.get_model('docs', 'DocumentRelease')
+    DocumentRelease.objects.update(release=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('docs', '0003_add_fk_to_release'),
+        ('releases', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_release, unset_release),
+    ]

--- a/docs/migrations/0005_remove_version.py
+++ b/docs/migrations/0005_remove_version.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('docs', '0004_populate_fk_to_release'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='documentrelease',
+            unique_together=set([('lang', 'release')]),
+        ),
+        migrations.RemoveField(
+            model_name='documentrelease',
+            name='version',
+        ),
+    ]

--- a/docs/models.py
+++ b/docs/models.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import operator
 from functools import reduce
@@ -38,6 +39,9 @@ class DocumentReleaseManager(models.Manager):
                 settings.CACHE_MIDDLEWARE_SECONDS,
             )
         return current_version
+
+    def get_by_version_and_lang(self, version, lang):
+        return self.get(lang=lang, **{'release__isnull': True} if version == 'dev' else {'release': version})
 
 
 class DocumentRelease(models.Model):
@@ -90,6 +94,13 @@ class DocumentRelease(models.Model):
     @property
     def is_dev(self):
         return self.release is None
+
+    @property
+    def is_supported(self):
+        if self.release is None:
+            return True
+        eol_date = self.release.eol_date
+        return eol_date is None or eol_date > datetime.date.today()
 
     @property
     def scm_url(self):

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -14,7 +14,10 @@ register = template.Library()
 @register.inclusion_tag('docs/search_form.html', takes_context=True)
 def search_form(context):
     request = context['request']
-    release = DocumentRelease.objects.get(version=context['version'], lang=context['lang'])
+    release = DocumentRelease.objects.get_by_version_and_lang(
+        context['version'],
+        context['lang'],
+    )
     return {
         'form': DocSearchForm(request.GET, release=release),
         'version': context['version'],
@@ -31,8 +34,8 @@ def get_all_doc_versions(context, url=None):
     """
     lang = context.get('lang', 'en')
     if url is None:
-        versions = DocumentRelease.objects.filter(lang=lang).order_by('version')
-        return versions.value_list('version', flat=True)
+        versions = DocumentRelease.objects.filter(lang=lang).order_by('release')
+        return versions.value_list('release', flat=True)
 
     versions = []
 

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from pathlib import Path
 
@@ -6,7 +7,28 @@ from django.core.urlresolvers import set_urlconf
 from django.template import Context, Template
 from django.test import TestCase
 
+from releases.models import Release
+
+from .models import DocumentRelease
 from .utils import get_doc_path
+
+
+class ModelsTests(TestCase):
+    def test_is_supported(self):
+        d = DocumentRelease.objects.create()
+        # Document without a release ("dev") is supported.
+        self.assertTrue(d.is_supported)
+        self.assertTrue(d.is_dev)
+
+        r = Release(major=1, minor=7, micro=0, version='1.7')
+        d.release = r
+        # Document with a release without an EOL date is supported.
+        self.assertTrue(d.is_supported)
+        self.assertFalse(d.is_dev)
+
+        # Document with an EOL date in the past is unsupported.
+        r.eol_date = datetime.date(2000, 1, 1)
+        self.assertFalse(d.is_supported)
 
 
 class SearchFormTestCase(TestCase):

--- a/docs/views.py
+++ b/docs/views.py
@@ -18,14 +18,7 @@ from .models import Document, DocumentRelease
 from .search import DocumentDocType, SearchPaginator
 from .utils import get_doc_path_or_404, get_doc_root_or_404
 
-CURRENT_LTS = '1.4'
-UNSUPPORTED_THRESHOLD = '1.7'
 SIMPLE_SEARCH_OPERATORS = ['+', '|', '-', '"', '*', '(', ')', '~']
-
-
-def version_is_unsupported(version):
-    # TODO: would be nice not to hardcode this.
-    return version != CURRENT_LTS and version < UNSUPPORTED_THRESHOLD
 
 
 def index(request):
@@ -47,6 +40,7 @@ def document(request, lang, version, url):
     # exception will be emitted by unipath, proactively check for bad data (mostly
     # from the Googlebot) so we can give a nice 404 error.
     try:
+        lang.encode("ascii")
         version.encode("ascii")
         url.encode("ascii")
     except UnicodeEncodeError:
@@ -57,6 +51,10 @@ def document(request, lang, version, url):
 
     docroot = get_doc_root_or_404(lang, version)
     doc_path = get_doc_path_or_404(docroot, url)
+    try:
+        release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
+    except DocumentRelease.DoesNotExist:
+        raise Http404
 
     if version == 'dev':
         rtd_version = 'latest'
@@ -75,8 +73,7 @@ def document(request, lang, version, url):
         'env': json.load((docroot.joinpath('globalcontext.json')).open('r')),
         'lang': lang,
         'version': version,
-        'version_is_dev': version == 'dev',
-        'version_is_unsupported': version_is_unsupported(version),
+        'release': release,
         'rtd_version': rtd_version,
         'docurl': url,
         'update_date': datetime.datetime.fromtimestamp((docroot.joinpath('last_build')).stat().st_mtime),
@@ -134,7 +131,10 @@ def search_results(request, lang, version, per_page=10, orphans=3):
     Search view to handle language and version specific queries.
     The old search view is being redirected here.
     """
-    release = get_object_or_404(DocumentRelease, version=version, lang=lang)
+    try:
+        release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
+    except DocumentRelease.DoesNotExist:
+        raise Http404
     form = DocSearchForm(request.GET or None, release=release)
 
     context = {
@@ -143,8 +143,6 @@ def search_results(request, lang, version, per_page=10, orphans=3):
         'version': release.version,
         'release': release,
         'searchparams': request.GET.urlencode(),
-        'version_is_dev': version == 'dev',
-        'version_is_unsupported': version_is_unsupported(version),
     }
 
     if form.is_valid():

--- a/releases/fixtures/doc_releases.json
+++ b/releases/fixtures/doc_releases.json
@@ -1,0 +1,67 @@
+[
+{
+  "model": "releases.release",
+  "pk": "1.4",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2012-03-23",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 4,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.5",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-02-26",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 5,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.6",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-11-06",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 6,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.7",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2014-09-02",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 7,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.8",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2015-04-01",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 8,
+    "status": "f"
+  }
+}
+]

--- a/releases/models.py
+++ b/releases/models.py
@@ -7,9 +7,6 @@ from django.db import models
 from django.utils.functional import cached_property
 from django.utils.version import get_version
 
-# How many days after the release an LTS is the previous LTS supported?
-LTS_SUPPORT_OVERLAP_DAYS = 180
-
 
 class ReleaseManager(models.Manager):
 
@@ -31,9 +28,14 @@ class ReleaseManager(models.Manager):
     def previous_lts(self):
         """Get the previous LTS if it's still supported."""
         current_lts = self.current_lts()
-        # Check if the previous LTS is too old to be supported.
-        if datetime.date.today() - current_lts.date < datetime.timedelta(LTS_SUPPORT_OVERLAP_DAYS):
-            return self.lts().exclude(minor=current_lts.minor).first()
+        previous_lts = list(self.lts().exclude(
+            major=current_lts.major,
+            minor=current_lts.minor,
+        ))
+        # Only the "X.Y" version will have an EOL date.
+        eol_date = previous_lts[-1].eol_date
+        if eol_date is None or eol_date > datetime.date.today():
+            return previous_lts[0]
 
     def current_version(self):
         current_version = cache.get(Release.DEFAULT_CACHE_KEY, None)


### PR DESCRIPTION
The primary goal of this PR was to mark 1.4 as unsupported on docs.djangoproject.com.

Along the way, I normalized and simplified models. I provided data migrations for zero-downtime deploy: no data editing in the admin is needed during deployment.