### PR TITLE
Fixed Sphinx command error

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,4 +20,4 @@ pykismet3==0.1.1
 requests==2.18.1
 sorl-thumbnail==12.3
 stripe==1.62.0
-Sphinx==1.6.3
+Sphinx==1.5.6


### PR DESCRIPTION
### Solution:
Downgrade to Sphinx 1.5.6 due to bug con sphinx-build command.

### Steps to reproduce:

- Create a fresh repo and follow de README installation instructions
- While running the command update_docs the following error popups:

### Traceback: 
```
(django-fts) ../djangoproject.com (master)$ ./manage.py update_docs
Updating en/dev...
HEAD is now at 504ce3914f Fixed #28394 -- Allowed setting BaseExpression.output_field (renamed from _output_field).
Removing django/__pycache__/
Removing django/apps/__pycache__/
Removing django/conf/__pycache__/
Removing django/conf/locale/__pycache__/
Removing django/conf/urls/__pycache__/
Removing django/contrib/__pycache__/
Removing django/contrib/admin/__pycache__/
Removing django/contrib/admin/templatetags/__pycache__/
Removing django/contrib/admin/views/__pycache__/
Removing django/contrib/auth/__pycache__/
Removing django/contrib/contenttypes/__pycache__/
Removing django/contrib/flatpages/__pycache__/
Removing django/contrib/gis/__pycache__/
Removing django/contrib/gis/admin/__pycache__/
Removing django/contrib/gis/db/__pycache__/
Removing django/contrib/gis/db/models/__pycache__/
Removing django/contrib/gis/forms/__pycache__/
Removing django/contrib/gis/gdal/__pycache__/
Removing django/contrib/gis/gdal/prototypes/__pycache__/
Removing django/contrib/gis/geoip2/__pycache__/
Removing django/contrib/gis/geos/__pycache__/
Removing django/contrib/gis/geos/prototypes/__pycache__/
Removing django/contrib/gis/utils/__pycache__/
Removing django/contrib/messages/__pycache__/
Removing django/contrib/messages/storage/__pycache__/
Removing django/contrib/postgres/__pycache__/
Removing django/contrib/postgres/aggregates/__pycache__/
Removing django/contrib/postgres/fields/__pycache__/
Removing django/contrib/postgres/forms/__pycache__/
Removing django/contrib/redirects/__pycache__/
Removing django/contrib/sessions/__pycache__/
Removing django/contrib/sessions/backends/__pycache__/
Removing django/contrib/sitemaps/__pycache__/
Removing django/contrib/sites/__pycache__/
Removing django/contrib/staticfiles/__pycache__/
Removing django/contrib/syndication/__pycache__/
Removing django/core/__pycache__/
Removing django/core/cache/__pycache__/
Removing django/core/cache/backends/__pycache__/
Removing django/core/checks/__pycache__/
Removing django/core/checks/security/__pycache__/
Removing django/core/files/__pycache__/
Removing django/core/handlers/__pycache__/
Removing django/core/mail/__pycache__/
Removing django/core/management/__pycache__/
Removing django/core/serializers/__pycache__/
Removing django/core/servers/__pycache__/
Removing django/db/__pycache__/
Removing django/db/backends/__pycache__/
Removing django/db/backends/base/__pycache__/
Removing django/db/migrations/__pycache__/
Removing django/db/migrations/operations/__pycache__/
Removing django/db/models/__pycache__/
Removing django/db/models/fields/__pycache__/
Removing django/db/models/functions/__pycache__/
Removing django/db/models/sql/__pycache__/
Removing django/dispatch/__pycache__/
Removing django/forms/__pycache__/
Removing django/http/__pycache__/
Removing django/middleware/__pycache__/
Removing django/template/__pycache__/
Removing django/template/backends/__pycache__/
Removing django/template/loaders/__pycache__/
Removing django/templatetags/__pycache__/
Removing django/test/__pycache__/
Removing django/urls/__pycache__/
Removing django/utils/__pycache__/
Removing django/utils/translation/__pycache__/
Removing django/views/__pycache__/
Removing django/views/decorators/__pycache__/
Removing django/views/generic/__pycache__/
Removing docs/_ext/__pycache__/
Updating es/1.9...
HEAD is now at 2c3c029ede [1.9.x] Added CVE-2017-7233,4 to the security release archive.
Updating fr/1.9...
HEAD is now at 2c3c029ede [1.9.x] Added CVE-2017-7233,4 to the security release archive.
Updating ja/1.9...
HEAD is now at 2c3c029ede [1.9.x] Added CVE-2017-7233,4 to the security release archive.
Updating id/1.9...
HEAD is now at 2c3c029ede [1.9.x] Added CVE-2017-7233,4 to the security release archive.
Updating pt-br/1.9...
HEAD is now at 2c3c029ede [1.9.x] Added CVE-2017-7233,4 to the security release archive.
Updating en/1.9...
HEAD is now at 2c3c029ede [1.9.x] Added CVE-2017-7233,4 to the security release archive.
../.pyenv/versions/3.5.3/envs/django-fts/lib/python3.5/site-packages/sphinx/util/compat.py:40: RemovedInSphinx17Warning: sphinx.util.compat.Directive is deprecated and will be removed in Sphinx 1.7, please use docutils' instead.
  RemovedInSphinx17Warning)

Extension error:
Could not import extension djangodocs (exception: cannot import name 'SmartyPantsHTMLTranslator')
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "../.pyenv/versions/django-fts/lib/python3.5/site-packages/django/core/management/__init__.py", line 363, in execute_from_command_line
    utility.execute()
  File "../.pyenv/versions/django-fts/lib/python3.5/site-packages/django/core/management/__init__.py", line 355, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "../.pyenv/versions/django-fts/lib/python3.5/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "../.pyenv/versions/django-fts/lib/python3.5/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "../Documents/sprints/europython-2017/djangoproject.com/docs/management/commands/update_docs.py", line 120, in handle
    str(build_dir),         # Destination directory
  File "../.pyenv/versions/3.5.3/lib/python3.5/subprocess.py", line 271, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['sphinx-build', '-b', 'json', '-D', 'language=en', '-q', '../.djangoproject/djangodocs/sources/1.9/docs', '../.djangoproject/djangodocs/en/1.9/_build/json']' returned non-zero exit status 1
```

This seems related with a change or [deprecation](https://github.com/sphinx-doc/sphinx/blob/007593fa810918f243223080598d7ef74fd48fe9/CHANGES#L27) on Sphinx 1.6 and after.

```
...
Features removed
----------------

* Configuration variables

  - html_use_smartypants
...
```


footnote:

Found while working with @Dunedan, @pauloxnet, @joaojunior, @lucifurtun, @leapforleap on the Europython 2017 sprints.