### PR TITLE
Fixed h5 styling in docs.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -181,6 +181,14 @@ h4 {
     font-weight: 700;
 }
 
+h5 {
+    @include font-size(14);
+    color: $text;
+    line-height: 1.2;
+    margin: 35px 0 20px;
+    font-weight: 700;
+}
+
 tt,
 code,
 kbd,


### PR DESCRIPTION
See [#33393](https://code.djangoproject.com/ticket/33393).