### PR TITLE
Fixed #203 -- Added a back to top button in documentation

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2197,7 +2197,7 @@ h2 + .list-link-soup {
     }
 }
 
-#doc-versions, #doc-languages {
+#doc-versions, #doc-languages, #backtotop-switchers {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
 
@@ -2229,6 +2229,15 @@ h2 + .list-link-soup {
             &:hover {
                 color: $green;
                 border: 1px solid $green-light;
+            }
+            &.backtotop-switchers {
+                padding: 0;
+                border: 0;
+                border-radius: 0;
+                &::before {
+                    @include fa-icon();
+                    content: $fa-var-chevron-up;
+                }
             }
         }
     }

--- a/djangoproject/templates/docs/doc.html
+++ b/djangoproject/templates/docs/doc.html
@@ -54,6 +54,13 @@
 
 {% block content %}
 <div id="version-switcher">
+
+  <ul id="backtotop-switchers">
+    <li class="current">
+      <a class="backtotop-switchers" href="#top" title="Back to top"></a>
+    </li>
+  </ul>
+
   <ul id="doc-languages" class="language-switcher">
   {% for available_lang in available_languages %}
   {% if lang != available_lang %}


### PR DESCRIPTION
I've added a button above the language and version switchers. See screenshot:

![backtotop](https://cloud.githubusercontent.com/assets/481052/17071199/11bb2962-502e-11e6-9ee9-972d1b1482b2.png)
