### PR TITLE
Prevented extra Payment creation for recurring donations.

### DIFF
--- a/fundraising/migrations/0003_payment_stripe_charge_id_unique.py
+++ b/fundraising/migrations/0003_payment_stripe_charge_id_unique.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fundraising', '0002_donation_donor_not_null'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='payment',
+            name='stripe_charge_id',
+            field=models.CharField(max_length=100, unique=True),
+        ),
+    ]

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -130,7 +130,7 @@ class Donation(FundraisingModel):
 class Payment(models.Model):
     donation = models.ForeignKey(Donation)
     amount = models.DecimalField(max_digits=9, decimal_places=2, null=True)
-    stripe_charge_id = models.CharField(max_length=100, blank=True)
+    stripe_charge_id = models.CharField(max_length=100, unique=True)
     date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -255,13 +255,13 @@ class TestDjangoHero(TestCase):
         self.campaign = Campaign.objects.create(name='test', goal=200, slug='test', is_active=True, is_public=True)
         self.h1 = DjangoHero.objects.create(**kwargs)
         d1 = Donation.objects.create(donor=self.h1, campaign=self.campaign)
-        Payment.objects.create(donation=d1, amount='5')
+        Payment.objects.create(donation=d1, amount='5', stripe_charge_id='a1')
         self.h2 = DjangoHero.objects.create(**kwargs)
         d2 = Donation.objects.create(donor=self.h2, campaign=self.campaign)
-        Payment.objects.create(donation=d2, amount='15')
+        Payment.objects.create(donation=d2, amount='15', stripe_charge_id='a2')
         self.h3 = DjangoHero.objects.create(**kwargs)
         d3 = Donation.objects.create(donor=self.h3, campaign=self.campaign)
-        Payment.objects.create(donation=d3, amount='10')
+        Payment.objects.create(donation=d3, amount='10', stripe_charge_id='a3')
         self.today = date.today()
 
     def test_thumbnail(self):

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -132,9 +132,8 @@ class TestCampaign(TestCase):
         donations = Donation.objects.all()
         self.assertEqual(donations.count(), 1)
         self.assertEqual(donations[0].subscription_amount, 100)
-        self.assertEqual(donations[0].total_payments(), 100)
         self.assertEqual(donations[0].receipt_email, 'test@example.com')
-        self.assertEqual(donations[0].payment_set.first().stripe_charge_id, '')
+        self.assertEqual(donations[0].payment_set.count(), 0)
 
     @patch('stripe.Customer.create')
     @patch('stripe.Charge.create')
@@ -152,6 +151,7 @@ class TestCampaign(TestCase):
         self.assertEqual(donations.count(), 1)
         self.assertEqual(donations[0].total_payments(), 100)
         self.assertEqual(donations[0].campaign, self.campaign)
+        self.assertEqual(donations[0].payment_set.first().stripe_charge_id, 'XYZ')
 
     @patch('stripe.Customer.create')
     @patch('stripe.Charge.create')


### PR DESCRIPTION
Payments for recurring donations are created through Stripe webhooks,
so there's no need to create one in PaymentForm.