### PR TITLE
Add management command to create missing stripe plans

### DIFF
--- a/fundraising/management/commands/create_stripe_plans.py
+++ b/fundraising/management/commands/create_stripe_plans.py
@@ -1,0 +1,54 @@
+import logging
+
+import stripe
+from django.core.management import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def handle(self, **kwargs):
+        try:
+            stripe.Plan.retrieve("monthly")
+            print("Monthly plan exists, not creating!")
+        except stripe.error.InvalidRequestError:
+            name = "Monthly donation"
+            logger.info("Creating plan: {0}".format(name))
+            stripe.Plan.create(
+                id="monthly",
+                amount=100,
+                interval="month",
+                interval_count=1,
+                product={"name": name},
+                currency="usd",
+            )
+        try:
+            stripe.Plan.retrieve("quarterly")
+            print("Quarterly plan exists, not creating!")
+        except stripe.error.InvalidRequestError:
+            name = "Quarterly donation"
+            logger.info("Creating plan: {0}".format(name))
+            stripe.Plan.create(
+                id="quarterly",
+                amount=100,
+                interval="month",
+                interval_count=3,
+                nickname=name,
+                product={"name": name},
+                currency="usd",
+            )
+        try:
+            stripe.Plan.retrieve("yearly")
+            print("Yearly plan exists, not creating!")
+        except stripe.error.InvalidRequestError:
+            name = "Yearly donation"
+            logger.info("Creating plan: {0}".format(name))
+            stripe.Plan.create(
+                id="yearly",
+                amount=100,
+                interval="year",
+                interval_count=1,
+                nickname=name,
+                product={"name": name},
+                currency="usd",
+            )


### PR DESCRIPTION
This command can create missing stripe plans for fundraising. It can also be used locally to create test plans for sandbox (if the plans in sandbox needs to be removed for testing purposes).

cc: @carltongibson 
Fixes #905 