### PR TITLE
Relocate doc search bar

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -395,8 +395,6 @@ blockquote {
     }
 }
 .container {
-    @include clearfix;
-    //reusable container class to center content
     @include respond-min(768px) {
         margin: 0 auto;
         max-width: 1400px;
@@ -407,6 +405,17 @@ blockquote {
         .mdzr-boxshadow & {
             box-shadow: -1200px 0 0 0px #fff;
         }
+    }
+}
+.container--flex {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.container--flex--wrap--mobile {
+    flex-wrap: wrap;
+    @include respond-min(768px) {
+        flex-wrap: no-wrap;
     }
 }
 
@@ -2580,7 +2589,7 @@ form {
         padding: 6px 14% 8px 10px;
         text-indent: 0;
         vertical-align: middle;
-        width: 82%;
+        width: 83%;
 
         @include respond-min(768px) {
             padding: 6px 18% 8px 10px;
@@ -2718,7 +2727,19 @@ form {
             }
         }
     }
-}
+    &.search {
+        @include respond-min(768px) {
+            flex: 0 0 40%;
+            margin: 10px 0;
+        }
+        flex: 0 0 100%;
+        margin: 0 0 10px 0;
+        button {
+            top: 19%;
+        }
+    }
+} 
+
 
 
 form.donate {

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -45,7 +45,7 @@
     {% include "includes/header.html" %}
 
     <div class="copy-banner">
-      <div class="container">
+      <div class="container {% block header-classes %}{% endblock %}">
         {% block header %}{% endblock %}
       </div>
     </div>

--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -1,12 +1,17 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n docs %}
 
 {% block html_language_code %}{{ lang|default:"en" }}{% endblock %}
 
 {% block title %}{% trans 'Django Documentation' %}{% endblock %}
 
+{% block header-classes %}
+container--flex container--flex--wrap--mobile
+{% endblock %}
+
 {% block header %}
-  <h1><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></h1>
+<h1><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></h1>
+{% search_form %}
 {% endblock %}
 
 {% block layout_class %}sidebar-right{% endblock %}

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -124,9 +124,6 @@
 {% block content-related %}
 <h1 class="visuallyhidden">{% trans "Additional Information" %}</h1>
 <div role="complementary">
-  {% block search %}
-  {% search_form %}
-  {% endblock search %}
 
   {% donation_snippet %}
 


### PR DESCRIPTION
This PR addresses issue #799 

Moving the search bar to be in-line with the "Documentation" header makes it more readily accessible when a user arrives on any documentation page (previously he/she had to scroll to near the bottom to use it).

The previous placeholder text also turned out to be too long on mobile devices (it overflowed beyond the width of the search bar, appearing behind the search button icon). The previous text displayed the version of documentation a user was viewing/could search, but since this information is already displayed in the bottom right corner version button, we can safely remove it and simply use "Search" as the new, shorter placeholder text.