### PR TITLE
Feature/fixed textarea styles in dark mode

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1321,6 +1321,7 @@ blockquote {
 
 .codedump {
     background: var(--code-bg);
+	color: var(--code-fg);
     border: 1px solid var(--hairline-color);
     padding: 10px;
     border-radius: 4px;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1321,7 +1321,7 @@ blockquote {
 
 .codedump {
     background: var(--code-bg);
-	color: var(--code-fg);
+    color: var(--code-fg);
     border: 1px solid var(--hairline-color);
     padding: 10px;
     border-radius: 4px;

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -17,6 +17,7 @@
     <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
     <meta name="msapplication-TileColor" content="#113228">
     <meta name="msapplication-TileImage" content="{% static "img/icon-tile.png" %}">
+    <meta name="theme-color" content="#0C4B33">
 
     <title>{% block title %}The web framework for perfectionists with deadlines{% endblock %} | Django</title>
 

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -17,7 +17,6 @@
     <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
     <meta name="msapplication-TileColor" content="#113228">
     <meta name="msapplication-TileImage" content="{% static "img/icon-tile.png" %}">
-    <meta name="theme-color" content="#0C4B33">
 
     <title>{% block title %}The web framework for perfectionists with deadlines{% endblock %} | Django</title>
 


### PR DESCRIPTION
After the recent dark mode introduction some `textarea` elements with `.codedump` class have black text making it super hard to read.