### PR TITLE
Add missing alternative text for screen reader users

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -59,7 +59,7 @@
         <li>
           <span>Hosting by</span> <a class="rackspace" href="https://www.rackspace.com">Rackspace</a>
         </li>
-        <li class="design"><span>Design by</span> <a class="threespot" href="https://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/"></a></li>
+        <li class="design"><span>Design by</span> <a class="threespot" href="https://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/">andrevv</a></li>
       </ul>
       <p class="copyright">&copy; 2005-{% now "Y" %}
         <a href="{% url 'homepage' %}foundation/"> Django Software


### PR DESCRIPTION
The URL would be read out loud, which isn’t too bad (`http://andrevv.com/`), but might as well have proper alt text like for the other images in the footer.