### PR TITLE
[wip] Started using HTTPS for local development server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ watch-scss:
 	watchmedo shell-command --patterns=*.scss --recursive --command="make compile-scss-debug" $(SCSS)
 
 run:
-	python manage.py runserver 0.0.0.0:8000
+	python manage.py runsslserver 0.0.0.0:8000
 
 install:
 	pip install -r requirements/dev.txt

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ To run locally, do the usual:
    .. _`Hosts.prefpane`: https://github.com/specialunderwear/Hosts.prefpane
    .. _`built-in network admin`: https://help.ubuntu.com/community/NetworkAdmin
 
-#. Compile the CSS (only the source SCSS files are stored in the repostiory)::
+#. Compile the CSS (only the source SCSS files are stored in the repository)::
 
     make compile-scss
 
@@ -122,8 +122,8 @@ To run locally, do the usual:
 
    This runs both the main site ("www") as well as the
    docs and dashboard site in the same process.
-   Open http://www.djangoproject.dev:8000/, http://docs.djangoproject.dev:8000/
-   or http://dashboard.djangoproject.dev:8000/.
+   Open https://www.djangoproject.dev:8000/, https://docs.djangoproject.dev:8000/
+   or https://dashboard.djangoproject.dev:8000/.
 
 Running the tests
 -----------------

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -34,6 +34,8 @@ DOCS_BUILD_ROOT = DATA_DIR.joinpath('djangodocs')
 
 PARENT_HOST = 'djangoproject.dev:8000'
 
+HOST_SCHEME = 'https'
+
 # django-push settings
 
 PUSH_SSL_CALLBACK = False
@@ -56,3 +58,5 @@ if DEBUG:
             MIDDLEWARE.index('debug_toolbar.middleware.DebugToolbarMiddleware') + 1,
             'djangoproject.middleware.CORSMiddleware'
         )
+
+    INSTALLED_APPS.append('sslserver')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r common.txt
 
 watchdog==0.8.3
+django-sslserver==0.20


### PR DESCRIPTION
Changes to redicts in the last months don't allows contributors to
use HTTP anymore.