### PR TITLE
Improve heart filling

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2929,6 +2929,11 @@ hr {
 			fill: rgba(50, 50, 50, 0.3);
 			stroke: #aaaaaa;
 			stroke-width: 2px;
+			-moz-user-select: none;
+			-ms-user-select: none;
+			-webkit-user-select: none;
+			user-select: none;
+			cursor: default;
 		}
 		@include respond-min(768px) {
 			width: 55%;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2922,10 +2922,6 @@ hr {
 			&.faded {
 				opacity: 0.05;
 				animation: pixel-pulse 2s infinite;
-				&:hover {
-					opacity: 0.7;
-					animation: none;
-				}
 			}
 		}
 		text {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2902,8 +2902,8 @@ hr {
 
 /// Fundraising page
 @keyframes pixel-pulse {
-	0%, 100% { opacity: 0.05; }
-	50% { opacity: 0.10; }
+	0%, 100% { opacity: 0.10; }
+	50% { opacity: 0.25; }
 }
 .fundraising-index {
 	margin-top: 50px;
@@ -2918,10 +2918,9 @@ hr {
 		rect {
 			-webkit-transition: opacity 250ms ease-out;
 			transition: opacity 250ms ease-out;
-
 			&.faded {
 				opacity: 0.05;
-				animation: pixel-pulse 2s infinite;
+				animation: pixel-pulse 3s infinite;
 			}
 		}
 		text {

--- a/djangoproject/static/js/mod/fundraising-heart.js
+++ b/djangoproject/static/js/mod/fundraising-heart.js
@@ -48,10 +48,6 @@ define([
 			{x:3, y: 5, color: razzmatazz},
 		];
 
-	function getRandomElement(array) {
-		return array[Math.floor(Math.random() * array.length)];
-	}
-
 	var Heart = function(heart) {
 		this.heart = $(heart);
 		if (Modernizr.svg) {
@@ -69,10 +65,12 @@ define([
 			var heart = this;
 		},
 		fadePixels: function () {
+			var pixels;
 			var percent = this.heart.data('percent');
 			var fadedCount = Math.ceil(this.pixels.length * (100 - percent) / 100);
 			for (var i = 0; i < fadedCount; i++) {
-				getRandomElement(this.visiblePixels()).hide();
+				pixels = this.visiblePixels();
+				pixels[0].hide();
 			}
 		},
 		hiddenPixels: function () {

--- a/djangoproject/static/js/mod/fundraising-heart.js
+++ b/djangoproject/static/js/mod/fundraising-heart.js
@@ -101,7 +101,7 @@ define([
 			this.setAttr('width', this.size);
 			this.setAttr('height', this.size);
 			this.setAttr('fill', opts.color);
-			this.element.style.animationDelay = 2 * Math.random() + "s";
+			this.element.style.animationDelay = 3 * Math.random() + "s";
 		},
 		setAttr: function(name, value) {
 			this.element.setAttributeNS(null, name, value);

--- a/djangoproject/static/js/mod/fundraising-heart.js
+++ b/djangoproject/static/js/mod/fundraising-heart.js
@@ -67,9 +67,6 @@ define([
 			this.fadePixels();
 			this.draw();
 			var heart = this;
-			window.setInterval(function () {
-				heart.moveFadedPixel();
-			}, 5000);
 		},
 		fadePixels: function () {
 			var percent = this.heart.data('percent');
@@ -83,14 +80,6 @@ define([
 		},
 		visiblePixels: function () {
 			return this.pixels.filter(function (p) { return !p.isHidden; });
-		},
-		moveFadedPixel: function () {
-			var hiddenPixels = this.hiddenPixels();
-			var visiblePixels = this.visiblePixels();
-			if (hiddenPixels.length && visiblePixels.length) {
-				var oldPixel = getRandomElement(hiddenPixels).show();
-				var newPixel = getRandomElement(visiblePixels).hide();
-			}
 		},
 		draw: function() {
 			this.pixels.forEach(function (p) {

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -10,7 +10,7 @@
           <g transform="translate(4, 2)" id="pixels">
             <path d="M 71 0 L 213 0 L 213 71 L 284 71 L 284 0 L 426 0 L 426 71 L 497 71 L 497 213 L 426 213 L 426 284 L 355 284 L 355 355 L 284 355 L 284 426 L 213 426 L 213 355 L 142 355 L 142 284 L 71 284 L 71 213 L 0 213 L 0 71 L 71 71 L 71 0" fill="#f8f8f8" stroke="#c0c0c0" stroke-width="1" />
           </g>
-          <text x="50%" y="43%" alignment-baseline="middle" text-anchor="middle">{{ goal_percent }}%</text>
+          <text x="50%" y="43%" alignment-baseline="middle" text-anchor="middle">{{ goal_percent|floatformat:'0' }}%</text>
         </g>
         <foreignObject>
           <img src="{% static 'img/fundraising-heart.png' %}" />


### PR DESCRIPTION
I got some feedback from fresh eyes (friends who hadn't seen this page before). Feel free to cherry pick specific commits if you don't want any of them (they should be fairly atomic).

Changes:

- Fill heart from the bottom up instead of randomly
- Remove (somewhat confusing) hover effect on heart pixels that also doesn't work over text sections
- Make overlaid heart percentage not act like text
- Don't randomly move heart pixels (just leave them static)
- Make pixel pulsing more colorful/contrasted and empty pixels slightly more colored/opaque