### PR TITLE
Added target property and rel="noopener" to external footer link

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -30,10 +30,10 @@
       <div class="col follow last-child">
         <h2>Follow Us</h2>
         <ul>
-          <li><a href="https://github.com/django">GitHub</a></li>
-          <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
+          <li><a href="https://github.com/django" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://twitter.com/djangoproject" target="_blank" rel="noopener">Twitter</a></li>
           <li><a href="{% url 'weblog-feed' %}">News RSS</a></li>
-          <li><a href="https://groups.google.com/forum/#!forum/django-users">Django Users Mailing List</a></li>
+          <li><a href="https://groups.google.com/forum/#!forum/django-users" target="_blank" rel="noopener">Django Users Mailing List</a></li>
         </ul>
       </div>
 
@@ -41,9 +41,9 @@
         <h2>Support Us</h2>
         <ul>
           <li><a href="{% url "fundraising:index" %}">Sponsor Django</a></li>
-          <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a></li>
-          <li><a href="/foundation/donate/#amazon-smile">Amazon Smile</a></li>
-          <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving Program</a></li>
+          <li><a href="https://django.threadless.com/"  target="_blank" rel="noopener">Official merchandise store</a></li>
+          <li><a href="/foundation/donate/#amazon-smile" target="_blank" rel="noopener">Amazon Smile</a></li>
+          <li><a href="/foundation/donate/#benevity-giving" target="_blank" rel="noopener">Benevity Workplace Giving Program</a></li>
         </ul>
       </div>
 
@@ -57,9 +57,9 @@
       </div>
       <ul class="thanks">
         <li>
-          <span>Hosting by</span> <a class="rackspace" href="https://www.rackspace.com">Rackspace</a>
+          <span>Hosting by</span> <a class="rackspace" href="https://www.rackspace.com" target="_blank" rel="noopener">Rackspace</a>
         </li>
-        <li class="design"><span>Design by</span> <a class="threespot" href="https://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/"></a></li>
+        <li class="design"><span>Design by</span> <a class="threespot" href="https://www.threespot.com" target="_blank" rel="noopener">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/" target="_blank" rel="noopener"></a></li>
       </ul>
       <p class="copyright">&copy; 2005-{% now "Y" %}
         <a href="{% url 'homepage' %}foundation/"> Django Software


### PR DESCRIPTION
I was going through the documentation and wanted to check django on twitter via the link on the footer, I did that and when I got to twitter I started doing other things, When I wanted to go back to what I was reading on django I now discovered I was not on a separate Tab. I now decided to fix this.