### PR TITLE
Fixed classmethod and staticmethod styling in docs.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2346,7 +2346,7 @@ h2 + .list-link-soup {
 
 }
 
-dl.function, dl.class, dl.method, dl.attribute, dl.exception {
+dl.function, dl.class, dl.method, dl.classmethod, dl.staticmethod, dl.attribute, dl.exception {
     dt {
         font-weight: 700;
     }


### PR DESCRIPTION
I noticed today that `.. classmethod::` definitions don't have the same style as `.. method::`.

See for example the difference between [`__init__`](https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.QueryDict.__init___) and [`fromkeys`](https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.QueryDict.fromkeys) in the `QueryDict` reference documentation.

Here's a hacked together before after of how the change would look like:
![Screenshot_2020-01-31 Request and response objects Django documentation Django](https://user-images.githubusercontent.com/6345/73538154-88a43700-442a-11ea-8e8a-7a5025a2e8ff.png)
![Screenshot_2020-01-31 Request and response objects Django documentation Django(1)](https://user-images.githubusercontent.com/6345/73538193-9eb1f780-442a-11ea-9a16-9afd434bff1e.png)
