### PR TITLE
switch STATIC_URL and MEDIA_URL to their own domains on production

### DIFF
--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -35,6 +35,8 @@ LOGGING["loggers"]["django.request"]["handlers"].append("syslog")
 
 MEDIA_ROOT = str(DATA_DIR.joinpath('media'))
 
+MEDIA_URL = 'https://media.djangoproject.com/'
+
 MIDDLEWARE = (
     ['django.middleware.cache.UpdateCacheMiddleware'] +
     MIDDLEWARE +
@@ -46,6 +48,8 @@ SESSION_COOKIE_SECURE = True
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 STATIC_ROOT = str(DATA_DIR.joinpath('static'))
+
+STATIC_URL = 'https://static.djangoproject.com/'
 
 # Docs settings
 DOCS_BUILD_ROOT = DATA_DIR.joinpath('data', 'docbuilds')


### PR DESCRIPTION
As a first step in moving to a CDN, we set up separate domains for static & uploaded media. This PR makes dp.com use those domains.

This has the added benefit of allowing the browser to reuse the otherwise identical static media files across the `docs` and `www` subdomains (and will give `www` some benefit from the CDN, even though sites to the main domain will not be routed through the CDN).
