### PR TITLE
Added missing 1.9 and 1.10 Releases to fixture

### DIFF
--- a/releases/fixtures/doc_releases.json
+++ b/releases/fixtures/doc_releases.json
@@ -63,5 +63,31 @@
     "minor": 8,
     "status": "f"
   }
+},
+{
+  "model": "releases.release",
+  "pk": "1.9",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2015-12-01",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 9,
+    "status": "f"
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "1.10",
+  "fields": {
+    "major": 1,
+    "is_lts": false,
+    "date": "2016-08-01",
+    "iteration": 0,
+    "micro": 0,
+    "minor": 10,
+    "status": "f"
+  }
 }
 ]


### PR DESCRIPTION
Closes #702 

The `./manage.py loaddata doc_releases` step of the README will work with this patch applied.

I hope the team doesn't mind PRs to this repo! 😎 