### PR TITLE
Docs: set the lang attribute on the <html> tag correctly

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -1,5 +1,5 @@
 {% load staticfiles %}<!DOCTYPE html>
-<html lang="en">
+<html lang="{% block html_language_code %}en{% endblock %}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/djangoproject/templates/base_docs.html
+++ b/djangoproject/templates/base_docs.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block html_language_code %}{{ lang|default:"en" }}{% endblock %}
+
 {% block title %}Django Documentation{% endblock %}
 
 {% block header %}


### PR DESCRIPTION
Right now, the `lang` attribute of the `<html>` tag is always set to `en`. This PR changes that behaviour for the docs section, so that `lang` is set to the language code of the docs that are currently viewed.