### PR TITLE
Refs #1064 -- Add dark mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12-alpine
+        image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ locale/*/LC_MESSAGES/django.mo
 .sass-cache/
 .coverage
 .tox
+djangoproject/cache
 djangoproject/static/js/lib/jquery-flot/examples
 djangoproject/static/css/*.map
 djangoproject/static/css/*.css

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+exclude: \/migrations\/
+default_language_version:
+  python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.3.0"
+    hooks:
+      - id: debug-statements
+      - id: detect-private-key
+      - id: file-contents-sorter
+        files: ^(requirements/\w*.txt)$
+        args: ["--ignore-case", "--unique"]
+      - id: fix-encoding-pragma
+        args: ["--remove"]
+  - repo: https://github.com/pycqa/isort
+    rev: "5.10.1"
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: "5.0.4"
+    hooks:
+      - id: flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk update \
     && apk del build-deps
 
 # install node and npm
-RUN apk add --update nodejs nodejs-npm
+RUN apk add --update nodejs npm
 
 # install pillow dependencies
 RUN apk add build-base python3-dev py-pip jpeg-dev zlib-dev
@@ -33,6 +33,7 @@ RUN apk add git
 # install dependencies
 RUN pip install --upgrade pip
 COPY ./requirements ./requirements
+COPY ./package.json ./package.json
 RUN pip install -r ./requirements/dev.txt
 RUN pip install -r ./requirements/tests.txt
 RUN pip install tox

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ To run locally, do the usual:
    ``/etc/hosts`` with your favorite editor.
 
    If you don't have admin rights but have an internet connection, you can use a
-   service like `xip.io <http://xip.io>`_. In that case, you'll also have to
+   service like `nip.io <http://nip.io>`_. In that case, you'll also have to
    update `ALLOWED_HOSTS` in `djangoproject/settings/dev.py` as well as the
    content of the `django_site` table in your database.
 

--- a/README.rst
+++ b/README.rst
@@ -394,3 +394,27 @@ Running Locally with Docker
 
     docker-compose exec web tox
     docker-compose exec web python -m manage test
+
+Pre-commit checks
+-----------------
+
+`pre-commit <https://pre-commit.com>`_ is a framework for managing pre-commit
+hooks. These hooks help to identify simple issues before committing code for
+review. By checking for these issues before code review it allows the reviewer
+to focus on the change itself, and it can also help to reduce the number CI
+runs.
+
+To use the tool, first install ``pre-commit`` and then the git hooks::
+
+.. console::
+
+    $ python3 -m pip install pre-commit
+    $ python3 -m pre_commit install
+
+On the first commit ``pre-commit`` will install the hooks, these are
+installed in their own environments and will take a short while to
+install on the first run. Subsequent checks will be significantly faster.
+If the an error is found an appropriate error message will be displayed.
+If the error was with ``isort`` then the tool will go ahead and fix them for
+you. Review the changes and re-stage for commit if you are happy with
+them.

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,13 @@ To run locally, do the usual:
     make install
 
 #. Make a directory to store the project's data (``MEDIA_ROOT``, ``DOC_BUILDS_ROOT``,
-   etc.). We'll use ``~/.djangoproject`` for example purposes.
+   etc.). We'll use ``~/.djangoproject`` for example purposes. Create a sub-directory
+   named ``conf`` inside that directory::
 
-   Create a ``secrets.json`` file in a directory named ``conf`` in that directory,
-   containing something like::
+    mkdir -p ~/.djangoproject/conf
+
+   Create a ``secrets.json`` file in the ``conf`` directory, containing something
+   like::
 
     {
       "secret_key": "xyz",

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ To run locally, do the usual:
 #. For docs (next step requires ``gettext``)::
 
     python -m manage loaddata doc_releases
-    python -m manage update_docs
+    python -m manage update_docs_and_index
 
 #. For dashboard:
 
@@ -269,7 +269,7 @@ library from ``bower.json``, you will need to commit the changes in
 Documentation search
 --------------------
 
-When running ``python -m manage update_docs`` to build all documents it will also
+When running ``python -m manage update_docs_and_index`` to build all documents it will also
 automatically index every document it builds in the search engine as well.
 In case you've already built the documents and would like to reindex the
 search index run the command::

--- a/README.rst
+++ b/README.rst
@@ -9,29 +9,33 @@ djangoproject.com source code
 
 To run locally, do the usual:
 
-#. Create a Python 3.8 virtualenv
+#. Create a Python 3.8+ virtualenv and activate it
 
 #. Install dependencies::
 
-    pip install -r requirements/dev.txt
+    python3 -m pip install -r requirements/dev.txt
     npm install
+
+   *Note: for Python 3.10+ you have to append* ``--ignore-requires-python`` *to* ``pip``
 
    Alternatively, use the make task::
 
     make install
 
-#. Make a directory to store the project's data (MEDIA_ROOT, DOC_BUILDS_ROOT,
+#. Make a directory to store the project's data (``MEDIA_ROOT``, ``DOC_BUILDS_ROOT``,
    etc.). We'll use ``~/.djangoproject`` for example purposes.
 
    Create a ``secrets.json`` file in a directory named ``conf`` in that directory,
    containing something like::
 
-    { "secret_key": "xyz",
+    {
+      "secret_key": "xyz",
       "superfeedr_creds": ["any@email.com", "some_string"],
       "db_host": "localhost",
       "db_password": "secret",
       "trac_db_host": "localhost",
-      "trac_db_password": "secret" }
+      "trac_db_password": "secret"
+    }
 
 #. Add ``export DJANGOPROJECT_DATA_DIR=~/.djangoproject`` (without the backticks)
    to your ``~/.bashrc`` (or ``~/.zshrc`` if you're using zsh, ``~/.bash_profile`` if
@@ -62,44 +66,44 @@ To run locally, do the usual:
 
     psql -d code.djangoproject < tracdb/trac.sql
 
-    ./manage.py migrate
+    python -m manage migrate
 
 #. Create a superuser::
 
-   ./manage.py createsuperuser
+    python -m manage createsuperuser
 
 #. Populate the www and docs hostnames in the django.contrib.sites app::
 
-    ./manage.py loaddata dev_sites
+    python -m manage loaddata dev_sites
 
 #. For docs (next step requires ``gettext``)::
 
-    ./manage.py loaddata doc_releases
-    ./manage.py update_docs
+    python -m manage loaddata doc_releases
+    python -m manage update_docs
 
-#. For dashboard::
+#. For dashboard:
 
    To load the latest dashboard categories and metrics::
 
-    ./manage.py loaddata dashboard_production_metrics
+    python -m manage loaddata dashboard_production_metrics
 
    Alternatively, to load a full set of sample data (takes a few minutes)::
 
-    ./manage.py loaddata dashboard_example_data
+    python -m manage loaddata dashboard_example_data
 
    Finally, make sure the loaded metrics have at least one data point (this
    makes API calls to the URLs from the metrics objects loaded above and may
    take some time depending on the metrics chosen)::
 
-    ./manage.py update_metrics
+    python -m manage update_metrics
 
-#. Point the ``www.djangoproject.localhost``, ``docs.djangoproject.localhost``,
+#. **(Optional)** Point the ``www.djangoproject.localhost``, ``docs.djangoproject.localhost``,
    and ``dashboard.djangoproject.localhost`` hostnames with your ``/etc/hosts``
    file to ``localhost``/``127.0.0.1`` by adding::
 
      127.0.0.1 docs.djangoproject.localhost www.djangoproject.localhost dashboard.djangoproject.localhost
 
-   This is unnecessary with some browsers (e.g. Opera and Chromium/Chrome) as
+   This is unnecessary with some browsers (e.g. Firefox, Opera and Chromium/Chrome) as
    they handle localhost subdomains automatically.
 
    If you're on macOS and don't feel like editing the ``/etc/hosts`` file
@@ -139,7 +143,7 @@ with those systems you should not have any problems writing tests.
 
 Our test results can be found here:
 
-    https://github.com/django/djangoproject.com/actions
+* https://github.com/django/djangoproject.com/actions
 
 For local development don't hesitate to install
 `tox <https://tox.readthedocs.io/>`_ to run the website's test suite.
@@ -148,7 +152,7 @@ Then in the root directory (next to the ``manage.py`` file) run::
 
     tox
 
-Behind the scenes, this will run the usual ``./manage.py test`` management
+Behind the scenes, this will run the usual ``python -m manage test`` management
 command with a preset list of apps that we want to test as well as
 `flake8 <https://flake8.readthedocs.io/>`_ for code quality checks. We
 collect test coverage data as part of that tox run, to show the result
@@ -172,7 +176,7 @@ Then run::
 
 or simply the usual test management command::
 
-    ./manage.py test [list of app labels]
+    python -m manage test [list of app labels]
 
 Supported browsers
 ------------------
@@ -265,12 +269,12 @@ library from ``bower.json``, you will need to commit the changes in
 Documentation search
 --------------------
 
-When running ``./manage.py update_docs`` to build all documents it will also
+When running ``python -m manage update_docs`` to build all documents it will also
 automatically index every document it builds in the search engine as well.
 In case you've already built the documents and would like to reindex the
 search index run the command::
 
-    ./manage.py update_index
+    python -m manage update_index
 
 This is also the right command to run when you work on the search feature
 itself. You can pass the ``-d`` option to try to drop the search index
@@ -287,7 +291,7 @@ from a copy of the production database and saved to the
 
 To update this file, run::
 
-    ./manage.py dumpdata dashboard --exclude dashboard.Datum --indent=4 > dashboard_production_metrics.json
+    python -m manage dumpdata dashboard --exclude dashboard.Datum --indent=4 > dashboard_production_metrics.json
 
 Translation
 -----------
@@ -328,7 +332,7 @@ the translations team will need to update Transifex as follows:
 
 1. Regenerate the English (only) .po file::
 
-    python manage.py makemessages -l en
+    python -m manage makemessages -l en
 
    (Never update alternate language .po files using makemessages. We'll update
    the English file, upload it to Transifex, then later pull the .po files with
@@ -362,11 +366,11 @@ our translation files as follows:
 
 4. Compile the messages::
 
-    python manage.py compilemessages
+    python -m manage compilemessages
 
 5. Run the test suite one more time::
 
-    python manage.py test
+    python -m manage test
 
 6. Commit and push the changes to GitHub::
 
@@ -389,4 +393,4 @@ Running Locally with Docker
 4. Run the tests::
 
     docker-compose exec web tox
-    docker-compose exec web python manage.py test
+    docker-compose exec web python -m manage test

--- a/aggregator/migrations/0003_increase_url_max_length.py
+++ b/aggregator/migrations/0003_increase_url_max_length.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aggregator', '0002_add_feed_approver_auth_group'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='feed',
+            name='public_url',
+            field=models.URLField(max_length=1023),
+        ),
+        migrations.AlterField(
+            model_name='feeditem',
+            name='link',
+            field=models.URLField(max_length=1023),
+        ),
+    ]

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -37,7 +37,7 @@ STATUS_CHOICES = (
 class Feed(models.Model):
     title = models.CharField(max_length=500)
     feed_url = models.URLField(unique=True, max_length=500)
-    public_url = models.URLField(max_length=500)
+    public_url = models.URLField(max_length=1023)
     approval_status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=PENDING_FEED)
     feed_type = models.ForeignKey(FeedType, on_delete=models.CASCADE)
     owner = models.ForeignKey(User, blank=True, null=True, related_name='owned_feeds', on_delete=models.SET_NULL)
@@ -105,7 +105,7 @@ class FeedItemManager(models.Manager):
 class FeedItem(models.Model):
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
     title = models.CharField(max_length=500)
-    link = models.URLField(max_length=500)
+    link = models.URLField(max_length=1023)
     summary = models.TextField(blank=True)
     date_modified = models.DateTimeField()
     guid = models.CharField(max_length=500, unique=True, db_index=True)

--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -53,6 +53,13 @@ class AggregatorTests(TestCase):
             approval_status=models.APPROVED_FEED,
             feed_type=self.feed_type,
         )
+        self.approved_feed_long_url, _ = models.Feed.objects.get_or_create(
+            title="Approved long URL",
+            feed_url="www.reddit.com/rss/",
+            public_url="https://www.reddit.com/r/django/?param=" + "x" * 511,
+            approval_status=models.APPROVED_FEED,
+            feed_type=self.feed_type,
+        )
         self.denied_feed, _ = models.Feed.objects.get_or_create(
             title="Denied",
             feed_url="bar.com/rss/",
@@ -68,7 +75,12 @@ class AggregatorTests(TestCase):
             feed_type=self.feed_type,
         )
 
-        for feed in [self.approved_feed, self.denied_feed, self.pending_feed]:
+        for feed in [
+            self.approved_feed,
+            self.approved_feed_long_url,
+            self.denied_feed,
+            self.pending_feed,
+        ]:
             models.FeedItem.objects.get_or_create(
                 feed=feed,
                 title="%s Item" % feed.title,

--- a/djangoproject/scss/_console-tabs.scss
+++ b/djangoproject/scss/_console-tabs.scss
@@ -15,7 +15,7 @@
             color: #555;
             border: 1px solid #ddd;
             border-top: 2px solid #ab5603;
-            border-bottom: 1px solid #fff;
+            border-bottom: 1px solid var(--white-color);
         }
     }
 

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -1,0 +1,104 @@
+@media (prefers-color-scheme: dark) {
+	body,
+	div[role="complementary"],
+	#billboard,
+	#generic,
+	.layout-tertiary,
+	.full-width.container,
+	.homepage .copy-banner {
+	  color: $text-very-light;
+	  background: $black;
+	}
+
+	[role="main"] {
+		color: $text-very-light;
+		background: $black;
+
+		h1 {
+			color: lighten($green-dark, 10%);
+		}
+	}
+
+
+	.mdzr-boxshadow {
+		[role="main"],
+		[role="complementary"],
+		.layout-tertiary,
+		.full-width {
+			box-shadow: none;
+		}
+		.sidebar-right {
+			& [role="main"],
+			& [role="complementary"] {
+				box-shadow: none;
+			}
+		}
+	}
+
+	.copy-banner, .footer, .subfooter {
+		.container {
+			background-color: initial;
+		}
+	}
+
+	a {
+	  color: lighten($green-dark, 20%);
+
+	  #docs-content & {
+		color: lighten($green-dark, 20%);
+		&.reference {
+			color: lighten($green-dark, 20%);
+			&:visited {
+				border-color: lighten($green-dark, 20%);
+			}
+			&:active,
+			&:focus,
+			&:hover {
+				color: lighten($green-dark, 20%);
+			}
+		}
+	  }
+	}
+
+
+	pre.literal-block, .literal-block {
+		border: 1px solid #343940;
+		background: #343940;
+		color: $white-dark;
+	}
+
+	code {
+		color: $white-dark;
+	}
+
+	table.django-supported-versions, t
+	table.django-unsupported-versions {
+		color: $green-dark;
+	}
+
+	blockquote {
+		background-color: $green-dark;
+	}
+
+	form {
+		select, textarea {
+			background: $black;
+			color: $white-dark;
+		}
+		input {
+			&[type="search"],
+			&[type="text"],
+			&[type="email"],
+			&[type="password"],
+			&[type="number"],
+			&[type="url"] {
+				background: $black;
+				color: $white-dark;
+			}
+		}
+	}
+
+	.cta, a.cta {
+		background-color: $green-dark;
+	}
+  }

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -1,104 +1,189 @@
-@media (prefers-color-scheme: dark) {
-	body,
-	div[role="complementary"],
-	#billboard,
-	#generic,
-	.layout-tertiary,
-	.full-width.container,
-	.homepage .copy-banner {
-	  color: $text-very-light;
-	  background: $black;
+// default theme: light
+:root {
+	--body-fg: #{$text};
+	--body-bg: #{$white};
+
+	--menu: #{$white};
+
+	--text-l10: #{$text-l10};
+	--text-l20: #{$text-l20};
+	--text-light: #{$text-light};
+
+	--primary: #{$green-medium};
+	--primary-accent: #{$green-medium-dark};
+
+	--secondary: #{$green};
+	--secondary-accent: #{$green-very-light};
+	--secondary-accent-l5: #{$green-very-light-l5};
+	--secondary-accent-l10: #{$green-very-light-l10};
+
+	--link-color: #{$green};
+	--sidebar-bg: #{$white-dark};
+
+	--code-bg: #{$white-dark};
+	--code-fg: #{$green-dark};
+	--code-border: #EAEAEA;
+
+	--warning: #{$warning-yellow};
+	--warning-dark: #{$warning-dark-yellow};
+	--warning-dark-d50: #{$warning-dark-yellow-d50};
+
+	--hairline-color: #{$gray-line};
+	--dark-hairline-color: #{$gray-medium};
+
+	--error-fg: #{$red};
+	--error-light: #{$red-light};
+	--error-light-l10: #{$red-light-l10};
+	--error-dark: #{$red-dark};
+	--error-dark-l10: #{$red-dark-l10};
+
+	--cta-color-accent: #{$green-very-light};
+	--table-color: var(--body-fg);
+	--white-color: #fff;
+
+}
+
+
+.dark-mode {
+	--body-fg: #C1CAD2;
+	--body-bg: #{$black};
+
+	--text-l10: #{$green-light};
+	--text-l20: #{$green-very-light};
+	--text-light: #{$text-light-l20};
+
+	--primary: #{$green};
+	--primary-accent: #{$green-light};
+
+	--secondary-accent: #{$green-medium};
+
+	--link-color: #{$green-light};
+	--sidebar-bg: #{$black-light-5};
+
+	--code-bg: #{$gray-dark};
+	--code-fg: #{$white-dark};
+	--code-border: #{$black-light-5};
+
+	--hairline-color: #{$gray-line};
+	--dark-hairline-color: #{gray-medium-l10};
+
+	--error-light: #E46767;
+	--error-dark: #E46767;
+
+	--table-color: var(--body-bg);
+	--cta-color-accent: #{$black};
+	--white-color: #{$black};
+
+
+	.img-release {
+		filter: invert(1);
 	}
 
-	[role="main"] {
-		color: $text-very-light;
-		background: $black;
+	.homepage {
+		.copy-banner {
+			background: var(--white-color);
+		}
+	}
 
+	.copy-banner {
+		background: darken($green, 10%);
+
+		p,
 		h1 {
-			color: lighten($green-dark, 10%);
-		}
-	}
+			color: $green-very-light;
 
+			@include respond-min(768px) {
+				color: $green-very-light;
+			}
 
-	.mdzr-boxshadow {
-		[role="main"],
-		[role="complementary"],
-		.layout-tertiary,
-		.full-width {
-			box-shadow: none;
-		}
-		.sidebar-right {
-			& [role="main"],
-			& [role="complementary"] {
-				box-shadow: none;
+			a {
+				color: $green-very-light;
 			}
 		}
 	}
 
-	.copy-banner, .footer, .subfooter {
-		.container {
-			background-color: initial;
-		}
-	}
+	table.django-supported-versions,
+	table.django-unsupported-versions {
+		a {
+			color: $black;
 
-	a {
-	  color: lighten($green-dark, 20%);
-
-	  #docs-content & {
-		color: lighten($green-dark, 20%);
-		&.reference {
-			color: lighten($green-dark, 20%);
-			&:visited {
-				border-color: lighten($green-dark, 20%);
-			}
 			&:active,
 			&:focus,
 			&:hover {
-				color: lighten($green-dark, 20%);
-			}
-		}
-	  }
-	}
-
-
-	pre.literal-block, .literal-block {
-		border: 1px solid #343940;
-		background: #343940;
-		color: $white-dark;
-	}
-
-	code {
-		color: $white-dark;
-	}
-
-	table.django-supported-versions, t
-	table.django-unsupported-versions {
-		color: $green-dark;
-	}
-
-	blockquote {
-		background-color: $green-dark;
-	}
-
-	form {
-		select, textarea {
-			background: $black;
-			color: $white-dark;
-		}
-		input {
-			&[type="search"],
-			&[type="text"],
-			&[type="email"],
-			&[type="password"],
-			&[type="number"],
-			&[type="url"] {
-				background: $black;
-				color: $white-dark;
+				color: $gray-medium;
 			}
 		}
 	}
 
-	.cta, a.cta {
-		background-color: $green-dark;
+	::-webkit-input-placeholder {
+		/* Chrome/Opera/Safari */
+		color: $gray-medium-l10;
 	}
-  }
+
+	::-moz-placeholder {
+		/* Firefox 19+ */
+		color: $gray-medium-l10;
+	}
+
+	:-ms-input-placeholder {
+		/* IE 10+ */
+		color: $gray-medium-l10;
+	}
+
+	:-moz-placeholder {
+		/* Firefox 18- */
+		color: $gray-medium-l10;
+	}
+
+	[role="contentinfo"] {
+		background: darken($green, 10%);
+	}
+}
+
+.img-release {
+	filter: invert(0);
+}
+
+label[for="toggle"] {
+	padding: 18px 0px;
+	display: inline-block;
+	color: var(--menu);
+
+	@include respond-min(768px) {
+		padding: 18px 10px;
+	}
+}
+
+#toggle[role="switch"] {
+	padding: 0;
+	width: 4rem;
+	height: 2rem;
+	border: 0;
+	border-radius: 1rem;
+	margin-left: 0.5rem;
+	background-color: lighten($gray-medium, 20);
+
+	&[aria-checked="true"] {
+		background-color: $white-dark;
+	}
+
+	&[aria-checked="false"] :last-child {
+		padding-left: .2em;
+	}
+
+	&[aria-checked="true"] :last-child,
+	&[aria-checked="false"] :first-child {
+		background: $black-light-5;
+	}
+
+	span {
+		display: inline;
+		color: $black-light-5;
+		font-weight: 600;
+		padding: 0.1rem;
+		pointer-events: none;
+		border-radius: 2rem;
+	}
+
+}
+

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -279,6 +279,23 @@ html[data-theme="light"] .theme-toggle svg.theme-icon-when-light {
 	display: block;
 }
 
+/* Fully hide screen reader text so we only show the one matching the current theme */
+.theme-toggle .visually-hidden {
+    display: none;
+}
+
+html[data-theme="auto"] .theme-toggle .theme-label-when-auto {
+    display: block;
+}
+
+html[data-theme="dark"] .theme-toggle .theme-label-when-dark {
+    display: block;
+}
+
+html[data-theme="light"] .theme-toggle .theme-label-when-light {
+    display: block;
+}
+
 .visually-hidden {
 	position: absolute;
 	width: 1px;
@@ -291,4 +308,19 @@ html[data-theme="light"] .theme-toggle svg.theme-icon-when-light {
 	border: 0;
 	color: var(--body-fg);
 	background-color: var(--body-bg);
+}
+
+.mobile-toggle {
+	width: 45px;
+	float: right;
+
+	@include respond-min(768px) {
+		display: none;
+	}
+}
+
+[role="banner"] .nav-menu-on li:last-child {
+	@include respond-max(768px) {
+		display: none;
+	}
 }

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -1,4 +1,5 @@
 // default theme: light
+html[data-theme="light"],
 :root {
 	--body-fg: #{$text};
 	--body-bg: #{$white};
@@ -43,8 +44,104 @@
 
 }
 
+@media (prefers-color-scheme: dark) {
+	:root {
+		--body-fg: #C1CAD2;
+		--body-bg: #{$black};
 
-.dark-mode {
+		--text-l10: #{$green-light};
+		--text-l20: #{$green-very-light};
+		--text-light: #{$text-light-l20};
+
+		--primary: #{$green};
+		--primary-accent: #{$green-light};
+
+		--secondary-accent: #{$green-medium};
+
+		--link-color: #{$green-light};
+		--sidebar-bg: #{$black-light-5};
+
+		--code-bg: #{$gray-dark};
+		--code-fg: #{$white-dark};
+		--code-border: #{$black-light-5};
+
+		--hairline-color: #{$gray-line};
+		--dark-hairline-color: #{gray-medium-l10};
+
+		--error-light: #E46767;
+		--error-dark: #E46767;
+
+		--table-color: var(--body-bg);
+		--cta-color-accent: #{$black};
+		--white-color: #{$black};
+	}
+
+	body .img-release {
+		filter: invert(1);
+	}
+
+	body .homepage {
+		.copy-banner {
+			background: var(--white-color);
+		}
+	}
+
+	body .copy-banner {
+		background: darken($green, 10%);
+
+		p,
+		h1 {
+			color: $green-very-light;
+
+			@include respond-min(768px) {
+				color: $green-very-light;
+			}
+
+			a {
+				color: $green-very-light;
+			}
+		}
+	}
+
+	body table.django-supported-versions,
+	body table.django-unsupported-versions {
+		a {
+			color: $black;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: $gray-medium;
+			}
+		}
+	}
+
+	body ::-webkit-input-placeholder {
+		/* Chrome/Opera/Safari */
+		color: $gray-medium-l10;
+	}
+
+	body ::-moz-placeholder {
+		/* Firefox 19+ */
+		color: $gray-medium-l10;
+	}
+
+	body :-ms-input-placeholder {
+		/* IE 10+ */
+		color: $gray-medium-l10;
+	}
+
+	body :-moz-placeholder {
+		/* Firefox 18- */
+		color: $gray-medium-l10;
+	}
+
+	body [role="contentinfo"] {
+		background: darken($green, 10%);
+	}
+}
+
+html[data-theme="dark"] {
 	--body-fg: #C1CAD2;
 	--body-bg: #{$black};
 
@@ -144,46 +241,54 @@
 	filter: invert(0);
 }
 
-label[for="toggle"] {
-	padding: 18px 0px;
-	display: inline-block;
-	color: var(--menu);
 
-	@include respond-min(768px) {
-		padding: 18px 10px;
-	}
-}
-
-#toggle[role="switch"] {
+/* THEME SWITCH */
+.theme-toggle {
+	cursor: pointer;
+	border: none;
 	padding: 0;
-	width: 4rem;
-	height: 2rem;
-	border: 0;
-	border-radius: 1rem;
-	margin-left: 0.5rem;
-	background-color: lighten($gray-medium, 20);
-
-	&[aria-checked="true"] {
-		background-color: $white-dark;
-	}
-
-	&[aria-checked="false"] :last-child {
-		padding-left: .2em;
-	}
-
-	&[aria-checked="true"] :last-child,
-	&[aria-checked="false"] :first-child {
-		background: $black-light-5;
-	}
-
-	span {
-		display: inline;
-		color: $black-light-5;
-		font-weight: 600;
-		padding: 0.1rem;
-		pointer-events: none;
-		border-radius: 2rem;
-	}
-
+	background: transparent;
+	vertical-align: middle;
+	padding: 20px 10px;
 }
 
+.theme-toggle svg {
+	vertical-align: middle;
+	height: 2rem;
+	width: 2rem;
+	display: none;
+}
+
+/* ICONS */
+.theme-toggle svg.theme-icon-when-auto,
+.theme-toggle svg.theme-icon-when-dark,
+.theme-toggle svg.theme-icon-when-light {
+	fill: var(--menu);
+	color: $green-dark;
+}
+
+html[data-theme="auto"] .theme-toggle svg.theme-icon-when-auto {
+	display: block;
+}
+
+html[data-theme="dark"] .theme-toggle svg.theme-icon-when-dark {
+	display: block;
+}
+
+html[data-theme="light"] .theme-toggle svg.theme-icon-when-light {
+	display: block;
+}
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+	color: var(--body-fg);
+	background-color: var(--body-bg);
+}

--- a/djangoproject/scss/_dashboard.scss
+++ b/djangoproject/scss/_dashboard.scss
@@ -11,7 +11,7 @@
     min-width: 240px;
     padding: 0 20px 10px 20px;
     margin: 10px 10px 20px 10px;
-    border: 1px solid $gray-line;
+    border: 1px solid var(--hairline-color);
     border-radius: 4px;
     display: inline-block;
     position: relative;
@@ -23,18 +23,18 @@
         font-weight: 400;
         display: block;
         text-align: left;
-        color: $text;
+        color: var(--body-fg);
         a {
-            color: $text;
+            color: var(--link-color);
 
             &:visited {
-                color: lighten($text, 10%);
+                color: var(--text-l10);
             }
 
             &:active,
             &:focus,
             &:hover {
-                color: lighten($text, 20%);
+                color: var(--text-l20);
             }
         }
     }
@@ -55,19 +55,19 @@
         pointer-events: none;
 
         a {
-            color: $text;
+            color: var(--body-fg);
             text-decoration: none;
             pointer-events: auto;
             z-index: 10;
 
             &:visited {
-                color: lighten($text, 10%);
+                color: var(--text-l10);
             }
 
             &:active,
             &:focus,
             &:hover {
-                color: lighten($text, 20%);
+                color: var(--text-l20);
             }
         }
         .timestamp {
@@ -89,7 +89,7 @@
 
 .graph-wrapper {
     border-radius: 4px;
-    border: 1px solid $gray-line;
+    border: 1px solid var(--hairline-color);
     padding: 20px;
     margin: 20px 0;
 }

--- a/djangoproject/scss/_pygments.scss
+++ b/djangoproject/scss/_pygments.scss
@@ -3,18 +3,18 @@
 pre.literal-block,
 .literal-block {
     @include font-size(14);
-    border: 1px solid #EAEAEA;
-    background: #F4F4F4;
-    background: #f8f8f8; overflow: auto;
+    border: 1px solid var(--code-border);
+    background: var(--code-bg);
+	overflow: auto;
     border-radius: 4px;
     margin: 25px 0;
     padding: 10px 20px;
-    color: $green-dark;
+    color: var(--code-fg);
 }
 
 .code-block-caption {
-    background: $green-very-light;
-    color: $green-dark;
+    background: var(--secondary-accent);
+    color: var(--code-fg);
     @include monospace;
     font-size: 1em;
     padding: 5px 20px;
@@ -29,8 +29,8 @@ pre.literal-block,
 
 // For Django 2.0 docs and older.
 .snippet-filename {
-    background: $green-very-light;
-    color: $green-dark;
+    background: var(--secondary-accent);
+    color: var(--code-fg);
     @include monospace;
     font-size: 1em;
     padding: 5px 20px;
@@ -45,9 +45,9 @@ pre.literal-block,
 
 .highlight {
     @include font-size(14);
-    border: 1px solid #EAEAEA;
-    background: #F4F4F4;
-    background: #f8f8f8; overflow: auto;
+    border: 1px solid var(--code-border);
+    background: var(--code-bg);
+	overflow: auto;
     border-radius: 4px;
     margin: 25px 0;
 
@@ -57,7 +57,7 @@ pre.literal-block,
 
     li {
         margin-top: 0;
-        border-left: 1px solid #EAEAEA;
+        border-left: 1px solid var(--code-border);
         padding: 0 0 2px 15px;
 
         &:first-child {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -15,8 +15,8 @@ CSS rendered with Libsass 0.7.0
 body {
     @include serif;
     @include font-size(18);
-    background: #f8f8f8;
-    color: $text;
+    background: var(--sidebar-bg);
+    color: var(--body-fg);
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -32,26 +32,26 @@ body {
     }
 }
 a {
-    color: $text;
+    color: var(--link-color);
     text-decoration: underline;
     -webkit-tap-highlight-color: transparent;
 
     &:visited {
-        color: lighten($text, 10%);
+        color: var(--text-l10);
     }
 
     &:active,
     &:focus,
     &:hover {
-        color: lighten($text, 20%);
+        color: var(--text-l20);
     }
 }
 
 ::selection { // Text Selection Colors
-    background: $green-very-light;
+    background: var(--secondary-accent);
 }
 ::-moz-selection {
-    background: $green-very-light;
+    background: var(--secondary-accent);
 }
 ol li, ul li { //list style
     margin-top: 10px;
@@ -96,7 +96,7 @@ h6 {
 }
 h1 {
     @include font-size(28);
-    color: #fff;
+    color: var(--white-color);
     letter-spacing: -1px;
     line-height: 1.1;
     @include respond-min(768px) {
@@ -104,13 +104,13 @@ h1 {
     }
 
     .layout-secondary & {
-        color: $text;
+        color: var(--body-fg);
     }
 
     [role="main"] & {
         @include font-size(32);
         margin: 40px 0px 30px;
-        color: $text;
+        color: var(--body-fg);
     }
 
     [role="complementary"] & {
@@ -122,7 +122,7 @@ h2 {
     [role="complementary"] &,
     .layout-secondary & {
         @include font-size(20);
-        border-bottom: 1px solid $gray-line;
+        border-bottom: 1px solid var(--hairline-color);
         font-weight: 400;
         padding-bottom: 15px;
         margin-top: 30px;
@@ -150,7 +150,7 @@ h2 {
 h3 {
     @include font-size(20);
     font-weight: 700;
-    color: $text;
+    color: var(--body-fg);
     line-height: 1.2;
     margin: 35px 0 20px;
 
@@ -169,13 +169,13 @@ h3 {
 
     [role="complementary"] & {
         @include font-size(18);
-        border-bottom: 1px solid $gray-line;
+        border-bottom: 1px solid var(--hairline-color);
     }
 }
 
 h4 {
     @include font-size(16);
-    color: $text;
+    color: var(--body-fg);
     line-height: 1.2;
     margin: 35px 0 20px;
     font-weight: 700;
@@ -183,7 +183,7 @@ h4 {
 
 h5 {
     @include font-size(14);
-    color: $text;
+    color: var(--body-fg);
     line-height: 1.2;
     margin: 35px 0 20px;
     font-weight: 700;
@@ -195,7 +195,7 @@ kbd,
 pre,
 samp {
     @include monospace;
-    color: $green-dark;
+    color: var(--code-fg);
     font-size: 1em;
 }
 
@@ -209,7 +209,7 @@ span.pre {
 
 a:hover, a:active, a:focus {
     tt {
-        color: lighten($text, 20%);
+        color: var(--text-l20);
     }
 }
 
@@ -226,9 +226,9 @@ ul {
 
 // TODO: most of this is copy/pasted from .admonition. We should factor out the common bits
 blockquote {
-    background: $white;
+    background: var(--body-bg);
     padding: 15px 20px 15px 70px;
-    border: 1px solid $green-very-light;
+    border: 1px solid var(--secondary-accent);
     border-radius: 4px;
     margin: 25px 0;
     position: relative;
@@ -254,7 +254,7 @@ blockquote {
 
 [role="main"] {
     //Main column. Left aligned by default. See /styleguide for explanation.
-    background: #fff;
+    background: var(--white-color);
     padding: 1px 10px 40px;
     @include respond-min(768px) {
         min-height: 800px;
@@ -267,7 +267,7 @@ blockquote {
         width: 60%;
         .mdzr-boxshadow & {
             border: none;
-            box-shadow: 0px 0px 0 0 #fff, 0px 0px 0 0 #fff, 460px 0 0 0 #fff, 1000px 0 0 0 #fff, 0px 600px 0 0px #fff, 460px 600px 0 0px #fff;
+            box-shadow: 0px 0px 0 0 var(--white-color), 0px 0px 0 0 var(--white-color), 460px 0 0 0 var(--white-color), 1000px 0 0 0 var(--white-color), 0px 600px 0 0px var(--white-color), 460px 600px 0 0px var(--white-color);
             padding-left: 4%;
             padding-right: 0;
             width: 63%;
@@ -277,7 +277,7 @@ blockquote {
             float: left;
             .mdzr-boxshadow & {
                 border: none;
-                box-shadow: 0px 0px 0 0 #fff, 0px 0px 0 0 #fff, -460px 0 0 0 #fff, -1000px 0 0 0 #fff, 0px 600px 0 0px #fff, -460px 600px 0 0px #fff;
+                box-shadow: 0px 0px 0 0 var(--white-color), 0px 0px 0 0 var(--white-color), -460px 0 0 0 var(--white-color), -1000px 0 0 0 var(--white-color), 0px 600px 0 0px var(--white-color), -460px 600px 0 0px var(--white-color);
                 padding-left: 0;
                 width: 62%;
                 padding-right: 4%;
@@ -302,7 +302,7 @@ blockquote {
 
     .section {
         padding-bottom: 40px;
-        border-bottom: 1px solid $gray-line;
+        border-bottom: 1px solid var(--hairline-color);
         &:last-of-type {
             padding-bottom: 0;
             border-bottom: 0;
@@ -322,7 +322,7 @@ blockquote {
         padding: 0;
         max-width: none;
         border-bottom: 1px solid #ddd;
-        background: #fff;
+        background: var(--white-color);
     }
     // High-level class denoting full-width layout
     @include clearfix;
@@ -366,7 +366,7 @@ blockquote {
                 padding: 10px 40px 10px 0;
                 font-size: 18px;
                 border-bottom: 0;
-                color: $green-medium;
+                color: var(--primary);
 
                 .collapsing-icon {
                     font-size: 10px;
@@ -394,7 +394,7 @@ blockquote {
 }
 .layout-tertiary {
     // Tertiary (white) content area on full-width pages
-    background: #fff;
+    background: var(--white-color);
     border-top: 1px solid #ddd;
     padding: 20px 10px 50px;
     .mdzr-boxshadow & {
@@ -411,7 +411,7 @@ blockquote {
 
     &.sidebar-right {
         .mdzr-boxshadow & {
-            box-shadow: -1200px 0 0 0px #fff;
+            box-shadow: -1200px 0 0 0px var(--white-color);
         }
     }
 }
@@ -448,7 +448,7 @@ blockquote {
 
     .meta {
         @include font-size(13);
-        color: $green-medium;
+        color: var(--primary);
         font-weight: 700;
         width: auto;
         float: left;
@@ -469,7 +469,7 @@ blockquote {
         @include font-size(40);
         @include sans-serif;
         background: url(../img/logo-django.png) 0 0 no-repeat;
-        color: #FFF;
+        color: var(--white-color);
         display: block;
         float: left;
         font-weight: 700;
@@ -493,7 +493,7 @@ blockquote {
         @include font-size(20);
         background: $green-dark;
         border-radius: 23px;
-        color: #fff;
+        color: var(--menu);
         cursor: pointer;
         display: block;
         float: right;
@@ -509,7 +509,7 @@ blockquote {
         }
 
         &:active {
-            color: $green-medium;
+            color: var(--primary);
         }
 
         span {
@@ -537,7 +537,7 @@ blockquote {
         }
 
         &.active {
-            max-height: 500px;
+            max-height: 580px;
         }
     }
 
@@ -579,24 +579,38 @@ blockquote {
             }
 
             &.active a {
-                color: $green-medium;
+                color: var(--primary);
             }
         }
 
         a {
-            color: #fff;
+            color: var(--menu);
             display: block;
             padding: 20px 0px;
             text-decoration: none;
 
             &:active, &:hover {
-                color: $green-very-light;
+                color: var(--secondary-accent);
             }
 
             @include respond-min(768px) {
                 padding: 20px 10px;
             }
         }
+
+		span {
+			display: inline-block;
+			padding: 20px 10px;
+			color: var(--white-color);
+
+			&:active, &:hover {
+                color: var(--secondary-accent);
+            }
+
+            @include respond-min(768px) {
+                padding: 20px 10px;
+            }
+		}
 
         .nav-primary {
             @include respond-min(768px) {
@@ -622,7 +636,7 @@ blockquote {
     p {
         @include serif;
         @include font-size(18);
-        color: #fff;
+        color: var(--white-color);
         left: -9999px;
         line-height: 1.5;
         padding: 0 0 10px;
@@ -637,7 +651,7 @@ blockquote {
 }
 .copy-banner {
     // Large green callout at the top of the page
-    background: $green-medium;
+    background: var(--primary);
     padding: 1px 10px;
 
     @include respond-min(768px) {
@@ -648,7 +662,7 @@ blockquote {
     h1 {
         @include sans-serif;
         @include font-size(24);
-        color: $green-very-light;
+        color: var(--secondary-accent);
         font-weight: 300;
         line-height: 1.3;
         padding: 1px 0 6px;
@@ -656,21 +670,21 @@ blockquote {
 
         em {
             font-style: normal;
-            color: white;
+            color: var(--menu);
         }
 
         @include respond-min(768px) {
             @include font-size(32);
 
             margin: .35em 0 .35em;
-            color: $green-very-light;
+            color: var(--secondary-accent);
             padding: 1px 0 6px;
 
         }
 
         a {
             font-weight: 300;
-            color: $green-very-light;
+            color: var(--secondary-accent);
         }
 
         a.cta, .cta {
@@ -682,65 +696,65 @@ blockquote {
     a.cta, .cta {
         margin: 15px 0;
         padding: 0.4em 1.5em 0.5em;
-        background: $green-medium-dark;
+        background: var(--primary-light);
         &:hover {
             background: lighten($green-medium-dark, 4%);
         }
 
         background: none;
-        border: 1px solid $green-very-light;
-        color: $green-very-light;
+        border: 1px solid var(--secondary-accent);
+        color: var(--cta-color-accent);
         font-weight: 400;
         em {
-            color: white;
+            color: var(--white-color);
         }
         &:hover {
-            background: $white;
-            color: $green;
-            border-color: $white;
+            background: var(--body-bg);
+            color: var(--secondary);
+            border-color: var(--body-bg);
             em {
-                color: $green;
+                color: var(--secondary);
             }
         }
 
         &.white {
-            background: $white;
-            color: $green;
+            background: var(--body-bg);
+            color: var(--secondary);
             font-weight: 700;
             border: 0;
             &:hover {
-                background: #fff;
+                background: var(--white-color);
             }
         }
     }
 
     .homepage & {
         padding: 50px 0;
-        background: white;
+        background: var(--white-color);
         text-align: center;
-        border-bottom: 1px solid $gray-line;
+        border-bottom: 1px solid var(--hairline-color);
         p {
             max-width: 700px;
             margin-left: auto;
             margin-right: auto;
             margin: 1em auto .5em;
-            color: $text;
+            color: var(--body-fg);
             @include font-size(36);
             &.small {
-                color: $text-light;
+                color: var(--text-light);
                 margin: 2em auto 1em;
                 @include font-size(14);
             }
             em {
-                color: $text;
+                color: var(--body-fg);
             }
         }
         a.cta, .cta {
             display: inline-block;
             padding: 1em 50px 1.1em;
             margin-bottom: 40px;
-            background: $green-medium;
-            color: white;
+            background: var(--primary);
+            color: var(--white-color);
             border: 0;
             font-weight: 700;
             &:hover {
@@ -796,7 +810,7 @@ blockquote {
 [role="alert"] {
     //Announcement banner above the footer.
     clear: both;
-    background: $white;
+    background: var(--body-bg);
     position: relative;
     box-shadow: 0 -2px 8px 0 rgba(0, 0, 0, 0.05);
 
@@ -813,7 +827,7 @@ blockquote {
         @include clearfix;
         dt {
             i.icon {
-                color: $green;
+                color: var(--secondary);
                 margin-right: 8px;
             }
         }
@@ -846,7 +860,7 @@ blockquote {
     @include clearfix;
     @include sans-serif;
     position: relative;
-    background: $green-medium;
+    background: var(--primary);
     clear: both;
     margin-top: 0px;
 
@@ -889,8 +903,8 @@ blockquote {
 
     h2 {
         @include font-size(16);
-        border-top: 1px solid $gray-line;
-        color: #fff;
+        border-top: 1px solid var(--hairline-color);
+        color: var(--menu);
         font-weight: 700;
         margin-top: 20px;
         padding: 30px 0 10px;
@@ -913,7 +927,7 @@ blockquote {
         }
 
         a {
-            color: $white;
+            color: var(--menu);
             text-decoration: none;
 
             &:hover,
@@ -928,7 +942,7 @@ blockquote {
         background: $green-dark;
         margin-top: 20px;
         padding: 10px 0 30px;
-        color: $green-medium-dark;
+        color: var(--primary-accent);
 
         .footer-logo {
             float: left;
@@ -973,7 +987,7 @@ blockquote {
 
     .thanks {
         @include font-size(12);
-        color: $green-medium-dark;
+        color: var(--primary-accent);
         margin: 0;
         padding: 0;
         @include respond-min(768px) {
@@ -1027,7 +1041,7 @@ blockquote {
 
         a.in-kind-donors {
             @include font-size(20);
-            color: $green-medium-dark;
+            color: var(--primary-accent);
         }
 
         a.threespot, a.andrevv {
@@ -1068,7 +1082,7 @@ blockquote {
         }
 
         a {
-            color: $green-medium-dark;
+            color: var(--primary-accent);
         }
     }
 }
@@ -1096,10 +1110,10 @@ blockquote {
     font-weight: 700;
     -webkit-appearance: none;
     -moz-appearance: none;
-    background: $green-medium;
+    background: var(--primary);
     border: none;
     border-radius: 5px;
-    color: #fff;
+    color: var(--white-color);
     display: block;
     -webkit-font-smoothing: subpixel-antialiased;
     -moz-osx-font-smoothing: auto;
@@ -1113,7 +1127,7 @@ blockquote {
     }
 
     em {
-        color: $green-very-light;
+        color: var(--cta-color-accent);
         font-style: normal;
     }
 
@@ -1141,8 +1155,8 @@ blockquote {
     &.outline {
         // Outline button for less-dominant CTA
         background: none;
-        border: 1px solid $gray-line;
-        color: $gray-medium;
+        border: 1px solid var(--hairline-color);
+        color: var(--dark-hairline-color);
         font-weight: 400;
 
         &.inline {
@@ -1155,17 +1169,17 @@ blockquote {
         }
 
         &:hover {
-            border-color: $green;
-            color: $green;
+            border-color: var(--secondary);
+            color: var(--secondary);
             em {
-                color: $green;
+                color: var(--secondary);
             }
         }
         &:active {
-            border-color: $green-medium;
-            color: $green-medium;
+            border-color: var(--primary);
+            color: var(--primary);
             em {
-                color: $green-medium;
+                color: var(--primary);
             }
         }
     }
@@ -1241,7 +1255,7 @@ blockquote {
 }
 .blue {
     // overide blue color class
-    color: $green;
+    color: var(--secondary);
 }
 .label {
     // Label style associated with forms and other global elements.
@@ -1306,8 +1320,8 @@ blockquote {
 }
 
 .codedump {
-    background: #f8f8f8;
-    border: 1px solid $gray-line;
+    background: var(--code-bg);
+    border: 1px solid var(--hairline-color);
     padding: 10px;
     border-radius: 4px;
     @include sans-serif;
@@ -1325,7 +1339,7 @@ blockquote {
 
     li {
         @include font-size(18);
-        border-top: 1px solid $gray-line;
+        border-top: 1px solid var(--hairline-color);
         display: block;
         line-height: 1.3;
         margin: 0;
@@ -1382,7 +1396,7 @@ blockquote {
 
     a {
         background: $green-light;
-        color: $white;
+        color: var(--body-bg);
         display: inline-block;
         line-height: 1.2;
         margin: 0;
@@ -1392,8 +1406,8 @@ blockquote {
         &:hover,
         &:active,
         &:focus {
-            background-color: $green-medium;
-            color: #fff;
+            background-color: var(--primary);
+            color: var(--white-color);
         }
     }
 }
@@ -1409,7 +1423,7 @@ blockquote {
     }
 
     li {
-        border-top: 1px solid $gray-line;
+        border-top: 1px solid var(--hairline-color);
         margin-top: 35px;
         padding-top: 10px;
 
@@ -1421,15 +1435,15 @@ blockquote {
 
         &.unpublished,
         &.unpublished * {
-            color: $gray-medium;
+            color: var(--dark-hairline-color);
         }
     }
 
     .meta {
         margin-top: 10px;
-        color: $gray-medium;
+        color: var(--dark-hairline-color);
         a:link {
-            color: $text-light;
+            color: var(--text-light);
             text-decoration: underline;
         }
     }
@@ -1447,7 +1461,7 @@ blockquote {
     }
 
     li {
-        border-top: 1px solid $gray-line;
+        border-top: 1px solid var(--hairline-color);
         margin-top: 20px;
         padding-top: 20px;
         @include respond-min(1024px) {
@@ -1549,7 +1563,7 @@ blockquote {
     @include sans-serif;
     @include clearfix;
     @include font-size(16);
-    border-top: 1px solid $gray-line;
+    border-top: 1px solid var(--hairline-color);
     list-style: none;
     margin: 20px 0 0;
     padding: 20px 0 10px;
@@ -1588,17 +1602,17 @@ h2 + .list-link-soup {
 
     dt {
         @include font-size(24);
-        border-top: 1px solid $gray-line;
+        border-top: 1px solid var(--hairline-color);
         padding-top: 25px;
     }
 
     i {
-        color: $white;
+        color: var(--body-bg);
         margin-right: 10px;
         width: 40px;
         height: 40px;
         border-radius: 25px;
-        background: $green;
+        background: var(--secondary);
         line-height: 1.68em;
         display: inline-block;
         text-align: center;
@@ -1656,9 +1670,9 @@ h2 + .list-link-soup {
 
             // Border Radius Enabled
             .mdzr-borderradius & {
-                background: $green-medium;
+                background: var(--primary);
                 border-radius: 100px;
-                color: #fff;
+                color: var(--white-color);
             }
 
             // SVG Enabled
@@ -1751,13 +1765,13 @@ h2 + .list-link-soup {
         }
 
         i {
-                color: $white;
+                color: var(--body-bg);
                 margin-right: 10px;
                 width: 40px;
                 height: 40px;
                 top: 10px;
                 border-radius: 20px;
-                background: $green;
+                background: var(--secondary);
                 display: inline-block;
                 text-align: center;
                 @include font-size(24);
@@ -1829,7 +1843,7 @@ h2 + .list-link-soup {
 
 .list-collapsing {
     // reusable accordion style collapsing list, as seen on the Get Started Page. 'Expand/Collapse All' toggle is generated by the javascript. H2 is used for label, and 'collapsing-content' class is used to identify all content that should expand and collapse onclick.
-    border-bottom: 1px solid $gray-line;
+    border-bottom: 1px solid var(--hairline-color);
     list-style: none;
     margin: 30px 0;
     padding: 0;
@@ -1838,7 +1852,7 @@ h2 + .list-link-soup {
     &.active {
 
         > li {
-            border-top: 1px solid $gray-line;
+            border-top: 1px solid var(--hairline-color);
             margin: 0;
             padding: 0;
 
@@ -1863,7 +1877,7 @@ h2 + .list-link-soup {
             &:hover,
             &:focus,
             &:active {
-                color: lighten($text, 20%);
+                color: var(--text-l20);
                 outline: none;
             }
 
@@ -1909,7 +1923,7 @@ h2 + .list-link-soup {
     padding: 0;
 
     li {
-        border-top: 1px solid $gray-line;
+        border-top: 1px solid var(--hairline-color);
         margin-top: 20px;
         padding-top: 40px;
         @include respond-min(768px) {
@@ -1930,7 +1944,7 @@ h2 + .list-link-soup {
         &:hover,
         &:active,
         &:focus {
-            color: $text-light;
+            color: var(--text-light);
         }
 
         &.link-readmore {
@@ -2080,9 +2094,9 @@ h2 + .list-link-soup {
 .note,
 .admonition,
 .help-block {
-        background: $white;
+        background: var(--body-bg);
         padding: 15px 20px 15px 70px;
-        border: 1px solid $green-very-light;
+        border: 1px solid var(--secondary-accent);
         border-radius: 4px;
         margin: 25px 0;
         position: relative;
@@ -2112,8 +2126,8 @@ h2 + .list-link-soup {
             }
         }
         &.warning {
-            background-color: $warning-yellow;
-            border-color: $warning-dark-yellow;
+            background-color: var(--warning);
+            border-color: var(--warning-dark);
             .admonition-title::before {
                 color: #E9BD46;
                 content: $fa-var-exclamation-triangle;
@@ -2143,8 +2157,8 @@ h2 + .list-link-soup {
     @include clearfix;
     font-weight: 700;
 
-    border-top: 1px solid $gray-line;
-    border-bottom: 1px solid $gray-line;
+    border-top: 1px solid var(--hairline-color);
+    border-bottom: 1px solid var(--hairline-color);
     padding: 20px 0;
     margin-top: 2em;
 
@@ -2201,15 +2215,15 @@ h2 + .list-link-soup {
         display: none;
         margin: 0 3px;
         @include sans-serif;
-        color: $text;
+        color: var(--body-fg);
         @include font-size(12);
         pointer-events: auto;
 
         &.current {
             display: inline-block;
-            background: $white;
+            background: var(--body-bg);
             padding: 8px 15px;
-            border: 1px solid $gray-line;
+            border: 1px solid var(--hairline-color);
             border-radius: 4px;
         }
         &.current-link {
@@ -2218,15 +2232,15 @@ h2 + .list-link-soup {
 
         a {
             display: inline-block;
-            background: $white;
-            color: $green-medium;
+            background: var(--body-bg);
+            color: var(--primary);
             text-decoration: none;
             font-weight: 700;
             padding: 8px 15px;
-            border: 1px solid $gray-line;
+            border: 1px solid var(--hairline-color);
             border-radius: 4px;
             &:hover {
-                color: $green;
+                color: var(--secondary);
                 border: 1px solid $green-light;
             }
         }
@@ -2264,8 +2278,8 @@ h2 + .list-link-soup {
 }
 
 #outdated-warning {
-    background-color: $red-light;
-    color: $red-dark;
+    background-color: var(--error-light);
+    color: var(--error-dark);
 }
 
 #docs-content {
@@ -2292,18 +2306,18 @@ h2 + .list-link-soup {
 
     a.reference {
         // for docs links. if we keep text-decoration, then underscores in function names become invisible.
-        color: $red-dark;
+        color: var(--error-dark);
         text-decoration: none;
-        border-bottom: 1px dotted $text-light;
+        border-bottom: 1px dotted var(--text-light);
 
         &:visited {
-            border-color: lighten($red-dark, 10%);
+            border-color: var(--error-dark-l10);
         }
 
         &:active,
         &:focus,
         &:hover {
-            background: $white;
+            background: var(--body-bg);
             color: $red;
         }
 
@@ -2327,7 +2341,7 @@ h2 + .list-link-soup {
     margin-bottom: 20px;
 
     padding: 10px 13px;
-    border: 1px solid $green-very-light;
+    border: 1px solid var(--secondary-accent);
     border-radius: 4px;
 
     p {
@@ -2371,7 +2385,7 @@ dl.function, dl.class, dl.method, dl.classmethod, dl.staticmethod, dl.attribute,
 
 
 table.docutils td, table.docutils th {
-    border-bottom: 1px solid $gray-line;
+    border-bottom: 1px solid var(--hairline-color);
 }
 
 .list-links {
@@ -2409,7 +2423,7 @@ table.docutils td, table.docutils th {
         dt,
         li {
             @include font-size(16);
-            border-top: 1px solid $gray-line;
+            border-top: 1px solid var(--hairline-color);
             margin-top: 0;
             padding-top: 20px;
 
@@ -2439,16 +2453,16 @@ table.docutils td, table.docutils th {
 
     em {
         font-weight: 700;
-        color: $text;
+        color: var(--body-fg);
     }
 
     span.meta {
         margin-top: 0;
         margin-bottom: 10px;
-        color: $gray-medium;
+        color: var(--dark-hairline-color);
 
         a {
-            color: $text-light;
+            color: var(--text-light);
 
             &:visited {
                 color: darken($text-light, 10%);
@@ -2467,7 +2481,7 @@ table.docutils td, table.docutils th {
     }
 
     span.arrow {
-        color: $text;
+        color: var(--body-fg);
         font-weight: 700;
     }
 
@@ -2502,7 +2516,7 @@ table.docutils td, table.docutils th {
     }
 
     dd {
-        color: $text-light;
+        color: var(--text-light);
         padding-top: 2px;
     }
 
@@ -2589,8 +2603,8 @@ form {
         @include font-size(16);
         -webkit-appearance: none;
         -moz-appearance: none;
-        background: #fff;
-        border: 1px solid $gray-line;
+        background: var(--white-color);
+        border: 1px solid var(--hairline-color);
         border-radius: 4px;
         cursor: auto;
         display: block;
@@ -2614,7 +2628,7 @@ form {
         &:active,
         &:focus {
             outline: none;
-            border-color: $green;
+            border-color: var(--secondary);
         }
     }
 
@@ -2628,8 +2642,9 @@ form {
     }
 
     select {
-        border: 1px solid $gray-line;
-        background: white;
+        border: 1px solid var(--hairline-color);
+        background: var(--white-color);
+        color: var(--body-fg);
         height: 46px;
         padding: 0 10px;
         border-radius: 4px;
@@ -2646,16 +2661,16 @@ form {
         -webkit-appearance: none;
         appearance: none;
 
-        background: $green;
+        background: var(--secondary);
         border-radius: 4px;
-        color: white;
+        color: var(--white-color);
         border: 0;
         height: 46px;
         padding: 0 15px;
         @include sans-serif;
         @include font-size(16);
         &:hover {
-            background: $green-medium;
+            background: var(--primary);
         }
     }
 }
@@ -2691,7 +2706,7 @@ form {
     button {
         background: none;
         border: none;
-        color: $green-medium;
+        color: var(--primary);
         height: 40px;
         padding: 0;
         position: absolute;
@@ -2758,7 +2773,7 @@ form.donate {
     label {
         position: absolute;
         left: 0px;
-        color: $green-medium-dark;
+        color: var(--primary-accent);
         padding-top: 0.3em;
         padding-left: 0.5em;
     }
@@ -2779,7 +2794,7 @@ div[role=main] {
 :-moz-placeholder,
 ::-moz-placeholder,
 :-ms-input-placeholder {
-    color: $gray-medium;
+    color: var(--dark-hairline-color);
 }
 
 .form-email {
@@ -2801,7 +2816,7 @@ div[role=main] {
     // Pagination style for use with the News & Events pages.
     @include sans-serif;
     @include font-size(14);
-    border-top: 1px solid $gray-line;
+    border-top: 1px solid var(--hairline-color);
     font-weight: 700;
     line-height: 31px;
     list-style: none;
@@ -2814,7 +2829,7 @@ div[role=main] {
     }
     a {
         border: none;
-        color: $text-light;
+        color: var(--text-light);
         height: auto;
         width: auto;
         margin: 0 5px;
@@ -2822,8 +2837,8 @@ div[role=main] {
         display: block;
         text-decoration: none;
         @include device-min(320px) {
-            background: $text-light;
-            color: #fff;
+            background: var(--text-light);
+            color: var(--white-color);
             height: 30px;
             margin: 0 2px;
             width: 30px;
@@ -2858,17 +2873,17 @@ div[role=main] {
         &:active,
         &.active {
             background: none;
-            color: $green;
+            color: var(--secondary);
             @include device-min(320px) {
-                background: $green;
-                color: white;
+                background: var(--secondary);
+                color: var(--white-color);
             }
         }
 
         .mdzr-no-borderradius & {
             display: inline;
             background: none;
-            color: $text-light;
+            color: var(--text-light);
             height: auto;
             width: auto;
             margin: 0 5px !important;
@@ -2878,7 +2893,7 @@ div[role=main] {
             &:focus,
             &.active {
                 background: none;
-                color: $green;
+                color: var(--secondary);
             }
         }
     }
@@ -2886,7 +2901,7 @@ div[role=main] {
 
 hr {
     border: 0;
-    border-top: 1px solid $gray-line;
+    border-top: 1px solid var(--hairline-color);
 }
 
 // em {
@@ -2902,8 +2917,8 @@ hr {
     letter-spacing: 0px;
     position: relative;
     bottom: 0.3em;
-    color: $white;
-    background-color: $green;
+    color: var(--body-bg);
+    background-color: var(--secondary);
 }
 
 .user-info {
@@ -3035,7 +3050,7 @@ hr {
 }
 
 .footnote {
-    color: $gray-medium;
+    color: var(--dark-hairline-color);
     @include font-size(14);
     margin-top: 20px;
     text-align: center;
@@ -3130,17 +3145,18 @@ form .footnote {
 table.django-supported-versions, table.django-unsupported-versions {
     border: 1px solid black;
     text-align: center;
+	color: var(--table-color);
     th, td {
         padding: 5px;
     }
 }
 
 table.django-supported-versions tr {
-    background-color: $green-very-light;
+    background-color: var(--secondary-accent);
 }
 
 table.django-unsupported-versions tr {
-    background-color: $red-light;
+    background-color: var(--error-light);
 }
 
 /* Corporate membership list page */
@@ -3165,7 +3181,7 @@ ul.corporate-members li {
 
     li {
         padding: 15px;
-        background-color: lighten($green-very-light, 10);
+        background-color: var(--secondary-accent-l10);
         color: $green-dark;
         border: 1px solid $green-dark;
         border-radius: 4px;
@@ -3187,7 +3203,7 @@ ul.corporate-members li {
         }
 
         &.success {
-            background-color: lighten($green-very-light, 5);
+            background-color: var(--secondary-accent-l5);
             content: $fa-var-check-circle;
             &::before {
                 content: $fa-var-check-circle;
@@ -3195,18 +3211,18 @@ ul.corporate-members li {
         }
 
         &.warning {
-            background-color: $warning-yellow;
-            border-color: darken($warning-dark-yellow, 50);
+            background-color: var(--warning);
+            border-color: var(--warning-dark-d50);
             &::before {
-                color: darken($warning-dark-yellow, 50);
+                color: var(--warning-dark-d50);
                 content: $fa-var-exclamation-triangle;
             }
         }
 
         &.error {
-            background-color: lighten($red-light, 10);
-            color: $red-dark;
-            border-color: $red-dark;
+            background-color: var(--error-light-l10);
+            color: var(--error-dark);
+            border-color: var(--error-dark);
             &::before {
                 content: $fa-var-times-circle;
             }

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2605,6 +2605,7 @@ form {
         -moz-appearance: none;
         background: var(--white-color);
         border: 1px solid var(--hairline-color);
+        color: var(--hairline-color);
         border-radius: 4px;
         cursor: auto;
         display: block;

--- a/djangoproject/scss/_styleguide.scss
+++ b/djangoproject/scss/_styleguide.scss
@@ -4,7 +4,7 @@
 
     .example {
         padding: 0 20px 20px;
-        border: 1px solid $gray-line;
+        border: 1px solid var(--hairline-color);
         border-radius: 4px;
         margin-top: 20px;
         margin-bottom: 64px;
@@ -13,7 +13,7 @@
             font-size: 16px;
             font-weight: 700;
             display: block;
-            color: $gray-line;
+            color: var(--hairline-color);
             @include sans-serif;
             text-align: left;
             padding: 10px 0;
@@ -31,7 +31,7 @@
         display: block;
         height: 400px;
         cursor: zoom-in;
-        border: 1px solid $gray-line;
+        border: 1px solid var(--hairline-color);
         overflow: hidden;
 
         iframe {
@@ -66,44 +66,44 @@
 
             // Primary
             &.text {
-                background: $text;
+                background: var(--body-fg);
             }
             &.green-dark {
                 background: $green-dark;
             }
             &.green {
-                background: $green;
+                background: var(--secondary);
             }
             &.green-light {
                 background: $green-light;
             }
             &.white {
-                background: $white;
-                border: 1px solid $gray-line;
+                background: var(--body-bg);
+                border: 1px solid var(--hairline-color);
             }
             &.red-dark {
-                background: $red-dark;
+                background: var(--error-dark);
             }
 
             // Secondary
             &.text-light {
-                background: $text-light;
+                background: var(--text-light);
             }
 
             &.green-medium-dark {
-                background: $green-medium-dark;
+                background: var(--primary-accent);
             }
 
             &.green-medium {
-                background: $green-medium;
+                background: var(--primary);
             }
 
             &.green-very-light {
-                background: $green-very-light;
+                background: var(--secondary-accent);
             }
 
             &.gray-line {
-                background: $gray-line;
+                background: var(--hairline-color);
             }
 
             &.red {
@@ -119,7 +119,7 @@
 
     #icons .icon {
         @include font-size(32);
-        color: $green;
+        color: var(--secondary);
         padding: 0 .2em;
     }
 

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -66,6 +66,12 @@ $font-path: "../fonts/fira-mono";
     }
 }
 
+@mixin respond-max($width) {
+    @media screen and (max-width: $width) {
+        @content;
+    }
+}
+
 @mixin device-min($width) {
     @media screen and (min-device-width: $width) {
         @content;

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -1,26 +1,41 @@
 // Colors
 
 $gray-medium: #859D94;
+$gray-medium-l10: lighten($gray-medium, 10);
+$gray-dark: #343940;
 $text: #0C3C26;
+$text-l10: lighten($text, 10);
+$text-l20: lighten($text, 20);
 $text-light: #798780;
-$text-very-light: #bec7cf;
+$text-light-l20: lighten($text-light, 20);
+$text-light-l30: lighten($text-light, 30);
+$text-light-d10: darken($text-light, 10);
+$text-light-d20: darken($text-light, 20);
 $gray-line: #CFE3DC;
 $green-very-light: #C9F0DD;
+$green-very-light-l5: lighten($green-very-light, 5);
+$green-very-light-l10: lighten($green-very-light, 10);
 $green-light: #93D7B7;
 $green-medium: #44B78B;
 $green-medium-dark: #2B8C67;
 $green: #20AA76;
+$green-l6: lighten($green, 6);
 $green-dark: #0C4B33;
 $green-dark-text: #3C8866;
 $white: #F1FFF7;
-$white-dark: #f8f8f8;
+$white-dark: #F8F8F8;
 $warning-yellow: #FFFDF1;
 $warning-dark-yellow: #F5F1C7;
+$warning-dark-yellow-d50: darken($warning-dark-yellow, 50);
 $red: #BA2121;
 $red-light: #FFBABA;
+$red-light-l10: lighten($red-light, 10);
 $red-dark: #6A0E0E;
+$red-dark-l10: lighten($red-dark, 10);
 $black: #0e1117;
+$black-light-5: lighten($black, 5);
 $font-path: "../fonts/fira-mono";
+
 
 // @font-face declarations
 
@@ -119,10 +134,10 @@ html {
 
 // Green Link Mixin
 @mixin link-green {
-    color: $green;
+    color: var(--link-color);
     text-decoration: none;
     &:visited {
-        color: $green;
+        color: var(--link-color);
     }
     &:hover,
     &:active,
@@ -148,6 +163,6 @@ html {
 
 @mixin framed-image {
     padding: 20px;
-    border: 1px solid $gray-line;
+    border: 1px solid var(--hairline-color);
     border-radius: 4px;
 }

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -3,6 +3,7 @@
 $gray-medium: #859D94;
 $text: #0C3C26;
 $text-light: #798780;
+$text-very-light: #bec7cf;
 $gray-line: #CFE3DC;
 $green-very-light: #C9F0DD;
 $green-light: #93D7B7;
@@ -12,11 +13,13 @@ $green: #20AA76;
 $green-dark: #0C4B33;
 $green-dark-text: #3C8866;
 $white: #F1FFF7;
+$white-dark: #f8f8f8;
 $warning-yellow: #FFFDF1;
 $warning-dark-yellow: #F5F1C7;
 $red: #BA2121;
 $red-light: #FFBABA;
 $red-dark: #6A0E0E;
+$black: #0e1117;
 $font-path: "../fonts/fira-mono";
 
 // @font-face declarations

--- a/djangoproject/scss/output.scss
+++ b/djangoproject/scss/output.scss
@@ -6,4 +6,5 @@
 @import "styleguide"; // code highlighting
 @import "print"; // print styles
 @import "dashboard";
+@import "dark-mode";
 @import "console-tabs"; // cli examples styles from console Sphinx directive

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -60,7 +60,7 @@ INSTALLED_APPS = [
     'blog',
     'contact',
     'dashboard',
-    'docs.apps.DocsConfig',
+    'docs',
     'foundation',
     'legacy',
     'members',

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -1,7 +1,8 @@
 // Require.js Module Loader - http://requirejs.org
 define(function() {
     var mods = [
-        'mod/mobile-menu' // require mobile menu automatically
+        'mod/mobile-menu', // require mobile menu automatically
+        'mod/switch-dark-mode' // require switch dark mode automatically
     ];
 
     //detect Class function

--- a/djangoproject/static/js/mod/mobile-menu.js
+++ b/djangoproject/static/js/mod/mobile-menu.js
@@ -4,6 +4,7 @@ define([
 
     var MobileMenuExport = function(menu) {
         this.menu = $(menu); //menu container
+        this.menuBtn = $('.mobile-toggle'); // toggle dark mode icon
         this.init();
     };
 
@@ -12,7 +13,7 @@ define([
             var self = this;
             self.menu.addClass('nav-menu-on');
             self.button = $('<div class="menu-button"><i class="icon icon-reorder"></i><span>Menu</span></div>');
-            self.button.insertBefore(self.menu);
+            self.button.insertBefore(self.menuBtn);
             self.button.on( 'click', function(){
                 self.menu.toggleClass('active');
                 self.button.toggleClass('active');

--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -1,46 +1,59 @@
 define([
-	'jquery' //requires jquery
+    'jquery' //requires jquery
 ], function ($) {
 
-	$(document).on('ready', function () {
-		const useDarkMode = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
-		const theme = window.localStorage.getItem('dark-mode');
+    function setTheme(mode) {
+        if (mode !== "light" && mode !== "dark" && mode !== "auto") {
+            console.error(`Got invalid theme mode: ${mode}. Resetting to auto.`);
+            mode = "auto";
+        }
+        document.documentElement.dataset.theme = mode;
+        localStorage.setItem("theme", mode);
+    }
 
-		// Toggles the "dark-mode" class based on if the media query matches or if theme exist
-		function toggleDarkMode(state, theme) {
-			if (theme != null) {
-				if (theme == 'true') {
-					$('html').addClass("dark-mode");
-				} else {
-					$('html').removeClass("dark-mode");
-				}
-				$('#toggle').attr('aria-checked', theme);
+    function cycleTheme() {
+        const currentTheme = localStorage.getItem("theme") || "auto";
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
 
-			} else {
-				$('html').toggleClass("dark-mode", state);
-				$('#toggle').attr('aria-checked', state);
-			}
-		}
+        if (prefersDark) {
+            // Auto (dark) -> Light -> Dark
+            if (currentTheme === "auto") {
+                setTheme("light");
+            } else if (currentTheme === "light") {
+                setTheme("dark");
+            } else {
+                setTheme("auto");
+            }
+        } else {
+            // Auto (light) -> Dark -> Light
+            if (currentTheme === "auto") {
+                setTheme("dark");
+            } else if (currentTheme === "dark") {
+                setTheme("light");
+            } else {
+                setTheme("auto");
+            }
+        }
+    }
 
-		// Initial setting
-		if (theme) {
-			toggleDarkMode(theme, theme);
-		} else {
-			toggleDarkMode(useDarkMode.matches, null);
-		}
+    function initTheme() {
+        // set theme defined in localStorage if there is one, or fallback to auto mode
+        const currentTheme = localStorage.getItem("theme");
+        currentTheme ? setTheme(currentTheme) : setTheme("auto");
+    }
 
-		// Listen for changes in the system preferences
-		$(useDarkMode).on('change', function (evt) { toggleDarkMode(evt.target.matches, theme) });
+    function setupTheme() {
+        // Attach event handlers for toggling themes
+        const buttons = document.getElementsByClassName("theme-toggle");
+        Array.from(buttons).forEach((btn) => {
+            btn.addEventListener("click", cycleTheme);
+        });
+        initTheme();
+    }
 
-		// Toggles the "dark-mode" class on click
-		$("#toggle").on("click", () => {
-			$('html').toggleClass("dark-mode");
-			const state = $('#toggle').attr('aria-checked');
-			const newState = (state == 'true') ? false : true;
-			$('#toggle').attr('aria-checked', newState);
-			window.localStorage.setItem('dark-mode', newState);
-		});
-	});
+
+
+    $(document).on('ready', function () {
+        setupTheme();
+    });
 })
-
-

--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -1,0 +1,46 @@
+define([
+	'jquery' //requires jquery
+], function ($) {
+
+	$(document).on('ready', function () {
+		const useDarkMode = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
+		const theme = window.localStorage.getItem('dark-mode');
+
+		// Toggles the "dark-mode" class based on if the media query matches or if theme exist
+		function toggleDarkMode(state, theme) {
+			if (theme != null) {
+				if (theme == 'true') {
+					$('html').addClass("dark-mode");
+				} else {
+					$('html').removeClass("dark-mode");
+				}
+				$('#toggle').attr('aria-checked', theme);
+
+			} else {
+				$('html').toggleClass("dark-mode", state);
+				$('#toggle').attr('aria-checked', state);
+			}
+		}
+
+		// Initial setting
+		if (theme) {
+			toggleDarkMode(theme, theme);
+		} else {
+			toggleDarkMode(useDarkMode.matches, null);
+		}
+
+		// Listen for changes in the system preferences
+		$(useDarkMode).on('change', function (evt) { toggleDarkMode(evt.target.matches, theme) });
+
+		// Toggles the "dark-mode" class on click
+		$("#toggle").on("click", () => {
+			$('html').toggleClass("dark-mode");
+			const state = $('#toggle').attr('aria-checked');
+			const newState = (state == 'true') ? false : true;
+			$('#toggle').attr('aria-checked', newState);
+			window.localStorage.setItem('dark-mode', newState);
+		});
+	});
+})
+
+

--- a/djangoproject/static/robots.docs.txt
+++ b/djangoproject/static/robots.docs.txt
@@ -20,7 +20,6 @@ Disallow: /id/4.1/internals
 Disallow: /id/4.1/ref
 Disallow: /id/4.1/releases
 Disallow: /id/4.1/topics
-Disallow: /it/4.1/howto
 Disallow: /it/4.1/internals
 Disallow: /it/4.1/ref
 Disallow: /it/4.1/releases
@@ -45,6 +44,7 @@ Disallow: /pl/4.1/releases
 Disallow: /pl/4.1/topics
 Disallow: /pt-br/4.1/howto
 Disallow: /pt-br/4.1/internals
+Disallow: /pt-br/4.1/intro
 Disallow: /pt-br/4.1/ref
 Disallow: /pt-br/4.1/releases
 Disallow: /pt-br/4.1/topics

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -117,6 +117,7 @@
             "mod/version-switcher": extless("{% static 'js/mod/version-switcher.js' %}"),
             "mod/search-key": extless("{% static 'js/mod/search-key.js' %}"),
             "mod/stripe-change-card": extless("{% static 'js/mod/stripe-change-card.js' %}"),
+            "mod/switch-dark-mode": extless("{% static 'js/mod/switch-dark-mode.js' %}"),
             "mod/console-tabs": extless("{% static 'js/mod/console-tabs.js' %}"),
             "stripe-checkout": "https://checkout.stripe.com/checkout",
             "stripe": "https://js.stripe.com/v3/?" // ? needed due to require.js

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -83,6 +83,14 @@
     {% block alert %}
     {% endblock %}
 
+    <!-- SVGs -->
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <symbol viewBox="0 0 24 24" width="16" height="16" id="icon-auto"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2V4a8 8 0 1 0 0 16z"/></symbol>
+      <symbol viewBox="0 0 24 24" width="16" height="16" id="icon-moon"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></symbol>
+      <symbol viewBox="0 0 24 24" width="16" height="16" id="icon-sun"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></symbol>
+    </svg>
+    <!-- END SVGs -->
+    
     {% block footer %}
       {% include "includes/footer.html" %}
     {% endblock %}
@@ -126,6 +134,5 @@
     </script>
     <script data-main="{% static "js/main.js" %}" src="{% static "js/lib/require.js" %}"></script>
     {% block body_extra %}{% endblock body_extra %}
-
   </body>
 </html>

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -32,11 +32,18 @@
           <a href="{% url 'fundraising:index' %}">&#9829; Donate</a>
         </li>
         <li>
-         <label for="toggle">dark mode
-          <button type="button" id="toggle" role="switch" aria-checked="false">
-            <span>on</span><span>off</span>  
+          <button class="theme-toggle">
+            <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
+            <svg class="theme-icon-when-auto">
+              <use xlink:href="#icon-auto" />
+            </svg>
+            <svg class="theme-icon-when-dark">
+              <use xlink:href="#icon-moon" />
+            </svg>
+            <svg class="theme-icon-when-light">
+              <use xlink:href="#icon-sun" />
+            </svg>
           </button>
-        </label>
         </li>
       </ul>
     </div>

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -2,6 +2,9 @@
   <div class="container">
     <a class="logo" href="{% url 'homepage' %}">Django</a>
     <p class="meta">The web framework for perfectionists with deadlines.</p>
+    <div class="mobile-toggle">
+      {% include "includes/toggle_theme.html" %}
+    </div>
     <div role="navigation">
       <ul>
         <li{% if 'start' in request.path %} class="active"{% endif %}>
@@ -32,18 +35,7 @@
           <a href="{% url 'fundraising:index' %}">&#9829; Donate</a>
         </li>
         <li>
-          <button class="theme-toggle">
-            <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
-            <svg class="theme-icon-when-auto">
-              <use xlink:href="#icon-auto" />
-            </svg>
-            <svg class="theme-icon-when-dark">
-              <use xlink:href="#icon-moon" />
-            </svg>
-            <svg class="theme-icon-when-light">
-              <use xlink:href="#icon-sun" />
-            </svg>
-          </button>
+          {% include "includes/toggle_theme.html" %}
         </li>
       </ul>
     </div>

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -31,6 +31,13 @@
         <li{% if 'fundraising' in request.path %} class="active"{% endif %}>
           <a href="{% url 'fundraising:index' %}">&#9829; Donate</a>
         </li>
+        <li>
+         <label for="toggle">dark mode
+          <button type="button" id="toggle" role="switch" aria-checked="false">
+            <span>on</span><span>off</span>  
+          </button>
+        </label>
+        </li>
       </ul>
     </div>
   </div>

--- a/djangoproject/templates/includes/toggle_theme.html
+++ b/djangoproject/templates/includes/toggle_theme.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+
+<button class="theme-toggle">
+  <div class="visually-hidden theme-label-when-auto">{% translate 'Toggle theme (current theme: auto)' %}</div>
+  <div class="visually-hidden theme-label-when-light">{% translate 'Toggle theme (current theme: light)' %}</div>
+  <div class="visually-hidden theme-label-when-dark">{% translate 'Toggle theme (current theme: dark)' %}</div>
+
+  <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
+  <svg aria-hidden="true" class="theme-icon-when-auto">
+    <use xlink:href="#icon-auto" />
+  </svg>
+  <svg aria-hidden="true" class="theme-icon-when-dark">
+    <use xlink:href="#icon-moon" />
+  </svg>
+  <svg aria-hidden="true" class="theme-icon-when-light">
+    <use xlink:href="#icon-sun" />
+  </svg>
+</button>

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -76,15 +76,21 @@
         <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
       </tr>
       <tr>
+        <td>4.1</td>
+        <td>{% get_latest_micro_release '4.1' %}</td>
+        <td>April 2023</td>
+        <td>December 2023</td>
+      </tr>
+      <tr>
         <td>4.0</td>
         <td>{% get_latest_micro_release '4.0' %}</td>
-        <td>August 2022</td>
+        <td>August 3, 2022</td>
         <td>April 2023</td>
       </tr>
       <tr>
         <td>3.2 LTS</td>
         <td>{% get_latest_micro_release '3.2' %}</td>
-        <td>December 2021</td>
+        <td>December 7, 2021</td>
         <td>April 2024</td>
       </tr>
   </table>
@@ -121,12 +127,6 @@
       <td>April 2023</td>
       <td>December 2023</td>
       <td>April 2026</td>
-    </tr>
-    <tr>
-      <td>4.1</td>
-      <td>August 2022</td>
-      <td>April 2023</td>
-      <td>December 2023</td>
     </tr>
   </table>
 

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -69,30 +69,30 @@
   <hr style="margin-bottom: 20px;">
 
   <table class='django-supported-versions'>
-      <tr>
-        <th>Release Series</th>
-        <th>Latest Release</th>
-        <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-        <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
-      </tr>
-      <tr>
-        <td>4.1</td>
-        <td>{% get_latest_micro_release '4.1' %}</td>
-        <td>April 2023</td>
-        <td>December 2023</td>
-      </tr>
-      <tr>
-        <td>4.0</td>
-        <td>{% get_latest_micro_release '4.0' %}</td>
-        <td>August 3, 2022</td>
-        <td>April 2023</td>
-      </tr>
-      <tr>
-        <td>3.2 LTS</td>
-        <td>{% get_latest_micro_release '3.2' %}</td>
-        <td>December 7, 2021</td>
-        <td>April 2024</td>
-      </tr>
+    <tr>
+      <th>Release Series</th>
+      <th>Latest Release</th>
+      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
+      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+    </tr>
+    <tr>
+      <td>4.1</td>
+      <td>{% get_latest_micro_release '4.1' %}</td>
+      <td>April 2023</td>
+      <td>December 2023</td>
+    </tr>
+    <tr>
+      <td>4.0</td>
+      <td>{% get_latest_micro_release '4.0' %}</td>
+      <td>August 3, 2022</td>
+      <td>April 2023</td>
+    </tr>
+    <tr>
+      <td>3.2 LTS</td>
+      <td>{% get_latest_micro_release '3.2' %}</td>
+      <td>December 7, 2021</td>
+      <td>April 2024</td>
+    </tr>
   </table>
 
   <h2 id="future-versions">Future Roadmap</h2>
@@ -134,96 +134,96 @@
   <p>These release series no longer receive security updates or bug fixes.</p>
 
   <table class='django-unsupported-versions'>
-      <tr>
-        <th>Release Series</th>
-        <th>Latest Release</th>
-        <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-        <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
-      </tr>
-      <tr>
-        <td>3.1</td>
-        <td>{% get_latest_micro_release '3.1' %}</td>
-        <td>April 6, 2021</td>
-        <td>December 7, 2021</td>
-      </tr>
-      <tr>
-        <td>3.0</td>
-        <td>{% get_latest_micro_release '3.0' %}</td>
-        <td>August 3, 2020</td>
-        <td>April 6, 2021</td>
-      </tr>
-      <tr>
-        <td>2.2 LTS</td>
-        <td>{% get_latest_micro_release '2.2' %}</td>
-        <td>December 2, 2019</td>
-        <td>April 11, 2022</td>
-      </tr>
-      <tr>
-        <td>2.1</td>
-        <td>{% get_latest_micro_release '2.1' %}</td>
-        <td>April 1, 2019</td>
-        <td>December 2, 2019</td>
-      </tr>
-      <tr>
-        <td>2.0</td>
-        <td>{% get_latest_micro_release '2.0' %}</td>
-        <td>August 1, 2018</td>
-        <td>April 1, 2019</td>
-      </tr>
-      <tr>
-        <td>1.11 LTS <sup><a href="#ft3">3</a></sup></td>
-        <td>{% get_latest_micro_release '1.11' %}</td>
-        <td>December 2, 2017</td>
-        <td>April 1, 2020</td>
-      </tr>
-      <tr>
-        <td>1.10</td>
-        <td>{% get_latest_micro_release '1.10' %}</td>
-        <td>April 4, 2017</td>
-        <td>December 2, 2017</td>
-      </tr>
-      <tr>
-        <td>1.9</td>
-        <td>{% get_latest_micro_release '1.9' %}</td>
-        <td>August 1, 2016</td>
-        <td>April 4, 2017</td>
-      </tr>
-      <tr>
-        <td>1.8 LTS</td>
-        <td>{% get_latest_micro_release '1.8' %}</td>
-        <td>December 1, 2015</td>
-        <td>April 1, 2018</td>
-      </tr>
-      <tr>
-        <td>1.7</td>
-        <td>{% get_latest_micro_release '1.7' %}</td>
-        <td>April 1, 2015</td>
-        <td>December 1, 2015</td>
-      </tr>
-      <tr>
-        <td>1.6</td>
-        <td>{% get_latest_micro_release '1.6' %}</td>
-        <td>September 2, 2014</td>
-        <td>April 1, 2015</td>
-      </tr>
-      <tr>
-        <td>1.5</td>
-        <td>{% get_latest_micro_release '1.5' %}</td>
-        <td>November 6, 2013</td>
-        <td>September 2, 2014</td>
-      </tr>
-      <tr>
-        <td>1.4 LTS</td>
-        <td>{% get_latest_micro_release '1.4' %}</td>
-        <td>February 26, 2013</td>
-        <td>October 1, 2015</td>
-      </tr>
-      <tr>
-        <td>1.3</td>
-        <td>{% get_latest_micro_release '1.3' %}</td>
-        <td>March 23, 2012</td>
-        <td>February 26, 2013</td>
-      </tr>
+    <tr>
+      <th>Release Series</th>
+      <th>Latest Release</th>
+      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
+      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+    </tr>
+    <tr>
+      <td>3.1</td>
+      <td>{% get_latest_micro_release '3.1' %}</td>
+      <td>April 6, 2021</td>
+      <td>December 7, 2021</td>
+    </tr>
+    <tr>
+      <td>3.0</td>
+      <td>{% get_latest_micro_release '3.0' %}</td>
+      <td>August 3, 2020</td>
+      <td>April 6, 2021</td>
+    </tr>
+    <tr>
+      <td>2.2 LTS</td>
+      <td>{% get_latest_micro_release '2.2' %}</td>
+      <td>December 2, 2019</td>
+      <td>April 11, 2022</td>
+    </tr>
+    <tr>
+      <td>2.1</td>
+      <td>{% get_latest_micro_release '2.1' %}</td>
+      <td>April 1, 2019</td>
+      <td>December 2, 2019</td>
+    </tr>
+    <tr>
+      <td>2.0</td>
+      <td>{% get_latest_micro_release '2.0' %}</td>
+      <td>August 1, 2018</td>
+      <td>April 1, 2019</td>
+    </tr>
+    <tr>
+      <td>1.11 LTS <sup><a href="#ft3">3</a></sup></td>
+      <td>{% get_latest_micro_release '1.11' %}</td>
+      <td>December 2, 2017</td>
+      <td>April 1, 2020</td>
+    </tr>
+    <tr>
+      <td>1.10</td>
+      <td>{% get_latest_micro_release '1.10' %}</td>
+      <td>April 4, 2017</td>
+      <td>December 2, 2017</td>
+    </tr>
+    <tr>
+      <td>1.9</td>
+      <td>{% get_latest_micro_release '1.9' %}</td>
+      <td>August 1, 2016</td>
+      <td>April 4, 2017</td>
+    </tr>
+    <tr>
+      <td>1.8 LTS</td>
+      <td>{% get_latest_micro_release '1.8' %}</td>
+      <td>December 1, 2015</td>
+      <td>April 1, 2018</td>
+    </tr>
+    <tr>
+      <td>1.7</td>
+      <td>{% get_latest_micro_release '1.7' %}</td>
+      <td>April 1, 2015</td>
+      <td>December 1, 2015</td>
+    </tr>
+    <tr>
+      <td>1.6</td>
+      <td>{% get_latest_micro_release '1.6' %}</td>
+      <td>September 2, 2014</td>
+      <td>April 1, 2015</td>
+    </tr>
+    <tr>
+      <td>1.5</td>
+      <td>{% get_latest_micro_release '1.5' %}</td>
+      <td>November 6, 2013</td>
+      <td>September 2, 2014</td>
+    </tr>
+    <tr>
+      <td>1.4 LTS</td>
+      <td>{% get_latest_micro_release '1.4' %}</td>
+      <td>February 26, 2013</td>
+      <td>October 1, 2015</td>
+    </tr>
+    <tr>
+      <td>1.3</td>
+      <td>{% get_latest_micro_release '1.3' %}</td>
+      <td>March 23, 2012</td>
+      <td>February 26, 2013</td>
+    </tr>
   </table>
 
   <p style="max-width: 720px;">

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -65,7 +65,7 @@
   <p>See the <a href="https://docs.djangoproject.com/en/dev/internals/release-process/#supported-versions">
     supported versions policy</a> for detailed guidelines about what fixes will be backported.</p>
 
-  <img src="{% static "img/release-roadmap.png" %}" style="max-width:100%;" alt="Django release roadmap">
+  <img src="{% static "img/release-roadmap.png" %}" class='img-release' style="max-width:100%;" alt="Django release roadmap">
   <hr style="margin-bottom: 20px;">
 
   <table class='django-supported-versions'>

--- a/djangoproject/templates/start.html
+++ b/djangoproject/templates/start.html
@@ -68,11 +68,12 @@
       <p>Deﬁne your data models entirely in Python. You get a rich, dynamic database-access API for free — but you can still write SQL if needed.</p>
       <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='topics/db/models' host 'docs' %}">Read more</a>
       {% pygment 'python' %}
+from django.db import models
+
 class Band(models.Model):
     """A model of a rock band."""
     name = models.CharField(max_length=200)
     can_rock = models.BooleanField(default=True)
-
 
 class Member(models.Model):
     """A model of a rock band member."""
@@ -107,10 +108,11 @@ urlpatterns = [
       {% endpygment %}
       {% pygment 'python' %}
 from django.shortcuts import render
+from bands.models import Band
 
 def band_listing(request):
     """A view of all bands."""
-    bands = models.Band.objects.all()
+    bands = Band.objects.all()
     return render(request, 'bands/band_listing.html', {'bands': bands})
       {% endpygment %}
     </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:11.2-alpine
+    image: postgres:12-alpine
     environment:
       - POSTGRES_USER=djangoproject
       - POSTGRES_PASSWORD=secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:12-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=djangoproject
       - POSTGRES_PASSWORD=secret

--- a/docs/fixtures/doc_releases.json
+++ b/docs/fixtures/doc_releases.json
@@ -10,19 +10,19 @@
 },
 {
   "model": "docs.documentrelease",
-  "pk": 33,
+  "pk": 35,
   "fields": {
     "lang": "fr",
-    "release": "4.0",
+    "release": "4.1",
     "is_default": false
   }
 },
 {
   "model": "docs.documentrelease",
-  "pk": 34,
+  "pk": 36,
   "fields": {
     "lang": "en",
-    "release": "4.0",
+    "release": "4.1",
     "is_default": true
   }
 }

--- a/docs/management/commands/update_docs_and_index.py
+++ b/docs/management/commands/update_docs_and_index.py
@@ -1,0 +1,10 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Update the docs then reindex them in the search vector field.
+    """
+    def handle(self, **options):
+        call_command('update_docs', update_index=True, **options)

--- a/docs/management/commands/update_index.py
+++ b/docs/management/commands/update_index.py
@@ -2,27 +2,19 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from ...models import Document
-from ...search import DOCUMENT_SEARCH_VECTOR
 
 
 class Command(BaseCommand):
 
-    def log(self, msg, level=2):
-        """
-        Small log helper
-        """
-        if self.verbosity >= level:
-            self.stdout.write(msg)
-
     @transaction.atomic
     def handle(self, *args, **options):
-        self.verbosity = options['verbosity']
-        Document.objects.update(search=None)
-        updated = (
-            # Don't index the module pages since source code is hard to
-            # combine with full text search.
-            Document.objects.exclude(path__startswith='_modules')
-            # Not the crazy big flattened index of the CBVs.
-            .exclude(path__startswith='ref/class-based-views/flattened-index')
-        ).update(search=DOCUMENT_SEARCH_VECTOR)
-        self.log('Successfully indexed %s item' % updated)
+        """
+        Update Document's search vector field in an atomic transaction.
+
+        Inside an atomic transaction all not null search vector values are set
+        to null and than the field are updated using the document definition.
+        """
+        Document.objects.search_reset()
+        updated_documents = Document.objects.search_update()
+        if options["verbosity"] >= 2:
+            self.stdout.write(self.style.SUCCESS(f"Successfully indexed {updated_documents} documents."))

--- a/docs/models.py
+++ b/docs/models.py
@@ -227,7 +227,7 @@ class DocumentManager(models.Manager):
         """Use full-text search to return documents matching query_text."""
         query_text = query_text.strip()
         if query_text:
-            search_query = SearchQuery(query_text, config=models.F('config'))
+            search_query = SearchQuery(query_text, config=models.F('config'), search_type='websearch')
             search_rank = SearchRank(models.F('search'), search_query)
             similarity = TrigramSimilarity('title', query_text)
             return self.get_queryset().prefetch_related(

--- a/docs/models.py
+++ b/docs/models.py
@@ -227,7 +227,7 @@ class DocumentManager(models.Manager):
         """Use full-text search to return documents matching query_text."""
         query_text = query_text.strip()
         if query_text:
-            search_query = SearchQuery(query_text, config=models.F('config'), search_type='websearch')
+            search_query = SearchQuery(query_text, config=models.F('config'))
             search_rank = SearchRank(models.F('search'), search_query)
             similarity = TrigramSimilarity('title', query_text)
             return self.get_queryset().prefetch_related(

--- a/docs/models.py
+++ b/docs/models.py
@@ -224,7 +224,7 @@ class DocumentManager(models.Manager):
         """Use full-text search to return documents matching query_text."""
         query_text = query_text.strip()
         if query_text:
-            search_query = SearchQuery(query_text, config=models.F('config'))
+            search_query = SearchQuery(query_text, config=models.F('config'), search_type='websearch')
             search_rank = SearchRank(models.F('search'), search_query)
             similarity = TrigramSimilarity('title', query_text)
             return self.get_queryset().prefetch_related(

--- a/docs/search.py
+++ b/docs/search.py
@@ -2,25 +2,32 @@ from django.contrib.postgres.search import SearchVector
 from django.db.models import F
 from django.db.models.fields.json import KeyTextTransform
 
-# Imported from https://github.com/postgres/postgres/blob/REL_10_STABLE/src/bin/initdb/initdb.c#L664
+# Imported from https://github.com/postgres/postgres/blob/REL_12_STABLE/src/bin/initdb/initdb.c#L701
 TSEARCH_CONFIG_LANGUAGES = {
+    'ar': 'arabic',
     'da': 'danish',
     'de': 'german',
     'en': 'english',
     'es': 'spanish',
     'fi': 'finnish',
     'fr': 'french',
+    'ga': 'irish',
     'hu': 'hungarian',
+    'id': 'indonesian',
     'it': 'italian',
+    'lt': 'lithuanian',
+    'ne': 'nepali',
     'nl': 'dutch',
     'no': 'norwegian',
     'pt': 'portuguese',
     'ro': 'romanian',
     'ru': 'russian',
     'sv': 'swedish',
+    'ta': 'tamil',
     'tr': 'turkish',
 }
-# Imported from https://github.com/postgres/postgres/blob/REL_10_STABLE/src/bin/initdb/initdb.c#L2599
+
+# Imported from https://github.com/postgres/postgres/blob/REL_12_STABLE/src/bin/initdb/initdb.c#L2668
 DEFAULT_TEXT_SEARCH_CONFIG = 'simple'
 
 DOCUMENT_SEARCH_VECTOR = (

--- a/docs/search.py
+++ b/docs/search.py
@@ -2,17 +2,22 @@ from django.contrib.postgres.search import SearchVector
 from django.db.models import F
 from django.db.models.fields.json import KeyTextTransform
 
-# Imported from https://github.com/postgres/postgres/blob/REL_12_STABLE/src/bin/initdb/initdb.c#L701
+# Imported from https://github.com/postgres/postgres/blob/REL_14_STABLE/src/bin/initdb/initdb.c#L659
 TSEARCH_CONFIG_LANGUAGES = {
     'ar': 'arabic',
+    'ca': 'catalan',
     'da': 'danish',
     'de': 'german',
+    'el': 'greek',
     'en': 'english',
     'es': 'spanish',
+    'eu': 'basque',
     'fi': 'finnish',
     'fr': 'french',
     'ga': 'irish',
+    'hi': 'hindi',
     'hu': 'hungarian',
+    'hy': 'armenian',
     'id': 'indonesian',
     'it': 'italian',
     'lt': 'lithuanian',
@@ -22,12 +27,14 @@ TSEARCH_CONFIG_LANGUAGES = {
     'pt': 'portuguese',
     'ro': 'romanian',
     'ru': 'russian',
+    'sr': 'serbian',
     'sv': 'swedish',
     'ta': 'tamil',
     'tr': 'turkish',
+    'yi': 'yiddish',
 }
 
-# Imported from https://github.com/postgres/postgres/blob/REL_12_STABLE/src/bin/initdb/initdb.c#L2668
+# Imported from https://github.com/postgres/postgres/blob/REL_14_STABLE/src/bin/initdb/initdb.c#L2557
 DEFAULT_TEXT_SEARCH_CONFIG = 'simple'
 
 DOCUMENT_SEARCH_VECTOR = (

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -482,12 +482,6 @@ class DocumentManagerTest(TestCase):
         document_list = [('Django 1.2.1 release notes', 0.96982837), ('Django 1.9.4 release notes', 0.9490876)]
         self.assertSequenceEqual(list(document_queryset), document_list)
 
-    def test_websearch(self):
-        query_text = 'django "release notes" -packaging'
-        document_queryset = Document.objects.search(query_text, self.release).values_list('title', 'rank')
-        document_list = [('Django 1.9.4 release notes', 1.5675676)]
-        self.assertSequenceEqual(list(document_queryset), document_list)
-
     def test_multilingual_search(self):
         query_text = 'publication'
         queryset = Document.objects.search(query_text, self.release_fr).values_list('title', 'rank')

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -482,6 +482,12 @@ class DocumentManagerTest(TestCase):
         document_list = [('Django 1.2.1 release notes', 0.96982837), ('Django 1.9.4 release notes', 0.9490876)]
         self.assertSequenceEqual(list(document_queryset), document_list)
 
+    def test_websearch(self):
+        query_text = 'django "release notes" -packaging'
+        document_queryset = Document.objects.search(query_text, self.release).values_list('title', 'rank')
+        document_list = [('Django 1.9.4 release notes', 1.5675676)]
+        self.assertSequenceEqual(list(document_queryset), document_list)
+
     def test_multilingual_search(self):
         query_text = 'publication'
         queryset = Document.objects.search(query_text, self.release_fr).values_list('title', 'rank')

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -14,7 +14,6 @@ from djangoproject.urls import www as www_urls
 from releases.models import Release
 
 from .models import Document, DocumentRelease
-from .search import DOCUMENT_SEARCH_VECTOR
 from .sitemaps import DocsSitemap
 from .utils import get_doc_path
 
@@ -473,7 +472,9 @@ class DocumentManagerTest(TestCase):
             }
         ]
         Document.objects.bulk_create(((Document(**doc) for doc in documents)))
-        Document.objects.update(search=DOCUMENT_SEARCH_VECTOR)
+
+    def setUp(self):
+        Document.objects.search_update()
 
     def test_search(self):
         query_text = 'django'
@@ -497,3 +498,13 @@ class DocumentManagerTest(TestCase):
 
     def test_empty_search(self):
         self.assertSequenceEqual(Document.objects.search('', self.release), [])
+
+    def test_search_reset(self):
+        self.assertEqual(Document.objects.exclude(search=None).count(), 6)
+        self.assertEqual(Document.objects.search_reset(), 6)
+        self.assertEqual(Document.objects.exclude(search=None).count(), 0)
+
+    def test_search_update(self):
+        self.assertEqual(Document.objects.exclude(search=None).count(), 6)
+        self.assertEqual(Document.objects.search_update(), 6)
+        self.assertEqual(Document.objects.exclude(search=None).count(), 6)

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -481,6 +481,12 @@ class DocumentManagerTest(TestCase):
         document_list = [('Django 1.2.1 release notes', 0.96982837), ('Django 1.9.4 release notes', 0.9490876)]
         self.assertSequenceEqual(list(document_queryset), document_list)
 
+    def test_websearch(self):
+        query_text = 'django "release notes" -packaging'
+        document_queryset = Document.objects.search(query_text, self.release).values_list('title', 'rank')
+        document_list = [('Django 1.9.4 release notes', 1.5675676)]
+        self.assertSequenceEqual(list(document_queryset), document_list)
+
     def test_multilingual_search(self):
         query_text = 'publication'
         queryset = Document.objects.search(query_text, self.release_fr).values_list('title', 'rank')

--- a/foundation/templatetags/foundation.py
+++ b/foundation/templatetags/foundation.py
@@ -1,9 +1,8 @@
 from decimal import ROUND_HALF_EVEN
 
-from django import template
 import moneyed
-from moneyed.localization import _format, format_money, _sign
-
+from django import template
+from moneyed.localization import _format, _sign, format_money
 
 register = template.Library()
 

--- a/foundation/urls/meetings.py
+++ b/foundation/urls/meetings.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from .. import views
 
-
 urlpatterns = [
     path('',
          views.MeetingArchiveIndex.as_view(),

--- a/releases/fixtures/doc_releases.json
+++ b/releases/fixtures/doc_releases.json
@@ -147,7 +147,21 @@
     "micro": 0,
     "status": "f",
     "iteration": 0,
-    "is_lts": true
+    "is_lts": false
+  }
+},
+{
+  "model": "releases.release",
+  "pk": "4.1",
+  "fields": {
+    "date": "2022-08-03",
+    "eol_date": null,
+    "major": 4,
+    "minor": 1,
+    "micro": 0,
+    "status": "f",
+    "iteration": 0,
+    "is_lts": false
   }
 }
 ]

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==3.2.14
+Django==3.2.15
 django-contact-form==1.9
 django-hosts==5.1
 django-money==2.1.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,11 +1,11 @@
-Django==3.2.15
+Babel==2.10.1
 django-contact-form==1.9
 django-hosts==5.1
 django-money==2.1.1
-Babel==2.10.1
 django-push==1.1
 django-recaptcha==3.0.0
 django-registration-redux==2.10
+Django==3.2.15
 docutils==0.17.1
 feedparser==6.0.8
 Jinja2==3.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 -r common.txt
-
+pre-commit~=2.20.0
 transifex-client==0.14.4
 watchdog==2.1.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,4 @@
 -r common.txt
-
 django-pylibmc==0.6.1
 django-redis-cache==3.0.1
 pylibmc==1.6.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,3 @@
 -r dev.txt
-
 coverage==6.3.2
 requests-mock==1.9.3


### PR DESCRIPTION
I have done something for the issue #1064 :)  

Looks like that :
<img width="1677" alt="Capture d’écran 2022-08-02 à 00 46 49" src="https://user-images.githubusercontent.com/17890338/182259506-6de3a931-2176-4c2f-8779-9dffa6ee6b7d.png">

UPDATE: 
- Review accessibility colors for dark theme
- Add CSS variables for each colors to make dark / light theme in CSS
- Add switch button to toggle theme (it takes system preferences by default and override it if the button is clicked)
- Change icon switch according Django admin switch based on Furo icon theme

