### PR TITLE
Improve docs releases

### DIFF
--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.test import SimpleTestCase, TestCase
 
 from docs.models import DocumentRelease
+from releases.models import Release
 
 from . import models
 from .forms import FeedModelForm
@@ -20,9 +21,13 @@ class AggregatorTests(TestCase):
     def setUp(self, mocker):
         mocker.register_uri('POST', settings.PUSH_HUB, status_code=202)
         # document release necessary to fetch main page
-        DocumentRelease.objects.get_or_create(
+        release, _ = Release.objects.get_or_create(
             version="1.4",
-            is_default=True,
+        )
+        DocumentRelease.objects.update_or_create(
+            release=release,
+            lang='en',
+            defaults={'is_default': True},
         )
 
         # Set up users who will get emailed

--- a/djangoproject/templates/docs/doc.html
+++ b/djangoproject/templates/docs/doc.html
@@ -18,11 +18,11 @@
 {% endblock head_extra %}
 
 {% block body_extra %}
-{% if version_is_dev %}
+{% if release.is_dev %}
 <div id="dev-warning" class="doc-floating-warning">
   {% trans "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
 </div>
-{% elif version_is_unsupported %}
+{% elif not release.is_supported %}
 <div id="outdated-warning" class="doc-floating-warning">
   {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
 </div>
@@ -43,8 +43,8 @@
   </li>
   {% endif %}
   {% endfor %}
-  <li class="current{% if version_is_dev %} dev{% endif %}"
-  title="{% if version_is_dev %}{% blocktrans trimmed %}
+  <li class="current{% if release.is_dev %} dev{% endif %}"
+  title="{% if release.is_dev %}{% blocktrans trimmed %}
     This document is for Django's development version, which can be significantly different from previous releases.
   {% endblocktrans %}{% else %}{% blocktrans trimmed %}
     This document describes Django {{ version }}.
@@ -52,7 +52,7 @@
     Click on the links on the left to see other versions.
   {% endblocktrans %}">
   <span>{% trans "Documentation version:" %}
-    <strong>{% if version_is_dev %}
+    <strong>{% if release.is_dev %}
       development{% else %}{{ version }}
       {% endif %}</strong>
     </span>

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -20,25 +20,25 @@
     Here’s how to get it:</p>
 
   <h2>Option {% cycle '1' '2' '3' as options %}: Get the latest official version</h2>
-  <p>The latest official version is {{ current_version }}. Read the
-    {% release_notes current_version show_version=True %}, then install it with
+  <p>The latest official version is {{ current.version }}. Read the
+    {% release_notes current.version show_version=True %}, then install it with
     <a href="http://www.pip-installer.org/en/latest/">pip</a>:</p>
-  <pre class="literal-block"><code>pip install Django=={{ current_version }}</code></pre>
+  <pre class="literal-block"><code>pip install Django=={{ current.version }}</code></pre>
 
-  {% if preview_version %}
-      {% with preview_version|slice:":3" as major_version %}
-      <h2>Option {% cycle options %}: Get the {{ preview_kind }} for {{ major_version }}</h2>
+  {% if preview %}
+      {% with preview.version|slice:":3" as major_version %}
+      <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
       <p>As part of the
         <a href="https://code.djangoproject.com/wiki/Version{{ major_version }}Roadmap">
         Django {{ major_version }} development process</a>, Django
-        {{ preview_version }} is available. This release is only for users who
+        {{ preview.version }} is available. This release is only for users who
         want to try the new version and help identify remaining bugs before the
         {{ major_version }} release. Please read the
-        {% release_notes preview_version show_version=True %} before using this package.
-      <p>Install the {{ preview_kind }} with <a href="https://pip.pypa.io/">pip</a>:</p>
+        {% release_notes preview.version show_version=True %} before using this package.
+      <p>Install the {{ preview.get_status_display }} with <a href="https://pip.pypa.io/">pip</a>:</p>
       <pre class="literal-block"><code>pip install --pre django</pre></code></pre>
-      <p>Or if you have pip < 1.4:</p>
-      <pre class="literal-block"><code>pip install {% url 'download-redirect' preview_version 'tarball' %}</code></pre>
+      <p>Or if you have pip &lt; 1.4:</p>
+      <pre class="literal-block"><code>pip install {% url 'download-redirect' preview.version 'tarball' %}</code></pre>
       {% endwith %}
   {% endif %}
 
@@ -165,20 +165,20 @@
     <h2>For the impatient:</h2>
     <ul>
       <li>Latest release:
-        <a href="{% url 'download-redirect' current_version 'tarball' %}">
-          Django-{{ current_version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' current_version 'checksum' %}">
-          Django-{{ current_version }}.checksum.txt</a><br>
-        Release notes: {% release_notes current_version %}
+        <a href="{% url 'download-redirect' current.version 'tarball' %}">
+          Django-{{ current.version }}.tar.gz</a><br>
+        Checksums: <a href="{% url 'download-redirect' current.version 'checksum' %}">
+          Django-{{ current.version }}.checksum.txt</a><br>
+        Release notes: {% release_notes current.version %}
       </li>
 
-      {% if preview_version %}
+      {% if preview %}
       <li>Preview release:
-        <a href="{% url 'download-redirect' preview_version 'tarball' %}">
-          Django-{{ preview_version }}.tar.gz</a><br>
-          Checksums: <a href="{% url 'download-redirect' preview_version 'checksum' %}">
-            Django-{{ preview_version }}.checksum.txt</a><br>
-          Release notes: {% release_notes preview_version %}
+        <a href="{% url 'download-redirect' preview.version 'tarball' %}">
+          Django-{{ preview.version }}.tar.gz</a><br>
+          Checksums: <a href="{% url 'download-redirect' preview.version 'checksum' %}">
+            Django-{{ preview.version }}.checksum.txt</a><br>
+          Release notes: {% release_notes preview.version %}
       </li>
       {% endif %}
     </ul>
@@ -189,32 +189,32 @@
     <p>If you’re just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading).</p>
     <h2>Previous releases</h2>
     <ul>
-      <li>Django {{ previous_version }}:
-        <a href="{% url 'download-redirect' previous_version 'tarball' %}">
-          Django-{{ previous_version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' previous_version 'checksum' %}">
-          Django-{{ previous_version }}.checksum.txt</a><br>
-        Release notes: {% release_notes previous_version %}
+      <li>Django {{ previous.version }}:
+        <a href="{% url 'download-redirect' previous.version 'tarball' %}">
+          Django-{{ previous.version }}.tar.gz</a><br>
+        Checksums: <a href="{% url 'download-redirect' previous.version 'checksum' %}">
+          Django-{{ previous.version }}.checksum.txt</a><br>
+        Release notes: {% release_notes previous.version %}
       </li>
-      {% if lts_version %}
-        <li>Django {{ lts_version }} (LTS):
-          <a href="{% url 'download-redirect' lts_version 'tarball' %}">
-            Django-{{ lts_version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' lts_version 'checksum' %}">
-          Django-{{ lts_version }}.checksum.txt</a><br>
-          Release notes: {% release_notes lts_version %}
+      {% if lts %}
+        <li>Django {{ lts.version }} (LTS):
+          <a href="{% url 'download-redirect' lts.version 'tarball' %}">
+            Django-{{ lts.version }}.tar.gz</a><br>
+        Checksums: <a href="{% url 'download-redirect' lts.version 'checksum' %}">
+          Django-{{ lts.version }}.checksum.txt</a><br>
+          Release notes: {% release_notes lts.version %}
         </li>
       {% endif %}
     </ul>
 
     <h2>Unsupported previous releases (no longer receive security updates or bug fixes)</h2>
     <ul>
-      {% for earlier_version in earlier_versions %}
-      <li>Django {{ earlier_version }}:
-        <a href="{% url 'download-redirect' earlier_version 'tarball' %}">
-          Django-{{ earlier_version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' earlier_version 'checksum' %}">
-          Django-{{ earlier_version }}.checksum.txt</a></li>
+      {% for release in unsupported %}
+      <li>Django {{ release.version }}:
+        <a href="{% url 'download-redirect' release.version 'tarball' %}">
+          Django-{{ release.version }}.tar.gz</a><br>
+        Checksums: <a href="{% url 'download-redirect' release.version 'checksum' %}">
+          Django-{{ release.version }}.checksum.txt</a></li>
       {% endfor %}
     </ul>
 

--- a/docs/admin.py
+++ b/docs/admin.py
@@ -4,7 +4,7 @@ from .models import DocumentRelease
 
 admin.site.register(
     DocumentRelease,
-    list_display=['version', 'lang', 'is_default'],
+    list_display=['release', 'lang', 'is_default'],
     list_editable=['is_default'],
     list_filter=['lang'],
 )

--- a/docs/fixtures/doc_releases.json
+++ b/docs/fixtures/doc_releases.json
@@ -3,7 +3,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "dev"
+    "release": null
   },
   "model": "docs.documentrelease",
   "pk": 1
@@ -12,16 +12,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.3"
-  },
-  "model": "docs.documentrelease",
-  "pk": 5
-},
-{
-  "fields": {
-    "lang": "en",
-    "is_default": false,
-    "version": "1.4"
+    "release": "1.4"
   },
   "model": "docs.documentrelease",
   "pk": 6
@@ -30,7 +21,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.5"
+    "release": "1.5"
   },
   "model": "docs.documentrelease",
   "pk": 7
@@ -39,7 +30,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.5"
+    "release": "1.5"
   },
   "model": "docs.documentrelease",
   "pk": 8
@@ -48,7 +39,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.6"
+    "release": "1.6"
   },
   "model": "docs.documentrelease",
   "pk": 9
@@ -57,7 +48,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.6"
+    "release": "1.6"
   },
   "model": "docs.documentrelease",
   "pk": 10
@@ -66,7 +57,7 @@
   "fields": {
     "lang": "en",
     "is_default": false,
-    "version": "1.7"
+    "release": "1.7"
   },
   "model": "docs.documentrelease",
   "pk": 11
@@ -75,7 +66,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.7"
+    "release": "1.7"
   },
   "model": "docs.documentrelease",
   "pk": 12
@@ -84,7 +75,7 @@
   "fields": {
     "lang": "en",
     "is_default": true,
-    "version": "1.8"
+    "release": "1.8"
   },
   "model": "docs.documentrelease",
   "pk": 13
@@ -93,7 +84,7 @@
   "fields": {
     "lang": "fr",
     "is_default": false,
-    "version": "1.8"
+    "release": "1.8"
   },
   "model": "docs.documentrelease",
   "pk": 14

--- a/docs/fixtures/doc_test_fixtures.json
+++ b/docs/fixtures/doc_test_fixtures.json
@@ -1,92 +1,157 @@
 [
-  {
-    "pk": 1,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "dev"
-    }
-  },
-  {
-    "pk": 2,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.0"
-    }
-  },
-  {
-    "pk": 3,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.1"
-    }
-  },
-  {
-    "pk": 4,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.2"
-    }
-  },
-  {
-    "pk": 5,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.3"
-    }
-  },
-  {
-    "pk": 6,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.4"
-    }
-  },
-  {
-    "pk": 7,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": false,
-      "version": "1.5"
-    }
-  },
-  {
-    "pk": 8,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "fr",
-      "is_default": false,
-      "version": "1.5"
-    }
-  },
-  {
-    "pk": 9,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "en",
-      "is_default": true,
-      "version": "1.6"
-    }
-  },
-  {
-    "pk": 10,
-    "model": "docs.documentrelease",
-    "fields": {
-      "lang": "fr",
-      "is_default": false,
-      "version": "1.6"
-    }
+{
+  "model": "releases.release",
+  "pk": "1.4",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2012-03-23",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 4,
+    "status": "f"
   }
+},
+{
+  "model": "releases.release",
+  "pk": "1.5",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-02-26",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 5,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.6",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-11-06",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 6,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.7",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2014-09-02",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 7,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.8",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2015-04-01",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 8,
+    "status": "f"
+  }
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": null
+  },
+  "model": "docs.documentrelease",
+  "pk": 1
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.4"
+  },
+  "model": "docs.documentrelease",
+  "pk": 6
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.5"
+  },
+  "model": "docs.documentrelease",
+  "pk": 7
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.5"
+  },
+  "model": "docs.documentrelease",
+  "pk": 8
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.6"
+  },
+  "model": "docs.documentrelease",
+  "pk": 9
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.6"
+  },
+  "model": "docs.documentrelease",
+  "pk": 10
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": false,
+    "release": "1.7"
+  },
+  "model": "docs.documentrelease",
+  "pk": 11
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.7"
+  },
+  "model": "docs.documentrelease",
+  "pk": 12
+},
+{
+  "fields": {
+    "lang": "en",
+    "is_default": true,
+    "release": "1.8"
+  },
+  "model": "docs.documentrelease",
+  "pk": 13
+},
+{
+  "fields": {
+    "lang": "fr",
+    "is_default": false,
+    "release": "1.8"
+  },
+  "model": "docs.documentrelease",
+  "pk": 14
+}
 ]

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         # building newer versions first works. I suspect Sphinx is hanging onto
         # some global state. Anyway, we can work around it by making sure that
         # "dev" builds before "1.0". This is ugly, but oh well.
-        for release in DocumentRelease.objects.order_by('-version'):
+        for release in DocumentRelease.objects.order_by('-release'):
             if verbosity >= 1:
                 self.stdout.write("Updating %s..." % release)
 

--- a/docs/migrations/0003_add_fk_to_release.py
+++ b/docs/migrations/0003_add_fk_to_release.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('releases', '0001_initial'),
+        ('docs', '0002_simplify_documentrelease'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='documentrelease',
+            name='release',
+            field=models.ForeignKey(null=True, to='releases.Release'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='documentrelease',
+            unique_together=set([('lang', 'release'), ('lang', 'version')]),
+        ),
+    ]

--- a/docs/migrations/0004_populate_fk_to_release.py
+++ b/docs/migrations/0004_populate_fk_to_release.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def set_release(apps, schema_editor):
+    DocumentRelease = apps.get_model('docs', 'DocumentRelease')
+    Release = apps.get_model('releases', 'Release')
+    for dr in DocumentRelease.objects.exclude(version='dev'):
+        try:
+            release = Release.objects.get(version=dr.version)
+        except Release.DoesNotExist:
+            # Hack: we need the actual Release model, specifically
+            # its overridden save(), to create a release.
+            from releases.models import Release as RealRelease
+            release = RealRelease(version=dr.version, date=None)
+            release.save()
+        # Because of the hack above, we cannot use dr.release = release.
+        dr.release_id = release.pk
+        dr.save()
+
+
+def unset_release(apps, schema_editor):
+    DocumentRelease = apps.get_model('docs', 'DocumentRelease')
+    DocumentRelease.objects.update(release=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('docs', '0003_add_fk_to_release'),
+        ('releases', '0004_make_release_date_nullable'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_release, unset_release),
+    ]

--- a/docs/migrations/0005_remove_version.py
+++ b/docs/migrations/0005_remove_version.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('docs', '0004_populate_fk_to_release'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='documentrelease',
+            unique_together=set([('lang', 'release')]),
+        ),
+        migrations.RemoveField(
+            model_name='documentrelease',
+            name='version',
+        ),
+    ]

--- a/docs/models.py
+++ b/docs/models.py
@@ -99,7 +99,15 @@ class DocumentRelease(models.Model):
     def is_supported(self):
         if self.release is None:
             return True
-        eol_date = self.release.eol_date
+        latest_release = (Release.objects
+                                 .filter(major=self.release.major,
+                                         minor=self.release.minor,
+                                         status='f')
+                                 .order_by('-micro')
+                                 .first())
+        if latest_release is None:
+            return True
+        eol_date = latest_release.eol_date
         return eol_date is None or eol_date > datetime.date.today()
 
     @property

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -14,7 +14,10 @@ register = template.Library()
 @register.inclusion_tag('docs/search_form.html', takes_context=True)
 def search_form(context):
     request = context['request']
-    release = DocumentRelease.objects.get(version=context['version'], lang=context['lang'])
+    release = DocumentRelease.objects.get_by_version_and_lang(
+        context['version'],
+        context['lang'],
+    )
     return {
         'form': DocSearchForm(request.GET, release=release),
         'version': context['version'],
@@ -31,8 +34,8 @@ def get_all_doc_versions(context, url=None):
     """
     lang = context.get('lang', 'en')
     if url is None:
-        versions = DocumentRelease.objects.filter(lang=lang).order_by('version')
-        return versions.value_list('version', flat=True)
+        versions = DocumentRelease.objects.filter(lang=lang).order_by('release')
+        return versions.value_list('release', flat=True)
 
     versions = []
 

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from pathlib import Path
 
@@ -6,7 +7,28 @@ from django.core.urlresolvers import set_urlconf
 from django.template import Context, Template
 from django.test import TestCase
 
+from releases.models import Release
+
+from .models import DocumentRelease
 from .utils import get_doc_path
+
+
+class ModelsTests(TestCase):
+    def test_is_supported(self):
+        d = DocumentRelease.objects.create()
+        # Document without a release ("dev") is supported.
+        self.assertTrue(d.is_supported)
+        self.assertTrue(d.is_dev)
+
+        r = Release(major=1, minor=7, micro=0, version='1.7')
+        d.release = r
+        # Document with a release without an EOL date is supported.
+        self.assertTrue(d.is_supported)
+        self.assertFalse(d.is_dev)
+
+        # Document with an EOL date in the past is unsupported.
+        r.eol_date = datetime.date(2000, 1, 1)
+        self.assertFalse(d.is_supported)
 
 
 class SearchFormTestCase(TestCase):

--- a/docs/views.py
+++ b/docs/views.py
@@ -18,13 +18,7 @@ from .models import Document, DocumentRelease
 from .search import DocumentDocType, SearchPaginator
 from .utils import get_doc_path_or_404, get_doc_root_or_404
 
-UNSUPPORTED_THRESHOLD = '1.7'
 SIMPLE_SEARCH_OPERATORS = ['+', '|', '-', '"', '*', '(', ')', '~']
-
-
-def version_is_unsupported(version):
-    # TODO: would be nice not to hardcode this.
-    return version < UNSUPPORTED_THRESHOLD
 
 
 def index(request):
@@ -46,6 +40,7 @@ def document(request, lang, version, url):
     # exception will be emitted by unipath, proactively check for bad data (mostly
     # from the Googlebot) so we can give a nice 404 error.
     try:
+        lang.encode("ascii")
         version.encode("ascii")
         url.encode("ascii")
     except UnicodeEncodeError:
@@ -56,6 +51,10 @@ def document(request, lang, version, url):
 
     docroot = get_doc_root_or_404(lang, version)
     doc_path = get_doc_path_or_404(docroot, url)
+    try:
+        release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
+    except DocumentRelease.DoesNotExist:
+        raise Http404
 
     if version == 'dev':
         rtd_version = 'latest'
@@ -74,8 +73,7 @@ def document(request, lang, version, url):
         'env': json.load((docroot.joinpath('globalcontext.json')).open('r')),
         'lang': lang,
         'version': version,
-        'version_is_dev': version == 'dev',
-        'version_is_unsupported': version_is_unsupported(version),
+        'release': release,
         'rtd_version': rtd_version,
         'docurl': url,
         'update_date': datetime.datetime.fromtimestamp((docroot.joinpath('last_build')).stat().st_mtime),
@@ -133,7 +131,10 @@ def search_results(request, lang, version, per_page=10, orphans=3):
     Search view to handle language and version specific queries.
     The old search view is being redirected here.
     """
-    release = get_object_or_404(DocumentRelease, version=version, lang=lang)
+    try:
+        release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
+    except DocumentRelease.DoesNotExist:
+        raise Http404
     form = DocSearchForm(request.GET or None, release=release)
 
     context = {
@@ -142,8 +143,6 @@ def search_results(request, lang, version, per_page=10, orphans=3):
         'version': release.version,
         'release': release,
         'searchparams': request.GET.urlencode(),
-        'version_is_dev': version == 'dev',
-        'version_is_unsupported': version_is_unsupported(version),
     }
 
     if form.is_valid():

--- a/releases/fixtures/doc_releases.json
+++ b/releases/fixtures/doc_releases.json
@@ -1,0 +1,67 @@
+[
+{
+  "model": "releases.release",
+  "pk": "1.4",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2012-03-23",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 4,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.5",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-02-26",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 5,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.6",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2013-11-06",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 6,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.7",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2014-09-02",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 7,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.8",
+  "fields": {
+    "major": 1,
+    "is_lts": true,
+    "date": "2015-04-01",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 8,
+    "status": "f"
+  }
+}
+]

--- a/releases/migrations/0003_populate_release_eol_date.py
+++ b/releases/migrations/0003_populate_release_eol_date.py
@@ -8,13 +8,32 @@ from django.db import migrations, models
 
 def set_eol_date(apps, schema_editor):
     Release = apps.get_model('releases', 'Release')
-    # List of EOL dates for releases for which docs are published.
+    # Set the EOL date of all releases to the date of the following release
+    # except for the final one in the 0 series and in each 1.x series.
+    releases = list(Release.objects.all().order_by('major', 'minor', 'micro',
+                                                   'status', 'iteration'))
+    for previous, current in zip(releases[:-1], releases[1:]):
+        if current.major != previous.major:
+            continue
+        if current.major == 1 and previous.minor != current.minor:
+            continue
+        previous.eol_date = current.date
+        previous.save()
+    # Set the EOL date of final releases the 0 series and in each 1.x series.
     for version, eol_date in [
-        ('1.4', datetime.date(2015, 10, 1)),
-        ('1.5', datetime.date(2014, 9, 2)),
-        ('1.6', datetime.date(2015, 4, 1)),
+        ('0.96.5', datetime.date(2008, 9, 3)),      # 1.0 release
+        ('1.0.4', datetime.date(2010, 5, 17)),      # 1.2 release
+        ('1.1.4', datetime.date(2011, 3, 23)),      # 1.3 release
+        ('1.2.7', datetime.date(2012, 3, 23)),      # 1.4 release
+        ('1.3.7', datetime.date(2013, 2, 26)),      # 1.5 release
+        ('1.4.22', datetime.date(2015, 10, 1)),     # end of LTS support
+        ('1.5.12', datetime.date(2014, 9, 2)),      # 1.7 release
+        ('1.6.11', datetime.date(2015, 4, 1)),      # 1.8 release
+        # 1.7.10 and 1.8.5 are still supported at the time of writing.
     ]:
+        # This patterns ignores missing releases e.g. during tests.
         Release.objects.filter(version=version).update(eol_date=eol_date)
+
 
 def unset_eol_date(apps, schema_editor):
     Release = apps.get_model('releases', 'Release')

--- a/releases/migrations/0004_make_release_date_nullable.py
+++ b/releases/migrations/0004_make_release_date_nullable.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import datetime
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('releases', '0003_populate_release_eol_date'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='release',
+            name='date',
+            field=models.DateField(null=True, blank=True, help_text="Leave blank if the release date isn't know yet, typically if you're creating the final release just after the alpha because you want to build docs for the upcoming version.", default=datetime.date.today, verbose_name='Release date'),
+        ),
+        migrations.AlterField(
+            model_name='release',
+            name='eol_date',
+            field=models.DateField(null=True, blank=True, help_text="Leave blank if the end of life date isn't known yet, typically because it depends on the release date of a later version.", verbose_name='End of life date'),
+        ),
+        migrations.AlterField(
+            model_name='release',
+            name='status',
+            field=models.CharField(max_length=1, editable=False, choices=[('a', 'alpha'), ('b', 'beta'), ('c', 'release candidate'), ('f', 'final')]),
+        ),
+    ]

--- a/releases/models.py
+++ b/releases/models.py
@@ -74,6 +74,12 @@ class Release(models.Model):
         self.status = self.STATUS_REVERSE[status]
         cache.delete(self.DEFAULT_CACHE_KEY)
         super(Release, self).save(*args, **kwargs)
+        # Each micro release EOLs the previous one in the same series.
+        if self.status == 'f' and self.micro > 0:
+            (type(self).objects
+                       .filter(major=self.major, minor=self.minor,
+                               micro=self.micro - 1, status='f')
+                       .update(eol_date=self.date))
 
     def __str__(self):
         return self.version

--- a/releases/templatetags/release_notes.py
+++ b/releases/templatetags/release_notes.py
@@ -36,6 +36,6 @@ def get_latest_micro_release(version):
     Given an X.Y version number, return the latest X.Y.Z version.
     """
     major, minor = version.split('.')
-    release = Release.objects.final().filter(major=major, minor=minor).order_by('-micro').first()
+    release = Release.objects.filter(major=major, minor=minor, status='f').order_by('-micro').first()
     if release:
         return release.version

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib.redirects.models import Redirect
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -30,8 +32,10 @@ class TestDownloadsView(TestCase):
     url = reverse('download')
 
     def test_lts_overlap(self):
-        Release.objects.create(major=1, minor=8, micro=0, is_lts=True, version='1.4')
-        Release.objects.create(major=1, minor=6, micro=0, version='1.6')
+        Release.objects.create(major=1, minor=4, micro=0, is_lts=True, version='1.4',
+                               eol_date=datetime.date.today() - datetime.timedelta(2))
+        Release.objects.create(major=1, minor=6, micro=0, version='1.6',
+                               eol_date=datetime.date.today() - datetime.timedelta(1))
         Release.objects.create(major=1, minor=7, micro=0, version='1.7')
         Release.objects.create(major=1, minor=8, micro=0, is_lts=True, version='1.8')
 
@@ -67,3 +71,79 @@ class TestTemplateTags(TestCase):
             '<a href="http://docs.djangoproject.dev:8000/en/1.8/releases/1.8/">'
             '1.8 release notes</a>'
         )
+
+
+class TestReleaseManager(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        today = datetime.date.today()
+        day = datetime.timedelta(1)
+        Release.objects.create(
+            version='1.4', is_lts=True,
+            date=today - 450 * day, eol_date=today + 50 * day)
+        Release.objects.create(
+            version='1.5',
+            date=today - 350 * day, eol_date=today - 150 * day)
+        Release.objects.create(
+            version='1.6',
+            date=today - 250 * day, eol_date=today - 50 * day)
+        Release.objects.create(
+            version='1.7',
+            date=today - 150 * day, eol_date=today + 50 * day)
+        Release.objects.create(
+            version='1.8a1',
+            date=today - 80 * day, eol_date=today - 65 * day)
+        Release.objects.create(
+            version='1.8b1', is_lts=True,
+            date=today - 65 * day, eol_date=today - 50 * day)
+        Release.objects.create(
+            version='1.8', is_lts=True,
+            date=today - 50 * day, eol_date=today)
+        Release.objects.create(
+            version='1.8.1', is_lts=True,
+            date=today, eol_date=None)
+        Release.objects.create(
+            version='1.9',
+            date=None, eol_date=None)
+
+    def test_active(self):
+        active_versions = Release.objects.active().values_list('version', flat=True)
+        self.assertEqual(list(active_versions), ['1.8.1', '1.7', '1.4'])
+
+    def test_supported(self):
+        supported_versions = Release.objects.supported().values_list('version', flat=True)
+        self.assertEqual(list(supported_versions), ['1.8.1', '1.7', '1.4'])
+
+    def test_unsupported(self):
+        unsupported_versions = [r.version for r in Release.objects.unsupported()]
+        self.assertEqual(unsupported_versions, ['1.6', '1.5'])
+
+    def test_current(self):
+        self.assertEqual(Release.objects.current().version, '1.8.1')
+        Release.objects.filter(version='1.8.1').delete()
+        self.assertEqual(Release.objects.current().version, '1.7')
+
+    def test_previous(self):
+        self.assertEqual(Release.objects.previous().version, '1.7')
+
+    def test_lts(self):
+        lts_versions = Release.objects.lts().values_list('version', flat=True)
+        self.assertEqual(list(lts_versions), ['1.8.1', '1.4'])
+
+    def test_current_lts(self):
+        self.assertEqual(Release.objects.current_lts().version, '1.8.1')
+        Release.objects.filter(version='1.8.1').delete()
+        self.assertEqual(Release.objects.current_lts().version, '1.4')
+
+    def test_previous_lts(self):
+        self.assertEqual(Release.objects.previous_lts().version, '1.4')
+        Release.objects.filter(version='1.8.1').delete()
+        self.assertEqual(Release.objects.previous_lts(), None)
+
+    def test_preview(self):
+        self.assertEqual(Release.objects.preview(), None)
+        Release.objects.create(
+            version='1.9b2',
+            date=datetime.date.today(), eol_date=None)
+        self.assertEqual(Release.objects.preview().version, '1.9b2')

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -1,7 +1,6 @@
 import datetime
 
 from django.contrib.redirects.models import Redirect
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils.safestring import SafeString
 
@@ -26,26 +25,6 @@ class LegacyURLsTests(TestCase):
                 location = location[17:]
             self.assertEquals(location, new_path)
             self.assertEquals(response.status_code, 301)
-
-
-class TestDownloadsView(TestCase):
-    url = reverse('download')
-
-    def test_lts_overlap(self):
-        Release.objects.create(major=1, minor=4, micro=0, is_lts=True, version='1.4',
-                               eol_date=datetime.date.today() - datetime.timedelta(2))
-        Release.objects.create(major=1, minor=6, micro=0, version='1.6',
-                               eol_date=datetime.date.today() - datetime.timedelta(1))
-        Release.objects.create(major=1, minor=7, micro=0, version='1.7')
-        Release.objects.create(major=1, minor=8, micro=0, is_lts=True, version='1.8')
-
-        response = self.client.get(self.url)
-        self.assertEqual(response.context['current_version'], '1.8')
-        self.assertEqual(response.context['previous_version'], '1.7')
-        # Previous LTS (still supported)
-        self.assertEqual(response.context['lts_version'], None)
-        # No longer supported versions
-        self.assertEqual(response.context['earlier_versions'], ['1.6', '1.4'])
 
 
 class TestTemplateTags(TestCase):

--- a/releases/views.py
+++ b/releases/views.py
@@ -22,12 +22,11 @@ def index(request):
     unsupported = Release.objects.unsupported()
 
     context = {
-        'current_version': current.version,
-        'previous_version': previous.version,
-        'lts_version': lts.version if lts else None,
-        'earlier_versions': [release.version for release in unsupported],
-        'preview_version': preview.version if preview else None,
-        'preview_kind': preview.get_status_display() if preview else None,
+        'current': current,
+        'previous': previous,
+        'lts': lts,
+        'unsupported': unsupported,
+        'preview': preview,
     }
     return render(request, 'releases/download.html', context)
 


### PR DESCRIPTION
This pull request attempts to address issues in #531 that required reverting it partially.

First commit makes `Release.date` nullable in order to allow creating a 1.9 release in the future. I reviewed all uses of `Release.objects`. They're all going through manager methods which have been updated to account for null dates so we should be safe on this front. I added tests for each manager method.

Second commit restores the commits that were reverted. I haven't performed any additional testing of this commit yet. It's hard to try the change locally because running `update_docs` takes 30-60 minutes per version (cloning Django over my lousy DSL connection is slow). I would have to run it overnight.