### PR TITLE
use nip.io instead of xip.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ To run locally, do the usual:
    ``/etc/hosts`` with your favorite editor.
 
    If you don't have admin rights but have an internet connection, you can use a
-   service like `xip.io <http://xip.io>`_. In that case, you'll also have to
+   service like `nip.io <http://nip.io>`_. In that case, you'll also have to
    update `ALLOWED_HOSTS` in `djangoproject/settings/dev.py` as well as the
    content of the `django_site` table in your database.
 


### PR DESCRIPTION
`xip.io` seems no longer service anymore, and the `nip.io`  do the same thing