### PR TITLE
Updated to Jinja2==3.2.1.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,9 +8,8 @@ django-recaptcha==3.0.0
 django-registration-redux==2.10
 docutils==0.17.1
 feedparser==6.0.8
-Jinja2==2.11.3
+Jinja2==3.1.2
 libsass==0.21.0
-MarkupSafe==2.0.1
 Pillow==9.0.1
 psycopg2==2.9.3
 Pygments==2.12.0


### PR DESCRIPTION
`Jinja2` is "only" one of the `Sphinx` requirements. We should be able to bump it after c4501eebc48a1d904a68d546e3aaa0f7231a86ae.