### PR TITLE
Fix block names in base_weblog.html and faq.html templates

### DIFF
--- a/djangoproject/templates/base_weblog.html
+++ b/djangoproject/templates/base_weblog.html
@@ -7,7 +7,7 @@
   <h1><a href="{% url 'weblog:index' %}">News &amp; Events</a></h1>
 {% endblock %}
 
-{% block extrahead %}
+{% block head_extra %}
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url 'weblog-feed' %}" />
 {% endblock %}
 

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -101,10 +101,10 @@ questions after reading it, please feel free to
 
 {% endblock %}
 
-{% block extrahead %}
+{% block head_extra %}
   {{ block.super }}
   <style type="text/css">
     h3 a.plink { display: none; }
     h3:hover a.plink { display: inline; }
   </style>
-{% endblock extrahead %}
+{% endblock head_extra %}


### PR DESCRIPTION
Two template files contain a block name ("extrahead") which is not used by parent templates.
By changing it to "head_extra" used by base.html, RSS application from weblog page will be available and some CSS styling will be applied to the FAQ page titles.
