### PR TITLE
Fix color contrast in header and footer

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -122,19 +122,7 @@ html[data-theme="light"],
 
     body .copy-banner {
         background: darken($green, 10%);
-
-        p,
-        h1 {
-            color: $green-very-light;
-
-            @include respond-min(768px) {
-                color: $green-very-light;
-            }
-
-            a {
-                color: $green-very-light;
-            }
-        }
+        color: $green-very-light;
     }
 
     body table.django-supported-versions,
@@ -152,6 +140,7 @@ html[data-theme="light"],
 
     body footer {
         background: darken($green, 10%);
+        color: $green-very-light;
     }
 
     body .admonition.warning {
@@ -221,19 +210,7 @@ html[data-theme="dark"] {
 
     .copy-banner {
         background: darken($green, 10%);
-
-        p,
-        h1 {
-            color: $green-very-light;
-
-            @include respond-min(768px) {
-                color: $green-very-light;
-            }
-
-            a {
-                color: $green-very-light;
-            }
-        }
+        color: $green-very-light;
     }
 
     table.django-supported-versions,

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -114,17 +114,6 @@ html[data-theme="light"],
         --community-img-fg: #{$white};
     }
 
-    body .homepage {
-        .copy-banner {
-            background: var(--white-color);
-        }
-    }
-
-    body .copy-banner {
-        background: darken($green, 10%);
-        color: $green-very-light;
-    }
-
     body table.django-supported-versions,
     body table.django-unsupported-versions {
         a {
@@ -136,11 +125,6 @@ html[data-theme="light"],
                 color: var(--table-link-hover);
             }
         }
-    }
-
-    body footer {
-        background: darken($green, 10%);
-        color: $green-very-light;
     }
 
     body .admonition.warning {
@@ -202,17 +186,6 @@ html[data-theme="dark"] {
     --community-img-bg: #{$green-dark};
     --community-img-fg: #{$white};
 
-    .homepage {
-        .copy-banner {
-            background: var(--white-color);
-        }
-    }
-
-    .copy-banner {
-        background: darken($green, 10%);
-        color: $green-very-light;
-    }
-
     table.django-supported-versions,
     table.django-unsupported-versions {
         a {
@@ -230,10 +203,6 @@ html[data-theme="dark"] {
         .admonition-title::before {
             opacity: 1;
         }
-    }
-
-    footer {
-        background: darken($green, 10%);
     }
 }
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -454,6 +454,7 @@ header {
     // Includes global navigation, logo, and tagline at top of document
     @include clearfix;
     background: $green-dark;
+    color: var(--menu);
     overflow: hidden;
     margin: 0;
     padding: 10px 0 6px;
@@ -530,9 +531,9 @@ header {
 
     .menu-button {
         @include font-size(20);
-        background: $green-dark;
+        background: transparent;
         border: 0;
-        color: var(--menu);
+        color: inherit;
         cursor: pointer;
         display: block;
         height: 45px;
@@ -624,7 +625,7 @@ header {
         }
 
         a {
-            color: var(--menu);
+            color: inherit;
             display: block;
             text-decoration: none;
 
@@ -752,6 +753,7 @@ header {
 .copy-banner {
     // Large green callout at the top of the page
     background: var(--primary);
+    color: var(--secondary-accent);
     padding: 1px 10px;
 
     @include respond-min(768px) {
@@ -762,7 +764,7 @@ header {
     h1 {
         @include sans-serif;
         @include font-size(24);
-        color: var(--secondary-accent);
+        color: inherit;
         font-weight: 300;
         line-height: 1.3;
         padding: 1px 0 6px;
@@ -778,14 +780,13 @@ header {
             @include font-size(32);
 
             margin: .35em 0 .35em;
-            color: var(--secondary-accent);
             padding: 1px 0 6px;
 
         }
 
         a {
             font-weight: 300;
-            color: var(--secondary-accent);
+            color: inherit;
             text-decoration: none;
         }
 
@@ -942,6 +943,7 @@ footer {
     @include sans-serif;
     position: relative;
     background: var(--primary);
+    color: var(--menu);
     clear: both;
     margin-top: 0px;
 
@@ -987,7 +989,7 @@ footer {
     h3 {
         @include font-size(16);
         border-top: 1px solid var(--hairline-color);
-        color: var(--menu);
+        color: inherit;
         font-weight: 700;
         margin-top: 20px;
         padding: 30px 0 10px;
@@ -1011,7 +1013,7 @@ footer {
         }
 
         a {
-            color: var(--menu);
+            color: inherit;
             text-decoration: none;
 
             &:visited {
@@ -1029,9 +1031,9 @@ footer {
 
     .footer {
         background: $green-dark;
+        color: var(--primary-accent);
         margin-top: 20px;
         padding: 10px 0 30px;
-        color: var(--primary-accent);
 
         .footer-logo {
             float: left;
@@ -1046,6 +1048,10 @@ footer {
             &:focus {
                 outline: 2px solid var(--menu);
             }
+        }
+
+        a {
+            color: inherit;
         }
     }
 
@@ -1071,7 +1077,6 @@ footer {
 
     .thanks {
         @include font-size(12);
-        color: var(--primary-accent);
         margin: 0;
         padding: 0;
 
@@ -1129,7 +1134,6 @@ footer {
 
         a.in-kind-donors {
             @include font-size(20);
-            color: var(--primary-accent);
 
             &:focus {
                 outline: 2px solid var(--menu);
@@ -1169,10 +1173,6 @@ footer {
             max-width: 80%;
             padding-top: 30px;
             margin: 0;
-        }
-
-        a {
-            color: var(--primary-accent);
         }
     }
 }

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -454,7 +454,7 @@ header {
     // Includes global navigation, logo, and tagline at top of document
     @include clearfix;
     background: $green-dark;
-    color: var(--menu);
+    color: $white;
     overflow: hidden;
     margin: 0;
     padding: 10px 0 6px;
@@ -468,7 +468,7 @@ header {
 
     .meta {
         @include font-size(13);
-        color: var(--primary);
+        color: $green-medium;
         font-weight: 700;
         width: auto;
         margin: 8px 0 0 10px;
@@ -547,7 +547,7 @@ header {
         }
 
         &:active {
-            color: var(--primary);
+            color: $green-medium;
         }
 
         &.active {
@@ -620,7 +620,7 @@ header {
             }
 
             &.active a {
-                color: var(--primary);
+                color: $green-medium;
             }
         }
 
@@ -630,12 +630,12 @@ header {
             text-decoration: none;
 
             &:visited {
-              color: var(--menu);
+              color: $white;
             }
 
             &:active,
             &:hover {
-                color: var(--secondary-accent);
+                color: $green-medium;
             }
         }
 
@@ -646,7 +646,7 @@ header {
 
             &:active,
             &:hover {
-                color: var(--secondary-accent);
+                color: $green-medium;
             }
 
             @include respond-min(1280px) {
@@ -752,8 +752,8 @@ header {
 
 .copy-banner {
     // Large green callout at the top of the page
-    background: var(--primary);
-    color: var(--secondary-accent);
+    background: darken($green, 10%);
+    color: $green-very-light;
     padding: 1px 10px;
 
     @include respond-min(768px) {
@@ -942,8 +942,8 @@ footer {
     @include clearfix;
     @include sans-serif;
     position: relative;
-    background: var(--primary);
-    color: var(--menu);
+    background: darken($green, 10%);
+    color: $green-very-light;
     clear: both;
     margin-top: 0px;
 
@@ -1031,7 +1031,7 @@ footer {
 
     .footer {
         background: $green-dark;
-        color: var(--primary-accent);
+        color: $green-light;
         margin-top: 20px;
         padding: 10px 0 30px;
 


### PR DESCRIPTION
This replaces #998. I decided to create a new pull request because the code had changed so much in the meantime that a simple rebase was not enough.

I noticed that the dark theme does not inverse colors in the header and footer, but improves their contrast. So my proposal is to use the better contrast version with both themes.

I did not check the contrast on other parts of the page.