### PR TITLE
Add 'data' dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+data
 *.pyc
 *.db
 locale/*/LC_MESSAGES/django.mo


### PR DESCRIPTION
This is created by `docker-compose up -d` which sets `DJANGOPROJECT_DATA_DIR=./data`.