### PR TITLE
Added `invisible` reCaptcha to donatations form. 

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     'svntogit',
     'tracdb',
     'fundraising',
+    'captcha',
 
     'registration',
     'django_hosts',

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -62,3 +62,7 @@ if DEBUG:
             MIDDLEWARE.index('debug_toolbar.middleware.DebugToolbarMiddleware') + 1,
             'djangoproject.middleware.CORSMiddleware'
         )
+
+
+# Disable for development only.
+SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'svntogit',
     'tracdb',
     'fundraising',
+    'captcha',
 
     'registration',
     'django_hosts',
@@ -255,7 +256,7 @@ THUMBNAIL_ALTERNATIVE_RESOLUTIONS = [2]
 TRAC_RPC_URL = "https://code.djangoproject.com/rpc"
 TRAC_URL = "https://code.djangoproject.com/"
 
-ALLOWED_HOSTS = ['.localhost', '127.0.0.1']
+ALLOWED_HOSTS = ['.localhost', '127.0.0.1', 'www.127.0.0.1']
 
 LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ['docs.djangoproject.localhost']
 
@@ -293,6 +294,8 @@ PARENT_HOST = 'localhost:8000'
 # django-push settings
 
 PUSH_SSL_CALLBACK = False
+
+SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
 
 # Enable optional components
 

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -77,3 +77,9 @@ PUSH_SSL_CALLBACK = True
 if 'sentry_dsn' in SECRETS and not DEBUG:
     INSTALLED_APPS.append('raven.contrib.django.raven_compat')
     RAVEN_CONFIG = {'dsn': SECRETS['sentry_dsn']}
+
+# RECAPTCHA KEYS
+# Defaults will trigger 'captcha.recaptcha_test_key_error' system check
+if 'recaptcha_public_key' in SECRETS:
+    RECAPTCHA_PUBLIC_KEY = SECRETS.get('recaptcha_public_key')
+    RECAPTCHA_PRIVATE_KEY = SECRETS.get('recaptcha_private_key')

--- a/djangoproject/static/js/mod/stripe-custom-checkout.js
+++ b/djangoproject/static/js/mod/stripe-custom-checkout.js
@@ -49,14 +49,31 @@ define([
         var interval = $donationForm.find('[name=interval]').val();
         var amountDollars = $donationForm.find('[name=amount]').val();
         var amountCents = parseFloat(amountDollars) * 100;
-
-        handler.open({
-            name: 'Django Software Foundation',
-            amount: amountCents,
-            currency: 'USD',
-            bitcoin: true,
-            zipCode: true,
-            billingAddress: true
-        });
+        var csrfToken = $donationForm.find('[name=csrfmiddlewaretoken]').val();
+        var recaptchaToken = document.getElementById('id_captcha').dataset.callback
+        var data = {
+            'captcha': recaptchaToken,
+            'csrfmiddlewaretoken': csrfToken
+        }
+        $.ajax({
+            type: "POST",
+            url: $donationForm.attr('action-for-verify'),
+            data: data,
+            dataType: 'json',
+            success: function (data) {
+                if (data.success) {
+		    handler.open({
+			name: 'Django Software Foundation',
+			amount: amountCents,
+			currency: 'USD',
+			bitcoin: true,
+			zipCode: true,
+			billingAddress: true
+		    });
+                } else {
+                    alert(data.error);
+                }
+            }
+        })
     });
 });

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -32,6 +32,7 @@
             method="post"
             class="stripe-custom-checkout"
             action="{% url "fundraising:donate" %}"
+            action-for-verify="{% url 'fundraising:verify-captcha' %}"
             data-stripe-key="{{ stripe_publishable_key }}"
             data-stripe-icon="{% static 'img/dj-stripe-icon.jpg' %}"
             data-is-logged-in="{{ user.is_authenticated }}"
@@ -43,6 +44,7 @@
         <div class="custom-donation">
           <span class="prefix">US $ (integer only)</span>
         </div>
+	      {{ form_captcha.captcha }}
         <input id="donate-button" type="submit" value="Donate monthly" class="cta" />
       </form>
     </div>

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -1,4 +1,6 @@
 import stripe
+from captcha.fields import ReCaptchaField
+from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.conf import settings
 from django.core.mail import send_mail
@@ -275,3 +277,7 @@ class PaymentForm(forms.Form):
             )
 
             return donation
+
+
+class ReCaptchaForm(forms.Form):
+    captcha = ReCaptchaField(widget=ReCaptchaV3)

--- a/fundraising/templatetags/fundraising_extras.py
+++ b/fundraising/templatetags/fundraising_extras.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.template.defaultfilters import floatformat
 
-from fundraising.forms import DonateForm
+from fundraising.forms import DonateForm, ReCaptchaForm
 from fundraising.models import (
     DEFAULT_DONATION_AMOUNT, DISPLAY_DONOR_DAYS, GOAL_AMOUNT, GOAL_START_DATE,
     LEADERSHIP_LEVEL_AMOUNT, DjangoHero, InKindDonor, Payment,
@@ -51,6 +51,7 @@ def donation_form_with_heart(context):
     form = DonateForm(initial={
         'amount': DEFAULT_DONATION_AMOUNT,
     })
+    form_captcha = ReCaptchaForm()
 
     return {
         'goal_amount': GOAL_AMOUNT,
@@ -58,6 +59,7 @@ def donation_form_with_heart(context):
         'donated_amount': donated_amount,
         'total_donors': total_donors,
         'form': form,
+        'form_captcha': form_captcha,
         'display_logo_amount': LEADERSHIP_LEVEL_AMOUNT,
         'stripe_publishable_key': settings.STRIPE_PUBLISHABLE_KEY,
         'user': user,

--- a/fundraising/urls.py
+++ b/fundraising/urls.py
@@ -6,6 +6,7 @@ app_name = 'fundraising'
 urlpatterns = [
     path('', views.index, name='index'),
     path('donate/', views.donate, name='donate'),
+    path('verify/', views.verify_captcha, name='verify-captcha'),
     path('thank-you/<donation>/', views.thank_you, name='thank-you'),
     path('manage-donations/<hero>/', views.manage_donations, name='manage-donations'),
     path('manage-donations/<hero>/cancel/', views.cancel_donation, name='cancel-donation'),

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from .exceptions import DonationError
-from .forms import DjangoHeroForm, DonationForm, PaymentForm
+from .forms import DjangoHeroForm, DonationForm, PaymentForm, ReCaptchaForm
 from .models import (
     LEADERSHIP_LEVEL_AMOUNT, DjangoHero, Donation, Payment, Testimonial,
 )
@@ -25,6 +25,20 @@ def index(request):
     return render(request, 'fundraising/index.html', {
         'testimonial': testimonial,
     })
+
+
+@require_POST
+def verify_captcha(request):
+    form = ReCaptchaForm(request.POST)
+
+    if form.is_valid():
+        data = {'success': True}
+    else:
+        data = {
+            'success': False,
+            'error': form.errors
+        }
+    return JsonResponse(data)
 
 
 @require_POST

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,3 +16,4 @@ requests==2.22.0
 sorl-thumbnail==12.5.0
 stripe==2.20.3
 Sphinx==1.8.4
+django-recaptcha==2.0.4


### PR DESCRIPTION
This is a conceptial PR for adding Google Invisible reCAPTCHA to stripe payment process. (cc: @carltongibson @frankwiles )

It has a dependency on [django-recaptcha](https://pypi.org/project/django-recaptcha/) package.

It basicly does an invisible captcha check before opening stripe modal. Recaptcha v3 requires a server side call to google in order to verify user interaction. That is also included in the implementation.

If there is a different requirement on the placement of the captcha it can easily be moved to that location. But this version prevents those users who fails the captcha check to enter their credit card information (and use stripe to check validation of those card information)

Settings are temporary, should be updated for prod use. Tests should be added as well.