### PR TITLE
Fixed literal styling in captions.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2314,6 +2314,11 @@ h2 + .list-link-soup {
     code.literal {
         font-weight: 700;
     }
+    .code-block-caption {
+        code.literal {
+            font-weight: 400;
+        }
+    }
 }
 
 .versionadded, .versionchanged, .versionmodified {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2865885/171132949-8b923ea2-1504-4957-b6c9-8621d05152bd.png)

After:
![image](https://user-images.githubusercontent.com/2865885/171132520-741a67b0-60a7-4b70-86df-420ebe4e8a6b.png)

Related to https://github.com/django/django/pull/15745.