### PR TITLE
Fixed "data" styling in docs.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2346,7 +2346,7 @@ h2 + .list-link-soup {
 
 }
 
-dl.function, dl.class, dl.method, dl.classmethod, dl.staticmethod, dl.attribute, dl.exception {
+dl.function, dl.class, dl.method, dl.classmethod, dl.staticmethod, dl.attribute, dl.exception, dl.data {
     dt {
         font-weight: 700;
     }


### PR DESCRIPTION
I noticed on [the documentation page for `timezone.utc`](https://docs.djangoproject.com/en/3.2/ref/utils/#django.utils.timezone.utc) that it wasn't styled like the rest of the documented methods (missing bold and padding).

See screenshot:
![Screenshot_2021-05-31 Django Utils Django documentation Django](https://user-images.githubusercontent.com/6345/120245475-97dd0400-c26d-11eb-8787-22302d3fc241.png)

The fix seems easy enough but I haven't tested it locally.