### PR TITLE
Fixed #796 -- Fixed debug toolbar panels for docs site.

### DIFF
--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -1,0 +1,12 @@
+class CORSMiddleware(object):
+    """
+    Set the CORS 'Access-Control-Allow-Origin' header to allow the debug
+    toolbar to work on the docs domain.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response['Access-Control-Allow-Origin'] = '*'
+        return response

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -52,3 +52,7 @@ if DEBUG:
             MIDDLEWARE.index('django.middleware.common.CommonMiddleware') + 1,
             'debug_toolbar.middleware.DebugToolbarMiddleware'
         )
+        MIDDLEWARE.insert(
+            MIDDLEWARE.index('debug_toolbar.middleware.DebugToolbarMiddleware') + 1,
+            'djangoproject.middleware.CORSMiddleware'
+        )


### PR DESCRIPTION
Set the CORS header Access-Control-Allow-Origin to allow a page loaded under the every subdomains to access a resource under the www subdomain.
Applied to the development environment only, to reduce the chance for abuse in production.