### PR TITLE
Fixed #647 -- Fixed djangoproject.com registration email by disabling HTML template.

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -228,6 +228,8 @@ ROOT_HOSTCONF = 'djangoproject.hosts'
 
 ACCOUNT_ACTIVATION_DAYS = 3
 
+REGISTRATION_EMAIL_HTML = False
+
 # aggregator / PubSubHubbub settings
 
 FEED_APPROVERS_GROUP_NAME = "feed-approver"

--- a/djangoproject/templates/registration/activation_email.txt
+++ b/djangoproject/templates/registration/activation_email.txt
@@ -1,6 +1,6 @@
 {% load humanize %}
 Someone, hopefully you, signed up for a new account at djangoproject.com using this email address. If it was you, and you'd like to activate and use your account, click the link below or copy and paste it into your web browser's address bar:
 
-http://www.djangoproject.com/accounts/activate/{{ activation_key }}/
+https://www.djangoproject.com/accounts/activate/{{ activation_key }}/
 
 If you didn't request this, you don't need to do anything; you won't receive any more email from us, and the account will expire automatically in {{ expiration_days|apnumber }} days.

--- a/djangoproject/test_registration.py
+++ b/djangoproject/test_registration.py
@@ -20,7 +20,7 @@ class TestRegistration(TestCase):
             "djangoproject.com using this email address. If it was you, and "
             "you'd like to activate and use your account, click the link below "
             "or copy and paste it into your web browser's address bar:\n\n"
-            "http://www.djangoproject.com/accounts/activate/activation-key/\n\n"
+            "https://www.djangoproject.com/accounts/activate/activation-key/\n\n"
             "If you didn't request this, you don't need to do anything; you "
             "won't receive any more email from us, and the account will expire "
             "automatically in three days.\n"

--- a/djangoproject/test_registration.py
+++ b/djangoproject/test_registration.py
@@ -1,0 +1,27 @@
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.core import mail
+from django.test import TestCase
+from registration.models import RegistrationProfile
+
+
+class TestRegistration(TestCase):
+    def test_activation_email(self):
+        site = Site.objects.get()
+        user = User()
+        profile = RegistrationProfile(user=user, activation_key='activation-key')
+        profile.send_activation_email(site)
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox.pop()
+        self.assertEqual(message.subject, 'Activate your djangoproject.com account')
+        self.assertEqual(
+            message.body,
+            "\nSomeone, hopefully you, signed up for a new account at "
+            "djangoproject.com using this email address. If it was you, and "
+            "you'd like to activate and use your account, click the link below "
+            "or copy and paste it into your web browser's address bar:\n\n"
+            "http://www.djangoproject.com/accounts/activate/activation-key/\n\n"
+            "If you didn't request this, you don't need to do anything; you "
+            "won't receive any more email from us, and the account will expire "
+            "automatically in three days.\n"
+        )


### PR DESCRIPTION
for https://github.com/django/djangoproject.com/issues/647