### PR TITLE
limit line length of billboard text

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -49,8 +49,8 @@
         {% block header %}{% endblock %}
       </div>
     </div>
-    <div id="billboard">{% block billboard %}
-      <div style="background: #0C4B33; color: #FFF; text-align:center;padding: 1em 3em;">
+    <div id="billboard" style="background: #0C4B33; color: #FFF;">{% block billboard %}
+      <div style="text-align:center; padding: 1em 3em; max-width: 60em; margin: 0 auto;">
         <p>
           The Django Software Foundation deeply values the diversity of our developers, users, and community. We are distraught by the suffering, oppression, and systemic racism the Black community faces every day. We can no longer remain silent. 
         </p>


### PR DESCRIPTION
I think limiting the line length makes the text look better on large screens. It shouldn't increase the total height or number of lines. It shouldn't have an effect on smaller screens.