### PR TITLE
Fixed #948 -- Added issue template.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,15 @@
+---
+name: Issue
+about: Submit a bug report or feature request for the website djangoproject.com
+
+---
+
+### Please read this first:
+
+This is the issue tracker for the website at djangoproject.com, **not** for Django itself.
+
+If you are looking for help or support with using Django, please follow the links in [our documentation](https://docs.djangoproject.com/en/stable/faq/help/).
+
+If you want to submit a bug report or a feature request to Django, you can find instructions [here](https://docs.djangoproject.com/en/stable/internals/contributing/bugs-and-features/).
+
+If you want to [report a bug on translations](https://docs.djangoproject.com/en/stable/internals/contributing/localizing/#translations) in Django or djangoproject.com, please use [Transifex](https://www.transifex.com/django/django/dashboard/).


### PR DESCRIPTION
This PR adds a default issue template that advises people opening an issue that this repository and its issue tracker are only for the djangoproject.com website, not for the Django project. It seems to me that this is a frequent reason for confusion, and this might help for at least some of the incoming issues.
You can see how this would look by [opening an issue on my fork](https://github.com/rixx/djangoproject.com/issues/new).

Comes with links to the docs on how to get help and how to open issues.

While I was creating the .github/ directory, I also added the `FUNDING` file, which I copied from the main Django repository.