### PR TITLE
Blocked docs search results in robots.txt.

### DIFF
--- a/djangoproject/static/robots.docs.txt
+++ b/djangoproject/static/robots.docs.txt
@@ -56,3 +56,4 @@ Disallow: /pt-br/1.9/releases
 Disallow: /pt-br/1.9/topics
 Disallow: /fr/1.8/internals
 Disallow: /fr/1.8/releases
+Disallow: /*search/?*


### PR DESCRIPTION
Blocks:
https://docs.djangoproject.com/en/1.10/search/?q=model
Allows:
https://docs.djangoproject.com/en/dev/ref/contrib/postgres/search/