### PR TITLE
Prevented a missing search index while rebuilding the docs.

### DIFF
--- a/docs/management/commands/update_docs_and_index.py
+++ b/docs/management/commands/update_docs_and_index.py
@@ -8,4 +8,4 @@ class Command(BaseCommand):
     """
     def handle(self, **options):
         call_command('update_docs', **options)
-        call_command('update_index', delete=True, **options)
+        call_command('update_index', **options)


### PR DESCRIPTION
for https://github.com/django/djangoproject.com/issues/626

deployment commands:
```python
from docs.search import DocumentDocType
connection = DocumentDocType().connection
connection.indices.delete('docs')
```