### PR TITLE
Fixes #535, Sitemap is broken

### DIFF
--- a/blog/sitemaps.py
+++ b/blog/sitemaps.py
@@ -10,4 +10,15 @@ class WeblogSitemap(Sitemap):
     def items(self):
         return Entry.objects.published()
 
+    def get_urls(self, page, site, protocol):
+        urls = []
+        for item in self.paginator.page(page).object_list:
+            loc = item.get_absolute_url()
+            url_info = {
+                'item': item,
+                'location': loc,
+            }
+            urls.append(url_info)
+        return urls
+
     # lastmod wasn't implemented, because weblog pages used to contain comments.

--- a/docs/sitemaps.py
+++ b/docs/sitemaps.py
@@ -25,3 +25,17 @@ class DocsSitemap(Sitemap):
             return 1
         else:
             return 0.1
+
+    def get_urls(self, page, site, protocol):
+        urls = []
+        for item in self.paginator.page(page).object_list:
+            loc = item.get_absolute_url()
+            priority = self.priority(item)
+            url_info = {
+                'item': item,
+                'location': loc,
+                'changefreq': self.changefreq(item),
+                'priority': str(priority if priority is not None else ''),
+            }
+            urls.append(url_info)
+        return urls

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -9,7 +9,8 @@ from django.test import TestCase
 
 from releases.models import Release
 
-from .models import DocumentRelease
+from .models import Document, DocumentRelease
+from .sitemaps import DocsSitemap
 from .utils import get_doc_path
 
 
@@ -143,3 +144,18 @@ class TestUtils(TestCase):
         # existing file
         path, filename = __file__.rsplit(os.path.sep, 1)
         self.assertEqual(get_doc_path(Path(path), filename), None)
+
+
+class SitemapTestCase(TestCase):
+
+    def test_sitemap(self):
+        doc_release = DocumentRelease.objects.create()
+        document = Document.objects.create(release=doc_release)
+        sitemap = DocsSitemap()
+        page = 1
+        site = Site.objects.get_current()
+        protocol = 'http'
+        urls = sitemap.get_urls(page, site, protocol)
+        self.assertEqual(len(urls), 1)
+        url_info = urls[0]
+        self.assertEqual(url_info['location'], document.get_absolute_url())


### PR DESCRIPTION
I've found that blog and docs models `get_absolute_url` returns the url including the protocol and domain. Then `contrib.sitemaps` builds the location attribute joining the protocol, domain and url thus resulting in a malformed url.

This PR solves the issue adding a custom `get_urls` to each sitemap.
