### PR TITLE
Change language on the download page for Django 2.0.

### DIFF
--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -13,8 +13,8 @@
   <h1>How to get Django</h1>
   <p>Django is available open-source under the
     <a href="https://github.com/django/django/blob/master/LICENSE">BSD license</a>.
-    We recommend using the latest version of Python 3, but you can also use
-    Python 2.7. See <a href="
+    We recommend using the latest version of Python 3. The last version to
+    support Python 2.7 is Django 1.11 LTS. See <a href="
     {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' %}#what-python-version-can-i-use-with-django">
     the FAQ</a> for the Python versions supported by each version of Django.
     Here’s how to get it:</p>


### PR DESCRIPTION
 Mention that `1.11 LTS` is the last release to support Python 2.7.