### PR TITLE
Fixed a 404 on the Diversity page

### DIFF
--- a/djangoproject/templates/diversity/changes.html
+++ b/djangoproject/templates/diversity/changes.html
@@ -23,7 +23,7 @@ Approved changes will be merged, published, and noted below.</p>
 (typo fixes, re-wordings, etc.) can be made immediately.</p>
 
 <p>A complete list of changes can always be found
-<a href="https://github.com/django/djangoproject.com/commits/master/templates/diversity">on GitHub</a>;
+<a href="https://github.com/django/djangoproject.com/commits/master/djangoproject/templates/diversity">on GitHub</a>;
 major changes and releases are summarized below.</p>
 
 <h2>Changelog</h2>


### PR DESCRIPTION
The GitHub link was not pointing to the right path.

Note : if accepted, this commit will be listed in the page pointed by the url it corrects ! :smile: 