### PR TITLE
Fixed #704 -- updated heroes css for fundraising

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3058,7 +3058,7 @@ form .footnote {
             text-align: center;
         }
         .hero {
-            width: 25%;
+            width: calc(100% / 3);
             position: relative;
             height: auto;
             div {


### PR DESCRIPTION
I've decided to add more space for heroes, so each now owns third part of the page. 😉

![image](https://cloud.githubusercontent.com/assets/627183/19020611/309ce268-88ae-11e6-8265-ba239a560ba8.png)
