### PR TITLE
Refs #838 -- Marked current release on downloads page as LTS (if so).

### DIFF
--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -20,7 +20,7 @@
     Here’s how to get it:</p>
 
   <h2>Option {% cycle '1' '2' '3' as options %}: Get the latest official version</h2>
-  <p>The latest official version is {{ current.version }}. Read the
+  <p>The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}. Read the
     {% release_notes current.version show_version=True %}, then install it with
     <a href="https://pip.pypa.io/en/latest/">pip</a>:</p>
   <pre class="literal-block"><code>pip install Django=={{ current.version }}</code></pre>


### PR DESCRIPTION
The LTS is well explained in the _Supported Versions_ section of the downloads page, but we can/could mark the current release as LTS above that (if it were so). Thus...