### PR TITLE
Fix issue #621 by replacing lang code in html tag

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -1,5 +1,5 @@
 {% load staticfiles %}<!DOCTYPE html>
-<html lang="en">
+<html lang="{% block html_language_code %}en{% endblock %}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/djangoproject/templates/base_docs.html
+++ b/djangoproject/templates/base_docs.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block html_language_code %}{{ LANGUAGE_CODE|default:"en" }}{% endblock %}
+
 {% block title %}Django Documentation{% endblock %}
 
 {% block header %}


### PR DESCRIPTION
Changed language code for docs page, so google and other browsers can
know in what language certain page is written and index it properly.

Fix changes code only on docs page, so other pages indexing won't be
affected even if there are some leftovers of language settings.

Also, there is default language code set for 'en', just in case.