### PR TITLE
Fixed exception styling in docs

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2362,7 +2362,7 @@ h2 + .list-link-soup {
 
 }
 
-dl.function, dl.class, dl.method, dl.attribute {
+dl.function, dl.class, dl.method, dl.attribute, dl.exception {
     dt {
         font-weight: 700;
     }


### PR DESCRIPTION
Closes #699 

Works locally as @bmispelon suggested:

![screen shot 2016-08-29 at 10 06 43 pm](https://cloud.githubusercontent.com/assets/101698/18074789/ed66b49e-6e34-11e6-9f80-5bd2583522a9.png)
