### PR TITLE
Block FLoC

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -140,6 +140,7 @@ MEDIA_URL = '/m/'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'django_permissions_policy.PermissionsPolicyMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_hosts.middleware.HostsRequestMiddleware',
     # Put LocaleMiddleware before SessionMiddleware to prevent the former from accessing the
@@ -237,6 +238,12 @@ HOST_SCHEME = 'http'
 HOST_SITE_TIMEOUT = 3600
 
 ROOT_HOSTCONF = 'djangoproject.hosts'
+
+# django-permissions-policy settings
+
+PERMISSIONS_POLICY = {
+    "interest-cohort": [],
+}
 
 # django-registration settings
 

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -121,6 +121,7 @@ MEDIA_URL = '/m/'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'django_permissions_policy.PermissionsPolicyMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_hosts.middleware.HostsRequestMiddleware',
     # Put LocaleMiddleware before SessionMiddleware to prevent the former from accessing the
@@ -219,6 +220,12 @@ HOST_SCHEME = 'http'
 HOST_SITE_TIMEOUT = 3600
 
 ROOT_HOSTCONF = 'djangoproject.hosts'
+
+# django-permissions-policy settings
+
+PERMISSIONS_POLICY = {
+    "interest-cohort": [],
+}
 
 # django-registration settings
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,6 +2,7 @@ Django==2.2.23
 django-contact-form==1.8.2
 django-hosts==3.0
 django-money==1.3.1
+django-permissions-policy==4.0.1
 django-push==1.1
 django-recaptcha==2.0.6
 django-registration-redux==2.9


### PR DESCRIPTION
Fixes #1091. Use django-permissions-policy to set the `Permissions-Policy` header to `interest-cohort=()`. I thought of disabling more browser features, but figured that was a little risky, so will look at that in the future.

Tested locally with `docker-compose` setup, saw the header set. (It took me a while to figure that the `docker` settings file doesn't import from the `common` settings - why?)