### PR TITLE
Added discord to community page

### DIFF
--- a/djangoproject/templates/base_community.html
+++ b/djangoproject/templates/base_community.html
@@ -18,7 +18,9 @@
   <h2>Get Involved</h2>
   <dl class="list-links">
     <dt><a href="irc://irc.libera.chat/django">#django IRC channel</a></dt>
-    <dd>chat with other Django users</dd>
+    <dd>chat with other Django users on IRC</dd>
+    <dt><a href="https://discord.gg/xcRH6mN4fa">Django Discord</a></dt>
+    <dd>chat with other Django users on Discord</dd>
     <dt><a href="https://code.djangoproject.com/">Ticket system</a></dt>
     <dd>report bugs and make feature requests</dd>
     <dt><a href="https://dashboard.djangoproject.com/">Development dashboard</a></dt>


### PR DESCRIPTION
I'm not sure about the wording. I changed the IRC one a bit to differentiate, otherwise they would just have the same description.

I'm using an invite link for the moment - in a few weeks there should be enough activity that Discord will let us have a proper public URL, I'll submit another PR when that happens.