### PR TITLE
Refs #1052 -- Added max_value validation to donations.

### DIFF
--- a/djangoproject/static/js/mod/stripe-donation.js
+++ b/djangoproject/static/js/mod/stripe-donation.js
@@ -26,8 +26,13 @@ define([
                     var stripe = Stripe($donationForm.data('stripeKey'))
                     return stripe.redirectToCheckout({sessionId: data.sessionId})
                 } else {
-                    alert('There was an error setting up your donation. ' +
-                          'Sorry. Please refresh the page and try again.');
+                    msg = 'There was an error setting up your donation. '
+                    if (data.error.amount) {
+                        msg += data.error.amount
+                    } else {
+                        msg += 'Sorry. Please refresh the page and try again.'
+                    }
+                    alert(msg);
                 }
             }
         })

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -165,6 +165,7 @@ class PaymentForm(forms.Form):
     amount = forms.IntegerField(
         required=True,
         min_value=1,  # Minimum payment from Stripe API
+        max_value=1_000_000,  # Reject clearly unrealistic amounts.
     )
     interval = forms.ChoiceField(
         required=True,

--- a/fundraising/tests/test_forms.py
+++ b/fundraising/tests/test_forms.py
@@ -10,3 +10,13 @@ class TestPaymentForm(TestCase):
             'interval': 'onetime',
         })
         self.assertTrue(form.is_valid())
+
+    def test_max_value_validation(self):
+        """
+        Reject unrealistic values greater than $1,000,000.
+        """
+        form = PaymentForm(data={
+            'amount': 1_000_001,
+            'interval': 'onetime',
+        })
+        self.assertFalse(form.is_valid())


### PR DESCRIPTION
Stripe's API rejects very large values. Sentry reports folks enjoying spending
the weekend entering such large values. So reject as invalid, and show an
appropriate alert before attempting to contact Stripe.