### PR TITLE
Display header link in code snippet on hover

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3207,6 +3207,10 @@ ul.corporate-members li {
 }
 
 .code-block-caption, .snippet {
+	&:hover .headerlink {
+		opacity: 1;
+	}
+
     .btn-clipboard {
         float: right;
         cursor: pointer;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3207,9 +3207,9 @@ ul.corporate-members li {
 }
 
 .code-block-caption, .snippet {
-	&:hover .headerlink {
-		opacity: 1;
-	}
+    &:hover .headerlink {
+        opacity: 1;
+    }
 
     .btn-clipboard {
         float: right;


### PR DESCRIPTION
The header link for the code snippet isn't displayed even when hovering.

This PR aims to fix that.

Example, in the tutorial: https://docs.djangoproject.com/en/3.0/intro/tutorial02/#id2

![image](https://user-images.githubusercontent.com/1469823/78599944-4ea04880-7852-11ea-8bc6-5fd787848e80.png)
