### PR TITLE
Switch Dockerfile to Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.5.7-alpine
+FROM python:3.6-alpine
 
 # set work directory
 WORKDIR /usr/src/app
@@ -19,7 +19,7 @@ RUN apk update \
 RUN apk add --update nodejs nodejs-npm
 
 # install pillow dependencies
-RUN apk add build-base python-dev py-pip jpeg-dev zlib-dev
+RUN apk add build-base python3-dev py-pip jpeg-dev zlib-dev
 ENV LIBRARY_PATH=/lib:/usr/lib
 
 # install psql client


### PR DESCRIPTION
The Docker setup is still on 3.5 – looks like this was missed from #1017. The `python-dev` replacement is because:

```
ERROR: unsatisfiable constraints:
  python-dev (missing):
    required by: world[python-dev]
ERROR: Service 'web' failed to build : The command '/bin/sh -c apk add build-base python-dev py-pip jpeg-dev zlib-dev' returned a non-zero code: 1
```

I switched the Dockerfile to use a broad range (3.6 rather than 3.6.12) to match how Python versions are defined elsewhere.