### PR TITLE
Restore update_docs_and_index command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ To run locally, do the usual:
 #. For docs (next step requires ``gettext``)::
 
     python -m manage loaddata doc_releases
-    python -m manage update_docs
+    python -m manage update_docs_and_index
 
 #. For dashboard:
 
@@ -269,7 +269,7 @@ library from ``bower.json``, you will need to commit the changes in
 Documentation search
 --------------------
 
-When running ``python -m manage update_docs`` to build all documents it will also
+When running ``python -m manage update_docs_and_index`` to build all documents it will also
 automatically index every document it builds in the search engine as well.
 In case you've already built the documents and would like to reindex the
 search index run the command::

--- a/docs/management/commands/update_docs_and_index.py
+++ b/docs/management/commands/update_docs_and_index.py
@@ -1,0 +1,10 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Update the docs then reindex them in the search vector field.
+    """
+    def handle(self, **options):
+        call_command('update_docs', update_index=True, **options)


### PR DESCRIPTION
To update the documentation and update the indexes there has always been the command `update_docs_and_index` that was removed in commit [`0a6cf5c`](https://github.com/django/djangoproject.com/commit/0a6cf5cc7e1d8a0a6b5634ade5524ccc5b1f2da6#diff-b478d680c67b1b838b7c6568fe8a2129) without an explicit reason.

I created this PR to restored the command and to re-add the `update_docs_and_index` command in the `README.rst`.