### PR TITLE
Add dependencies for update_docs to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ENV PYTHONUNBUFFERED 1
 RUN apk update \
     && apk add --virtual build-deps gcc python3-dev musl-dev \
     && apk add postgresql-dev \
+    && apk add gettext-dev \
+    && apk add rsync \
     && pip install psycopg2 \
     && apk del build-deps
 


### PR DESCRIPTION
I needed those packages to be added to the `Dockerfile` to be able to run `docker-compose exec web python manage.py update_docs` successfully. Without `rsync` it did not create the `_built` folder necessary to be able to open the documentation pages on the website.