### PR TITLE
Improve language/version switcher

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2230,6 +2230,7 @@ h2 + .list-link-soup {
             padding: 8px 15px;
             border: 1px solid var(--hairline-color);
             border-radius: 4px;
+            cursor: pointer;
         }
         &.hover-on {
             display: inline-block;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2213,8 +2213,18 @@ h2 + .list-link-soup {
 }
 
 #doc-versions, #doc-languages, #faq-link {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
+    margin: 0;
+    padding-top: 0.25em;
+    padding-bottom: 0.25em;
+
+    &.open {
+        li{
+            display: inline-block;
+            &.current {
+                border: 1px solid $green-light;
+            }
+        }
+    }
 
     li {
         display: none;
@@ -2232,9 +2242,7 @@ h2 + .list-link-soup {
             border-radius: 4px;
             cursor: pointer;
         }
-        &.hover-on {
-            display: inline-block;
-        }
+
         &.current-link {
             display: inline-block;
         }
@@ -2257,6 +2265,8 @@ h2 + .list-link-soup {
 
     &:hover {
         pointer-events: auto;
+        padding: 2em 0;
+        margin: -1.75em 0;
         li {
             display: inline-block;
         }

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2231,6 +2231,9 @@ h2 + .list-link-soup {
             border: 1px solid var(--hairline-color);
             border-radius: 4px;
         }
+        &.hover-on {
+            display: inline-block;
+        }
         &.current-link {
             display: inline-block;
         }
@@ -2251,7 +2254,7 @@ h2 + .list-link-soup {
         }
     }
 
-    &:hover, .hover-on {
+    &:hover {
         pointer-events: auto;
         li {
             display: inline-block;

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -47,6 +47,10 @@ define(function() {
         mods.push('mod/version-switcher');
     }
 
+    if (hasClass('doc-switcher')) {
+        mods.push('mod/doc-switcher');
+    }
+
     if (hasClass('doc-floating-warning')) {
         mods.push('mod/floating-warning');
     }

--- a/djangoproject/static/js/mod/doc-switcher.js
+++ b/djangoproject/static/js/mod/doc-switcher.js
@@ -14,7 +14,7 @@ define([
                 // Make version switcher clickable for touch devices
 
                 self.switchers.find('li.current').on('click', function () {
-                    $(this).closest("ul").find('li.other').toggleClass('hover-on');
+                    $(this).closest("ul").toggleClass('open');
                 });
             });
         }

--- a/djangoproject/static/js/mod/doc-switcher.js
+++ b/djangoproject/static/js/mod/doc-switcher.js
@@ -1,0 +1,25 @@
+define([
+    'jquery' //requires jquery
+], function( $ ) {
+
+    var DocSwitcher = function(switchers) {
+        this.switchers = $(switchers);
+        this.init();
+    };
+
+    DocSwitcher.prototype = {
+        init: function(){
+            var self = this;
+            $(document).ready(function () {
+                // Make version switcher clickable for touch devices
+
+                self.switchers.find('li.current').on('click', function () {
+                    $(this).closest("ul").find('li.other').toggleClass('hover-on');
+                });
+            });
+        }
+    };
+
+    // Export a single instance of our module:
+    return new DocSwitcher('.doc-switcher');
+});

--- a/djangoproject/static/js/mod/version-switcher.js
+++ b/djangoproject/static/js/mod/version-switcher.js
@@ -17,10 +17,6 @@ define([
                     this.href = hrefWithoutFragment + window.location.hash;
                     // do nothing and let the event bubble up
                 });
-                // Make version switcher clickable for touch devices
-                self.switcher.find('li.current').on('click', function () {
-                    self.switcher.find('li.other').toggleClass('hover-on');
-                });
             });
         }
     };

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -60,7 +60,7 @@
       </a>
     </li>
   </ul>
-  <ul id="doc-languages" class="language-switcher">
+  <ul id="doc-languages" class="language-switcher doc-switcher">
   {% for available_lang in available_languages %}
   {% if lang != available_lang %}
   <li class="other">
@@ -80,7 +80,7 @@
   </ul>
 
   {% get_all_doc_versions docurl as other_versions %}
-  <ul id="doc-versions" class="version-switcher">
+  <ul id="doc-versions" class="version-switcher doc-switcher">
     {% for other_version in other_versions %}
     {% if version != other_version %}
     <li class="other">


### PR DESCRIPTION
Closes #1027 

A few things:
- The code already had a "click to force the switcher to stay on"
- But only the version, not on the language. So I moved the code to apply to both
- It was actually broken because the scss assigned the style "stay on" to `ul.hover-on`, but the `hover-on` was set on the `li` class. I fixed the css (but I could have fixed the code too).
- Finally, to make it more clear that it's clickable, I adjusted the cursor.

Tested locally (building the doc locally took a good hour!)
![screencap](https://user-images.githubusercontent.com/1457576/94375546-bace7b80-0114-11eb-84c5-6172c7e313be.gif)


Also: I set up my env with Docker, which made me realize that the Dockerfile is missing rsync and gettext which are needed for building the doc (well except if the doc building is not meant to be done in the container, but... I assumed all make targets were supposed to be done in the container, no ?). Did I did something wrong or should I add them (in a separate PR)