### PR TITLE
Refs #1003: Used system font stack for sans-serif text.

### DIFF
--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -95,7 +95,19 @@ $font-path: "../fonts/fira-mono";
     font-family: Palatino, "Palatino Linotype", "Book Antiqua", "Hoefler Text", Georgia, "Lucida Bright", Cambria, Times, "Times New Roman", serif;
 }
 @mixin sans-serif {
-    font-family: "Roboto", Corbel, Avenir, "Lucida Grande", "Lucida Sans", sans-serif;
+    font-family:
+		-apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        system-ui,
+        Roboto,
+        "Helvetica Neue",
+        Arial,
+        sans-serif,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        "Noto Color Emoji";
 }
 @mixin monospace {
     font-family: "Fira Mono", Consolas, Menlo, Monaco, "Courier New", Courier, monospace;

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -27,10 +27,6 @@
       custom: {
         families: ['FontAwesome', 'Fira+Mono'],
       },
-      google: {
-        families: ['Roboto:400italic,700italic,300,700,400:latin'
-        ]
-      },
       classes: false,
       events: false,
       timeout: 1000

--- a/djangoproject/templates/styleguide.html
+++ b/djangoproject/templates/styleguide.html
@@ -106,7 +106,9 @@
     <h2>Typography</h2>
 
     <p>
-      The djangoproject.com website is set in both serif and sans-serif fonts. The serif font is <em>Palatino</em>, which is widely available as a system font. The sans-serif font is <em><a href="https://fonts.google.com/specimen/Roboto">Roboto</a></em>, a web font that is loaded via Google Fonts. 5 styles of this typeface are loaded, <em>Light (300)</em>, <em>Normal (400)</em>, <em>Normal Italic</em>, <em>Bold (700)</em> and <em>Bold Italic</em>. Refrain from using weights and italics that are not loaded.
+      The djangoproject.com website is set in both serif and sans-serif fonts.
+      The serif font is <em>Palatino</em>, which is widely available as a system font.
+      The sans-serif font uses the most appropriate system UI font available.
     </p>
 
     <p>
@@ -119,15 +121,15 @@
 
       <div class="copy-banner">
         <div class="container">
-          <p>Copy Banner text - 32px Roboto Light</p>
+          <p>Copy Banner text - 32px sans-serif Light</p>
         </div>
       </div>
 
-      <h1>H1 Header - 32px Roboto Normal</h1>
-      <h2>H2 Header - 24px Roboto Normal</h2>
-      <h3>H3 Header - 20px Roboto Bold</h3>
-      <h4>H4 Header - 16px Roboto Bold</h4>
-      <h5>H5 Header - 16px Roboto Normal</h5>
+      <h1>H1 Header - 32px sans-serif Normal</h1>
+      <h2>H2 Header - 24px sans-serif Normal</h2>
+      <h3>H3 Header - 20px sans-serif Bold</h3>
+      <h4>H4 Header - 16px sans-serif Bold</h4>
+      <h5>H5 Header - 16px sans-serif Normal</h5>
 
 
       <p>
@@ -143,13 +145,13 @@
     <div class="example">
 
       <div role="complementary">
-        <h1>H1 Header - 28px Roboto Normal</h1>
-        <h2>H2 Header - 20px Roboto Normal</h2>
-        <h3>H3 Header - 18px Roboto Normal</h3>
-        <h4>H4 Header - 16px Roboto Bold</h4>
+        <h1>H1 Header - 28px sans-serif Normal</h1>
+        <h2>H2 Header - 20px sans-serif Normal</h2>
+        <h3>H3 Header - 18px sans-serif Normal</h3>
+        <h4>H4 Header - 16px sans-serif Bold</h4>
 
         <p>
-          Sans-serif paragraph type. Roboto font is used in documentation paragraph text, sidebars, headers, and footers.
+          Sans-serif paragraph type. The system UI font is used in documentation paragraph text, sidebars, headers, and footers.
         </p>
       </div>
 


### PR DESCRIPTION
Looks a bit worse to my eye but maybe it's okay.

Before:
<img width="1509" alt="Screenshot 2022-10-09 at 11 51 29" src="https://user-images.githubusercontent.com/3871354/194753935-b7bff007-803d-49a6-94b1-c1f4542a3cc1.png">

After:
<img width="1512" alt="Screenshot 2022-10-09 at 11 51 40" src="https://user-images.githubusercontent.com/3871354/194753943-6225c03a-ccf8-4b06-8d19-d24cd484e2a7.png">
