### PR TITLE
Updated to Django==1.11

### DIFF
--- a/docs/tests.py
+++ b/docs/tests.py
@@ -146,6 +146,7 @@ class RedirectsTests(TestCase):
             response,
             'https://www.djangoproject.com/foundation/teams/',
             status_code=HTTPStatus.MOVED_PERMANENTLY,
+            fetch_redirect_response=False,
         )
 
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 bleach==2.0.0
 certifi==2017.4.17
-Django==1.10.7
+Django==1.11.1
 django-contact-form==1.4.1
 django-hosts==2.0
 django-markdownx==2.0.21


### PR DESCRIPTION
Blocked on a 1.11 compatible release of django-contact-form https://github.com/ubernostrum/django-contact-form/issues/29