### PR TITLE
speed up travis by running tox only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: no
-dist: trusty
+dist: xenial
 addons:
   postgresql: "9.5"
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ addons:
 language: python
 python:
   - "3.5"
-env:
-  - TOXENV=py35-tests
-  - TOXENV=py35-flake8
-  - TOXENV=py35-isort
 install:
   - pip install coveralls tox
 before_script:


### PR DESCRIPTION
I noticed Travis is building each `TOXENV` before continuing to the next (including the container overhead for each build). I wonder if running them all at once might be faster. I also took the opportunity to upgrade Travis to Xenial (https://docs.travis-ci.com/user/reference/xenial/).

UPDATE: It looks like this roughly cuts the runtime in half: https://www.dropbox.com/s/uzlke0ln2dh3rai/Screenshot%202019-02-21%2008.55.00.png?dl=0