### PR TITLE
Fixed #1221 -- Add highlight in search results page

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -49,6 +49,10 @@ html[data-theme="light"],
 	--table-color: var(--body-fg);
 	--white-color: #fff;
 
+	--search-link: #{$green};
+	--search-link-hover: #{$green-light};
+	--search-mark-text: #{$green-dark};
+
 }
 
 @media (prefers-color-scheme: dark) {
@@ -90,6 +94,11 @@ html[data-theme="light"],
 		--table-color: var(--body-bg);
 		--cta-color-accent: #{$black};
 		--white-color: #{$black};
+
+		--search-link: #{$green-dark};
+		--search-link-hover: #{$green-light};
+		--search-mark-text: #{$black-light-5};
+
 	}
 
 	body .homepage {
@@ -166,6 +175,10 @@ html[data-theme="dark"] {
 	--table-color: var(--body-bg);
 	--cta-color-accent: #{$black};
 	--white-color: #{$black};
+
+	--search-link: #{$green-dark};
+	--search-link-hover: #{$green-light};
+	--search-mark-text: #{$black-light-5};
 
 
 	.img-release {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2480,7 +2480,19 @@ table.docutils td, table.docutils th {
 
     a {
         mark {
-            @include link-green;
+			color: var(--search-mark-text);
+			text-decoration: none;
+
+			&:visited {
+				color: var(--link-color);
+			}
+
+			&:hover,
+			&:active,
+			&:focus {
+				color: var(--search-link-hover);
+				text-decoration: none;
+			}
             background-color: var(--secondary-accent);
         }
     }
@@ -2523,7 +2535,7 @@ table.docutils td, table.docutils th {
         margin-bottom: 30px;
         mark {
             background-color: var(--secondary-accent);
-            color: var(--body-fg);
+            color: var(--search-mark-text);
         }
     }
 }

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2478,6 +2478,13 @@ table.docutils td, table.docutils th {
 .search-links {
     @extend .list-links;
 
+    a {
+        mark {
+            @include link-green;
+            background-color: var(--secondary-accent);
+        }
+    }
+
     em {
         font-weight: 700;
         color: var(--body-fg);
@@ -2514,6 +2521,10 @@ table.docutils td, table.docutils th {
 
     dd {
         margin-bottom: 30px;
+        mark {
+            background-color: var(--secondary-accent);
+            color: var(--body-fg);
+        }
     }
 }
 

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -36,17 +36,17 @@
     {% for result in page.object_list %}
     <dt>
       <h2 class="result-title">
-        <a href="{% url 'document-detail' lang=result.release.lang version=result.release.version url=result.path host 'docs' %}">{{ result.title }}</a>
+        <a href="{% url 'document-detail' lang=result.release.lang version=result.release.version url=result.path host 'docs' %}">{{ result.headline|safe }}</a>
       </h2>
       <span class="meta breadcrumbs">
-        {% for breadcrumb in result.metadata.breadcrumbs %}
+        {% for breadcrumb in result.breadcrumbs %}
         <a href="{% url 'document-detail' lang=result.release.lang version=result.release.version url=breadcrumb.path host 'docs' %}">{{ breadcrumb.title }}</a>{% if not forloop.last %} <span class="arrow">»</span>{% endif %}
         {% endfor %}
       </span>
     </dt>
     <dd>
-      {% if result.meta.highlight %}
-      {{ result.meta.highlight.content_raw.0|safe }}…
+      {% if result.highlight %}
+      …&nbsp;{{ result.highlight|cut:"¶"|safe }}&nbsp;…
       {% endif %}
     </dd>
     {% endfor %}

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -484,9 +484,35 @@ class DocumentManagerTest(TestCase):
 
     def test_search(self):
         query_text = 'django'
-        document_queryset = Document.objects.search(query_text, self.release).values_list('title', 'rank')
-        document_list = [('Django 1.2.1 release notes', 0.96982837), ('Django 1.9.4 release notes', 0.9490876)]
-        self.assertSequenceEqual(list(document_queryset), document_list)
+        document_list = list(
+            Document.objects.search(
+                query_text, self.release
+            ).values_list(
+                'rank', 'path', 'headline', 'highlight'
+            )
+        )
+        expected_list = [
+            (
+                0.96982837,
+                'releases/1.2.1',
+                '<mark>Django</mark> 1.2.1 release notes',
+                (
+                    '<mark>Django</mark> 1.2.1 release notes ¶  \n '
+                    '<mark>Django</mark> 1.2.1 was released almost immediately after 1.2.0 to correct two small'
+                )
+            ),
+            (
+                0.9490876,
+                'releases/1.9.4',
+                '<mark>Django</mark> 1.9.4 release notes',
+                (
+                    '<mark>Django</mark> 1.9.4 release notes ¶  \n  '
+                    'March 5, 2016  \n '
+                    '<mark>Django</mark> 1.9.4 fixes a regression on Python 2 in the 1.9.3 security'
+                )
+            )
+        ]
+        self.assertSequenceEqual(document_list, expected_list)
 
     def test_websearch(self):
         query_text = 'django "release notes" -packaging'


### PR DESCRIPTION
This only a first attempt to restore the old highlight functionality in the search results page.

Review and local tests are welcome.

This is how it look in my local environment:
![search-results-page-with-highlight-min](https://user-images.githubusercontent.com/521097/193405388-61b60331-436e-427b-a5ce-dfb1925eff63.png)
