### PR TITLE
Passed DJANGO_SETTINGS_MODULE to tox test environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = true
 
 [testenv]
 whitelist_externals = make
+passenv = DJANGO_SETTINGS_MODULE
 deps =
     tests: -r{toxinidir}/requirements/tests.txt
     flake8: flake8


### PR DESCRIPTION
I use a custom settings file for local development. This PR exposes the `DJANGO_SETTINGS_MODULE` environment variable to the tox test environment so it can be customized as needed.