### PR TITLE
Updated CSS and "copy to clipboard" for replacing snippet with code-block.

### DIFF
--- a/djangoproject/scss/_pygments.scss
+++ b/djangoproject/scss/_pygments.scss
@@ -12,6 +12,22 @@ pre.literal-block,
     color: $green-dark;
 }
 
+.code-block-caption {
+    background: $green-very-light;
+    color: $green-dark;
+    @include monospace;
+    font-size: 1em;
+    padding: 5px 20px;
+    border-radius: 4px 4px 0 0;
+
+    + div > .highlight {
+        margin-top: 0;
+        border-radius: 0 0 4px 4px;
+        border-top: 0;
+    }
+}
+
+// For Django 2.0 docs and older.
 .snippet-filename {
     background: $green-very-light;
     color: $green-dark;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3188,7 +3188,7 @@ ul.corporate-members li {
     }
 }
 
-.snippet {
+.code-block-caption, .snippet {
     .btn-clipboard {
         float: right;
         cursor: pointer;

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -94,7 +94,7 @@ define(function() {
         mods.push('mod/messages');
     }
 
-    if (hasClass('snippet')) {
+    if (hasClass('code-block-caption') || hasClass('snippet')) {
         mods.push('mod/clippify');
     }
 

--- a/djangoproject/static/js/mod/clippify.js
+++ b/djangoproject/static/js/mod/clippify.js
@@ -1,4 +1,14 @@
 define(['jquery', 'clipboard'], function($, Clipboard) {
+    $('.code-block-caption').each(function() {
+        var header = $(this);
+        var wrapper = header.parent();
+        var code = $('.highlight', wrapper);
+        var btn = $('<span class="btn-clipboard" title="Copy this code">');
+        btn.append('<i class="icon icon-clipboard">');
+        btn.data('clipboard-text', $.trim(code.text()));
+        header.append(btn);
+    });
+    // For Django 2.0 docs and older.
     $('.snippet').each(function() {
         var code = $('.highlight', this);
         var btn = $('<span class="btn-clipboard" title="Copy this code">');


### PR DESCRIPTION
For https://github.com/django/django/pull/10356.
