### PR TITLE
Added alternate instructions on how to sign up to our mailing lists

### DIFF
--- a/djangoproject/templates/includes/mailing_lists.html
+++ b/djangoproject/templates/includes/mailing_lists.html
@@ -9,6 +9,12 @@
         <span class="visuallyhidden">Subscribe</span>
       </button>
     </form>
+    <p class="meta">
+      You can also subscribe by sending an email to
+      <a href="mailto:django-users+subscribe@googlegroups.com">
+      django-users+subscribe@googlegroups.com</a> and following the
+      instructions that will be sent to you.
+    </p>
   </div>
   <div class="col form-email last-child">
     <h3><a href="http://groups.google.com/group/django-developers">Contributing to Django</a></h3>
@@ -20,5 +26,18 @@
         <span class="visuallyhidden">Subscribe</span>
       </button>
     </form>
+    <p class="meta">
+      You can also subscribe by sending an email to
+      <a href="mailto:django-developers+subscribe@googlegroups.com">
+      django-developers+subscribe@googlegroups.com</a> and following the
+      instructions that will be sent to you.
+    </p>
   </div>
+
 </div>
+<p>
+    We have a few other specialized lists (mentorship, i18n, ...). You can
+    find more information about them in our
+    <a href="{% url 'document-detail' url='internals/mailing-lists' lang='en' version='dev' host 'docs' %}">
+    mailing list documentation</a>.
+  </p>


### PR DESCRIPTION
This should make it possible for people who can't access
groups.google.com (blocked in China) to sign up anyway.