### PR TITLE
Added theme color meta tag

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -17,6 +17,7 @@
     <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
     <meta name="msapplication-TileColor" content="#113228">
     <meta name="msapplication-TileImage" content="{% static "img/icon-tile.png" %}">
+    <meta name="theme-color" content="#0C4B33">
 
     <title>{% block title %}The web framework for perfectionists with deadlines{% endblock %} | Django</title>
 


### PR DESCRIPTION
Noticed this missing while browsing the site on mobile. This theme color is used mostly by mobile browser to color part of their UI and it makes the header look quite nice.