### PR TITLE
disable LocaleMiddleware for docs.djangoproject.com

### DIFF
--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -1,3 +1,10 @@
+from django.conf import settings
+from django.http.request import split_domain_port
+from django.middleware.locale import LocaleMiddleware
+from django.utils.functional import cached_property
+from django.utils.http import is_same_domain
+
+
 class CORSMiddleware(object):
     """
     Set the CORS 'Access-Control-Allow-Origin' header to allow the debug
@@ -9,4 +16,34 @@ class CORSMiddleware(object):
     def __call__(self, request):
         response = self.get_response(request)
         response['Access-Control-Allow-Origin'] = '*'
+        return response
+
+
+class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
+    """
+    Locale middleware that lets us exclude requests to certain hosts (e.g.,
+    docs.djangoproject.com) from being processed by LocaleMiddleware.
+    """
+
+    @cached_property
+    def _excluded_hosts(self):
+        return frozenset(getattr(settings, 'LOCALE_MIDDLEWARE_EXCLUDED_HOSTS', []))
+
+    def _is_host_included(self, host):
+        """
+        Mirrors the behavior of django.http.request.validate_host(), but does
+        not match '*' (which would exclude all hosts). To exclude all requests
+        from being processed by LocaleMiddleware one should simply remove this
+        class from settings.MIDDLEWARE.
+        """
+        domain, _ = split_domain_port(host)
+        return not any(is_same_domain(domain, pattern) for pattern in self._excluded_hosts)
+
+    def process_request(self, request):
+        if self._is_host_included(request.get_host()):
+            super().process_request(request)
+
+    def process_response(self, request, response):
+        if self._is_host_included(request.get_host()):
+            return super().process_response(request, response)
         return response

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -140,7 +140,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_hosts.middleware.HostsRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+    'djangoproject.middleware.ExcludeHostsLocaleMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -7,6 +7,8 @@ ALLOWED_HOSTS = [
     'dashboard.djangoproject.localhost',
 ] + SECRETS.get('allowed_hosts', [])
 
+LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ['docs.djangoproject.localhost']
+
 DEBUG = True
 THUMBNAIL_DEBUG = DEBUG
 

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -7,6 +7,8 @@ ALLOWED_HOSTS = [
     'dashboard.djangoproject.com',
 ] + SECRETS.get('allowed_hosts', [])
 
+LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ['docs.djangoproject.com']
+
 DEBUG = False
 THUMBNAIL_DEBUG = DEBUG
 

--- a/docs/views.py
+++ b/docs/views.py
@@ -46,8 +46,7 @@ def document(request, lang, version, url):
     except UnicodeEncodeError:
         raise Http404
 
-    if lang != 'en':
-        activate(lang)
+    activate(lang)
 
     canonical_version = DocumentRelease.objects.current_version()
     canonical = version == canonical_version
@@ -145,6 +144,9 @@ def search_results(request, lang, version, per_page=10, orphans=3):
         release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
     except DocumentRelease.DoesNotExist:
         raise Http404
+
+    activate(lang)
+
     form = DocSearchForm(request.GET or None, release=release)
 
     context = {
@@ -192,9 +194,6 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                 'paginator': paginator,
             })
 
-    if release.lang != 'en':
-        activate(release.lang)
-
     return render(request, 'docs/search_results.html', context)
 
 
@@ -212,6 +211,8 @@ def search_suggestions(request, lang, version, per_page=20):
         release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
     except DocumentRelease.DoesNotExist:
         raise Http404
+
+    activate(lang)
 
     form = DocSearchForm(request.GET or None, release=release)
     suggestions = []
@@ -257,6 +258,9 @@ def search_description(request, lang, version):
         release = DocumentRelease.objects.get_by_version_and_lang(version, lang)
     except DocumentRelease.DoesNotExist:
         raise Http404
+
+    activate(lang)
+
     context = {
         'site': Site.objects.get_current(),
         'release': release,


### PR DESCRIPTION
When looking into adding a CDN, I noticed docs.djangoproject.com is setting `Vary: Cookie` and `Vary: Accept-Language` headers, neither of which should be needed (there are no cookies, and we use URL-based rather than header-based language selection).

While no other apps currently have translation, work is in progress (#866) to enable that to happen, so we may not want to disable `LocaleMiddleware` entirely.

This PR selectively disables `LocaleMiddleware` for the domain(s) specified in settings, and standardizes how language activation is done in the `docs` app to always use the language in the URL (rather than a mix of the two).