### PR TITLE
Re-added reCaptcha to fundraising page.

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     'tracdb',
     'fundraising',
 
+    'captcha',
     'registration',
     'django_hosts',
     'sorl.thumbnail',

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -62,3 +62,5 @@ if DEBUG:
             MIDDLEWARE.index('debug_toolbar.middleware.DebugToolbarMiddleware') + 1,
             'djangoproject.middleware.CORSMiddleware'
         )
+
+SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'tracdb',
     'fundraising',
 
+    'captcha',
     'registration',
     'django_hosts',
     'sorl.thumbnail',
@@ -158,6 +159,7 @@ SILENCED_SYSTEM_CHECKS = [
     'fields.W342',  # tracdb has ForeignKey(unique=True) in lieu of multi-col PKs
     'security.W008',  # SSL redirect is handled by nginx
     'security.W009',  # SECRET_KEY is setup through Ansible secrets
+    'captcha.recaptcha_test_key_error'  # Default test keys for development.
 ]
 
 SITE_ID = 1

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -87,3 +87,9 @@ if 'sentry_dsn' in SECRETS and not DEBUG:
         ],
         traces_sample_rate=0.1,
     )
+
+# RECAPTCHA KEYS
+# Defaults will trigger 'captcha.recaptcha_test_key_error' system check
+if 'recaptcha_public_key' in SECRETS:
+    RECAPTCHA_PUBLIC_KEY = SECRETS.get('recaptcha_public_key')
+    RECAPTCHA_PRIVATE_KEY = SECRETS.get('recaptcha_private_key')

--- a/djangoproject/static/js/mod/stripe-donation.js
+++ b/djangoproject/static/js/mod/stripe-donation.js
@@ -9,10 +9,12 @@ define([
         e.preventDefault();
         var interval = $donationForm.find('[name=interval]').val();
         var amount = $donationForm.find('[name=amount]').val();
+        var recaptchaToken = document.getElementById('id_captcha').value;
         var csrfToken = $donationForm.find('[name=csrfmiddlewaretoken]').val();
         var data = {
             'interval': interval,
             'amount': amount,
+            'captcha': recaptchaToken,
             'csrfmiddlewaretoken': csrfToken
         }
         $.ajax({

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -43,6 +43,7 @@
         <div class="custom-donation">
           <span class="prefix">US $ (integer only)</span>
         </div>
+        {{ form.captcha }}
         <input id="donate-button" type="submit" value="Donate monthly" class="cta" />
       </form>
     </div>

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -1,4 +1,6 @@
 import stripe
+from captcha.fields import ReCaptchaField
+from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.utils.safestring import mark_safe
 
@@ -125,6 +127,7 @@ class DonateForm(forms.Form):
 
     amount = forms.ChoiceField(choices=AMOUNT_CHOICES)
     interval = forms.ChoiceField(choices=INTERVAL_CHOICES)
+    captcha = ReCaptchaField(widget=ReCaptchaV3)
 
 
 class DonationForm(forms.ModelForm):
@@ -162,6 +165,7 @@ class PaymentForm(forms.Form):
 
     `amount` can be any integer, so a ChoiceField is not appropriate.
     """
+    captcha = ReCaptchaField(widget=ReCaptchaV3)
     amount = forms.IntegerField(
         required=True,
         min_value=1,  # Minimum payment from Stripe API

--- a/fundraising/tests/test_forms.py
+++ b/fundraising/tests/test_forms.py
@@ -8,6 +8,7 @@ class TestPaymentForm(TestCase):
         form = PaymentForm(data={
             'amount': 100,
             'interval': 'onetime',
+            'captcha': 'TESTING',
         })
         self.assertTrue(form.is_valid())
 
@@ -18,5 +19,15 @@ class TestPaymentForm(TestCase):
         form = PaymentForm(data={
             'amount': 1_000_001,
             'interval': 'onetime',
+            'captcha': 'TESTING',
         })
         self.assertFalse(form.is_valid())
+        self.assertIn('amount', form.errors)
+
+    def test_captcha_token_required(self):
+        form = PaymentForm(data={
+            'amount': 1_000,
+            'interval': 'onetime',
+        })
+        self.assertFalse(form.is_valid())
+        self.assertIn('captcha', form.errors)

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -55,6 +55,7 @@ class TestCampaign(TestCase):
         response = self.client.post(reverse('fundraising:donation-session'), {
             'amount': 100,
             'interval': 'onetime',
+            'captcha': 'TESTING',
         })
         content = json.loads(response.content.decode())
         self.assertEqual(response.status_code, 200)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,6 +3,7 @@ django-contact-form==1.8.2
 django-hosts==3.0
 django-money==1.3.1
 django-push==1.1
+django-recaptcha==2.0.6
 django-registration-redux==2.9
 docutils==0.16
 feedparser==6.0.2


### PR DESCRIPTION
Try to prevent automated creation of Stripe sessions. Stripe detects and rejects
these but logs report MANY such sessions being created. Adding as a
defense-in-depth measure.