### PR TITLE
Stopped leaking the CSRF token in donate form

### DIFF
--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -29,7 +29,7 @@
 
     <div class="donate">
       <form
-            method="get"
+            method="post"
             class="stripe-custom-checkout"
             action="{% url "fundraising:donate" %}"
             data-stripe-key="{{ stripe_publishable_key }}"


### PR DESCRIPTION
The corresponding /fundraising/donate/ view only accepts POST anyway.