### PR TITLE
Stopped setting Vary: Cookie on all responses

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -139,8 +139,10 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_hosts.middleware.HostsRequestMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
+    # Put LocaleMiddleware before SessionMiddleware to prevent the former from accessing the
+    # session and adding 'Vary: Cookie' to all responses.
     'djangoproject.middleware.ExcludeHostsLocaleMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
I realized we might as well make this minor enhancement for sites other than docs (where `LocaleMiddleware` is not used at all). At the moment, if you have a `csrftoken` or `sessionid` cookie set, you'll never get a cached page from the cache middleware (except your own, once it's cached).

I noticed this because the community page is always slow to load for me, because I logged into the admin at some point (I was surprised by this because I figured it would be a pretty popular page).

**Before:**
```
$ curl -I http://www.djangoproject.localhost:8000/community/
HTTP/1.1 200 OK
Date: Fri, 15 Mar 2019 13:01:14 GMT
Server: WSGIServer/0.2 CPython/3.6.8
Content-Type: text/html; charset=utf-8
Content-Length: 12297
Vary: Accept-Language, Cookie
Content-Language: en
X-Frame-Options: SAMEORIGIN
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
```

**After:**
```
$ curl -I http://www.djangoproject.localhost:8000/community/
HTTP/1.1 200 OK
Date: Fri, 15 Mar 2019 13:01:28 GMT
Server: WSGIServer/0.2 CPython/3.6.8
Content-Type: text/html; charset=utf-8
Content-Length: 12297
Vary: Accept-Language
Content-Language: en
X-Frame-Options: SAMEORIGIN
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
```