### PR TITLE
Included Donation.subscription_amount for one-time donations.

### DIFF
--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -245,16 +245,14 @@ class PaymentForm(forms.Form):
 
         else:
             # Finally create the donation and return it
-            donation_params = {
-                'interval': interval,
-                'stripe_customer_id': customer.id,
-                'stripe_subscription_id': subscription_id,
-                'receipt_email': receipt_email,
-                'donor': hero,
-            }
-            if interval != 'onetime':
-                donation_params['subscription_amount'] = amount
-            donation = Donation.objects.create(**donation_params)
+            donation = Donation.objects.create(
+                interval=interval,
+                subscription_amount=amount,
+                stripe_customer_id=customer.id,
+                stripe_subscription_id=subscription_id,
+                receipt_email=receipt_email,
+                donor=hero,
+            )
             # Only one-time donations are created here. Recurring payments are
             # created by Stripe webhooks.
             if charge_id:

--- a/fundraising/tests.py
+++ b/fundraising/tests.py
@@ -104,7 +104,7 @@ class TestCampaign(TestCase):
         })
         donations = Donation.objects.all()
         self.assertEqual(donations.count(), 1)
-        self.assertEqual(donations[0].subscription_amount, None)
+        self.assertEqual(donations[0].subscription_amount, 100)
         self.assertEqual(donations[0].total_payments(), 100)
         self.assertEqual(donations[0].receipt_email, 'test@example.com')
         self.assertEqual(donations[0].stripe_subscription_id, '')


### PR DESCRIPTION
All one-time donations created before we release one-time donations
have this field populated and it's helpful not to have to reference
the payment object when viewing donations in the admin.