### PR TITLE
Fixed #868 -- display hreflang tags on all docs pages, and remove x-default

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -11,6 +11,7 @@
     <meta name="keywords" content="Python, Django, framework, open-source" />
     <meta name="description" content="{% block description %}{% endblock %}" />
 
+    {% block link_rel_tags %}{% endblock link_rel_tags %}
     <!-- Favicons -->
     <link rel="apple-touch-icon" href="{% static "img/icon-touch.png" %}">
     <link rel="icon" sizes="192x192" href="{% static "img/icon-touch.png" %}">

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="ROBOTS" content="ALL" />
-    <meta http-equiv="imagetoolbar" content="no" />
     <meta name="MSSmartTagsPreventParsing" content="true" />
     <meta name="Copyright" content="Django Software Foundation" />
     <meta name="keywords" content="Python, Django, framework, open-source" />

--- a/djangoproject/templates/docs/doc.html
+++ b/djangoproject/templates/docs/doc.html
@@ -5,7 +5,7 @@
 
 {% block doc_url %}{% url 'document-index' lang=lang version=version host 'docs' %}{% endblock %}
 
-{% block head_extra %}
+{% block link_rel_tags %}
   {% if docurl %}
     {% if "internals" in docurl %} {# The canonical version of "internals" is the dev docs. #}
       {% url 'document-detail' lang=lang version='dev' url=docurl host 'docs' as canonical_url %}
@@ -31,7 +31,7 @@
         type="application/opensearchdescription+xml"
         href="{% url 'document-search-description' lang=lang version=version host 'docs' %}"
         title="{% trans "Django documentation" %}">
-{% endblock head_extra %}
+{% endblock link_rel_tags %}
 
 {% block body_extra %}
 {% if release.is_dev %}

--- a/djangoproject/templates/docs/doc.html
+++ b/djangoproject/templates/docs/doc.html
@@ -16,23 +16,16 @@
     {% url 'document-index' lang=lang version=canonical_version host 'docs' as canonical_url %}
   {% endif %}
   <link rel="canonical" href="{{ canonical_url }}">
-  {% if canonical %}
-    {% for available_lang in available_languages %}
-        {% if docurl %}
-          {% url 'document-detail' lang=available_lang version=version url=docurl host 'docs' as alternate_url %}
-        {% else %}
-          {% url 'document-index' lang=available_lang version=version host 'docs' as alternate_url %}
-        {% endif %}
-        {% if available_lang == "en" %}
-        <link rel="alternate"
-           hreflang="x-default"
-           href="{{ alternate_url }}">
-        {% endif %}
-        <link rel="alternate"
-           hreflang="{{ available_lang }}"
-           href="{{ alternate_url }}">
-    {% endfor %}
-  {% endif %}
+  {% for available_lang in available_languages %}
+    {% if docurl %}
+      {% url 'document-detail' lang=available_lang version=version url=docurl host 'docs' as alternate_url %}
+    {% else %}
+      {% url 'document-index' lang=available_lang version=version host 'docs' as alternate_url %}
+    {% endif %}
+    <link rel="alternate"
+       hreflang="{{ available_lang }}"
+       href="{{ alternate_url }}">
+  {% endfor %}
 
   <link rel="search"
         type="application/opensearchdescription+xml"

--- a/djangoproject/templates/docs/search_form.html
+++ b/djangoproject/templates/docs/search_form.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <form action="{% url 'document-search' version=version lang=lang host 'docs' %}" class="search form-input" role="search">
-  <label class="visuallyhidden" for="news-search">Search:</label>
+  <label class="visuallyhidden" for="id_q">Search:</label>
     {{ form.q }}
 
     <button type="submit">


### PR DESCRIPTION
- I'm not sure why we had `<link rel="alternate">` tags only on the docs for the current canonical version. It seems like we can and should specify these for all versions.
- I removed the `<link rel="alternate" hreflang="x-default">` tag because that might be telling Google not to associate a language with these pages (and we just so happen to display this tag only on the English language version of the page): https://webmasters.googleblog.com/2013/04/x-default-hreflang-for-international-pages.html?m=1
- Moved the `<link rel="alternate">` tags higher up in `<head>` per: https://support.google.com/webmasters/answer/189077?hl=en
- I removed the `<meta http-equiv="imagetoolbar">` tag because it did not validate per https://validator.w3.org/nu/#textarea (and Google seems to suggest that it may be picky about such things in the `<head>` tag, especially when they come before our `<link rel="alternate">` tags. I figured we didn't need it anymore because it sounds like it was only really an IE6 thing: https://stackoverflow.com/questions/7207649/imagetoolbar-meta-tag-and-ie-versions
- Finally, I discovered the docs search label was pointing to an invalid element ID via the validator, and fixed that