### PR TITLE
Docs build cleanup

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -31,10 +31,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, **kwargs):
-        try:
-            verbosity = int(kwargs['verbosity'])
-        except (KeyError, TypeError, ValueError):
-            verbosity = 1
+        verbosity = kwargs['verbosity']
 
         default_builders = ['json', 'html']
 

--- a/docs/management/commands/update_docs_and_index.py
+++ b/docs/management/commands/update_docs_and_index.py
@@ -1,0 +1,11 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Update the docs then reindex them in elasticsearch.
+    """
+    def handle(self, **options):
+        call_command('update_docs', **options)
+        call_command('update_index', delete=True, **options)

--- a/docs/management/commands/update_index.py
+++ b/docs/management/commands/update_index.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
                help='Whether to delete the index or not'),
     )
 
-    def log(self, msg, level='2'):
+    def log(self, msg, level=2):
         """
         Small log helper
         """

--- a/docs/search.py
+++ b/docs/search.py
@@ -76,7 +76,6 @@ class ImprovedDocType(DocType):
             client.indices.delete(index=cls._doc_type.index, ignore=[400, 404])
         cls._doc_type.init()
         for ok, item in streaming_bulk(client, actions_generator(),
-                                       raise_on_error=True,
                                        refresh=True,
                                        **kwargs):
             yield ok, item

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,8 @@ django-flat-theme==0.9.3
 django-hosts==1.2
 django-push==0.7
 django-registration-redux==1.2
-elasticsearch-dsl==0.0.4
+elasticsearch-dsl==0.0.9
+elasticsearch>=1.0.0,<2.0.0
 docutils==0.11
 feedparser==5.1.3
 Jinja2==2.7.3


### PR DESCRIPTION
Result of my Pycon CZ sprint with @HonzaKral.

This adds some tests and simplifies some of the logic in `update_docs`.

One practical result is that the elasticsearch indexing now needs to be done in a separate step by running the `update_index --delete` command.

This should fix #534.