### PR TITLE
Refs #1244 -- alert message text visibility in dark mode

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2288,7 +2288,8 @@ h2 + .list-link-soup {
     @include sans-serif;
     font-size: 14px;
     text-align: center;
-    background-color: #ffe761;
+    background-color: $warning-bg;
+	color: $text;
 
     @include respond-min(768px) {
         position: fixed;

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -24,6 +24,7 @@ $green-dark: #0C4B33;
 $green-dark-text: #3C8866;
 $white: #F1FFF7;
 $white-dark: #F8F8F8;
+$warning-bg: #ffe761;
 $warning-yellow: #FFFDF1;
 $warning-dark-yellow: #F5F1C7;
 $warning-dark-yellow-d50: darken($warning-dark-yellow, 50);


### PR DESCRIPTION
Closes #1244 

- add variable for the background
- fix color text

Before the fix : 
<img width="1516" alt="Capture d’écran 2022-10-15 à 16 27 03" src="https://user-images.githubusercontent.com/17890338/195991741-eb502418-3bba-4be8-afad-74e70d7aa092.png">
<img width="1539" alt="Capture d’écran 2022-10-15 à 16 26 53" src="https://user-images.githubusercontent.com/17890338/195991744-62a2ac24-c32d-44bc-a569-9de7ca5caa4d.png">

After the fix : 
<img width="1614" alt="Capture d’écran 2022-10-15 à 16 26 11" src="https://user-images.githubusercontent.com/17890338/195991750-6db07311-74c1-455d-9794-3f191ee5cfe6.png">
<img width="1567" alt="Capture d’écran 2022-10-15 à 16 26 29" src="https://user-images.githubusercontent.com/17890338/195991757-8372b0fc-db94-4bd2-bc3c-01efbab564c9.png">
