### PR TITLE
Increased FeedItem.link/Feed.public_url max_length to 1023 characters.

### DIFF
--- a/aggregator/migrations/0003_increase_url_max_length.py
+++ b/aggregator/migrations/0003_increase_url_max_length.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aggregator', '0002_add_feed_approver_auth_group'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='feed',
+            name='public_url',
+            field=models.URLField(max_length=1023),
+        ),
+        migrations.AlterField(
+            model_name='feeditem',
+            name='link',
+            field=models.URLField(max_length=1023),
+        ),
+    ]

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -37,7 +37,7 @@ STATUS_CHOICES = (
 class Feed(models.Model):
     title = models.CharField(max_length=500)
     feed_url = models.URLField(unique=True, max_length=500)
-    public_url = models.URLField(max_length=500)
+    public_url = models.URLField(max_length=1023)
     approval_status = models.CharField(max_length=1, choices=STATUS_CHOICES, default=PENDING_FEED)
     feed_type = models.ForeignKey(FeedType, on_delete=models.CASCADE)
     owner = models.ForeignKey(User, blank=True, null=True, related_name='owned_feeds', on_delete=models.SET_NULL)
@@ -105,7 +105,7 @@ class FeedItemManager(models.Manager):
 class FeedItem(models.Model):
     feed = models.ForeignKey(Feed, on_delete=models.CASCADE)
     title = models.CharField(max_length=500)
-    link = models.URLField(max_length=500)
+    link = models.URLField(max_length=1023)
     summary = models.TextField(blank=True)
     date_modified = models.DateTimeField()
     guid = models.CharField(max_length=500, unique=True, db_index=True)

--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -53,6 +53,13 @@ class AggregatorTests(TestCase):
             approval_status=models.APPROVED_FEED,
             feed_type=self.feed_type,
         )
+        self.approved_feed_long_url, _ = models.Feed.objects.get_or_create(
+            title="Approved long URL",
+            feed_url="www.reddit.com/rss/",
+            public_url="https://www.reddit.com/r/django/?param=" + "x" * 511,
+            approval_status=models.APPROVED_FEED,
+            feed_type=self.feed_type,
+        )
         self.denied_feed, _ = models.Feed.objects.get_or_create(
             title="Denied",
             feed_url="bar.com/rss/",
@@ -68,7 +75,12 @@ class AggregatorTests(TestCase):
             feed_type=self.feed_type,
         )
 
-        for feed in [self.approved_feed, self.denied_feed, self.pending_feed]:
+        for feed in [
+            self.approved_feed,
+            self.approved_feed_long_url,
+            self.denied_feed,
+            self.pending_feed,
+        ]:
             models.FeedItem.objects.get_or_create(
                 feed=feed,
                 title="%s Item" % feed.title,


### PR DESCRIPTION
[See on Sentry](https://sentry.io/organizations/django/issues/3488490686/?referrer=alert_email&alert_type=email&alert_timestamp=1660018743380&alert_rule_id=51107&environment=production).