### PR TITLE
Fixed snippet header-text selection visibility on Firefox.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3237,4 +3237,7 @@ ul.corporate-members li {
             margin-right: 10px;
         }
     }
+    .caption-text::selection{
+        background: $green-light;
+    }
 }


### PR DESCRIPTION
When you select the text on code snippet header, the selection is not visible on Firefox ie. you cannot see what is selected.
This PR aims to fix that issue.
Fix #987 