### PR TITLE
Introducing i18n URL patterns (#883)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ data
 *.db
 locale/*/LC_MESSAGES/django.mo
 */locale/*/LC_MESSAGES/django.mo
+locale/*/LC_MESSAGES/djangojs.mo
+*/locale/*/LC_MESSAGES/djangojs.mo
 .sass-cache/
 .coverage
 .tox

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import Profile
 
@@ -12,11 +13,11 @@ class ProfileForm(forms.ModelForm):
     """
     name = forms.CharField(
         required=False,
-        widget=forms.TextInput(attrs={'placeholder': 'Name'})
+        widget=forms.TextInput(attrs={'placeholder': _('Name')})
     )
     email = forms.EmailField(
         required=False,
-        widget=forms.TextInput(attrs={'placeholder': 'Email'})
+        widget=forms.TextInput(attrs={'placeholder': _('Email')})
     )
 
     class Meta:

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -19,7 +19,7 @@ class ViewTests(TestCase):
 
     def test_login_redirect(self):
         response = self.client.post(reverse('login'), self.credentials)
-        self.assertRedirects(response, '/accounts/edit/')
+        self.assertRedirects(response, '/en/accounts/edit/')
 
     def test_profile_view_reversal(self):
         """

--- a/aggregator/admin.py
+++ b/aggregator/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
 from .models import APPROVED_FEED, DENIED_FEED, Feed, FeedItem, FeedType
 
@@ -9,7 +10,7 @@ def mark_approved(modeladmin, request, queryset):
         item.save()
 
 
-mark_approved.short_description = "Mark selected feeds as approved."
+mark_approved.short_description = _("Mark selected feeds as approved.")
 
 
 def mark_denied(modeladmin, request, queryset):
@@ -18,7 +19,7 @@ def mark_denied(modeladmin, request, queryset):
         item.save()
 
 
-mark_denied.short_description = "Mark selected feeds as denied."
+mark_denied.short_description = _("Mark selected feeds as denied.")
 
 
 admin.site.register(

--- a/aggregator/feeds.py
+++ b/aggregator/feeds.py
@@ -1,5 +1,6 @@
 from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from django_hosts.resolvers import reverse
 
 from .models import FeedItem, FeedType
@@ -39,7 +40,7 @@ class CommunityAggregatorFeed(BaseCommunityAggregatorFeed):
         return qs[:25]
 
     def title(self, obj):
-        return "Django community aggregator: %s" % obj.name
+        return _("Django community aggregator: %s" % obj.name)
 
     def link(self, obj):
         return reverse('aggregator-feed', args=[obj.slug], host='www')
@@ -49,8 +50,8 @@ class CommunityAggregatorFeed(BaseCommunityAggregatorFeed):
 
 
 class CommunityAggregatorFirehoseFeed(BaseCommunityAggregatorFeed):
-    title = 'Django community aggregator firehose'
-    description = 'All activity from the Django community aggregator'
+    title = _('Django community aggregator firehose')
+    description = _('All activity from the Django community aggregator')
 
     def link(self):
         return reverse('aggregator-firehose-feed', host='www')

--- a/aggregator/forms.py
+++ b/aggregator/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import Feed
 
@@ -8,21 +9,21 @@ class FeedModelForm(forms.ModelForm):
         max_length=250,
         widget=forms.TextInput(attrs={
             'class': 'required',
-            'placeholder': 'Title of the resource / blog',
+            'placeholder': _('Title of the resource / blog'),
         }),
     )
     feed_url = forms.URLField(
         label='Feed URL',
         widget=forms.TextInput(attrs={
             'class': 'required',
-            'placeholder': 'Link to the RSS/Atom feed. Please only use Django-specific feeds.',
+            'placeholder': _('Link to the RSS/Atom feed. Please only use Django-specific feeds.'),
         }),
     )
     public_url = forms.URLField(
         label='Public URL',
         widget=forms.TextInput(attrs={
             'class': 'required',
-            'placeholder': 'Link to main page (i.e. blog homepage)',
+            'placeholder': _('Link to main page (i.e. blog homepage)'),
         }),
     )
 
@@ -34,7 +35,6 @@ class FeedModelForm(forms.ModelForm):
         feed_url = self.cleaned_data.get('feed_url')
         if feed_url and '//stackoverflow.com' in feed_url:
             raise forms.ValidationError(
-                "Stack Overflow questions tagged with 'django' will appear "
-                "here automatically."
+                _("Stack Overflow questions tagged with 'django' will appear here automatically.")
             )
         return feed_url

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -5,6 +5,7 @@ import feedparser
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 from django_push.subscriber import signals as push_signals
 from django_push.subscriber.models import Subscription
 
@@ -28,9 +29,9 @@ DENIED_FEED = 'D'
 PENDING_FEED = 'P'
 
 STATUS_CHOICES = (
-    (PENDING_FEED, 'Pending'),
-    (DENIED_FEED, 'Denied'),
-    (APPROVED_FEED, 'Approved')
+    (PENDING_FEED, _('Pending')),
+    (DENIED_FEED, _('Denied')),
+    (APPROVED_FEED, _('Approved'))
 )
 
 

--- a/aggregator/views.py
+++ b/aggregator/views.py
@@ -1,8 +1,8 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
-from django.views.generic.list import ListView
 from django.utils.translation import gettext_lazy as _
+from django.views.generic.list import ListView
 
 from .forms import FeedModelForm
 from .models import APPROVED_FEED, Feed, FeedItem, FeedType

--- a/aggregator/views.py
+++ b/aggregator/views.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic.list import ListView
+from django.utils.translation import gettext_lazy as _
 
 from .forms import FeedModelForm
 from .models import APPROVED_FEED, Feed, FeedItem, FeedType
@@ -72,7 +73,7 @@ def add_feed(request, feed_type_slug):
     if f.is_valid():
         f.save()
         messages.add_message(
-            request, messages.INFO, 'Your feed has entered moderation. Please allow up to 1 week for processing.')
+            request, messages.INFO, _('Your feed has entered moderation. Please allow up to 1 week for processing.'))
         return redirect('community-index')
 
     ctx = {'form': f, 'feed_type': ft, 'adding': True}

--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -1,12 +1,13 @@
 from django.contrib.syndication.views import Feed
+from django.utils.translation import gettext_lazy as _
 
 from .models import Entry
 
 
 class WeblogEntryFeed(Feed):
-    title = "The Django weblog"
+    title = _("The Django weblog")
     link = "https://www.djangoproject.com/weblog/"
-    description = "Latest news about Django, the Python web framework."
+    description = _("Latest news about Django, the Python web framework.")
 
     def items(self):
         return Entry.objects.published()[:10]

--- a/contact/forms.py
+++ b/contact/forms.py
@@ -8,6 +8,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.utils.encoding import force_bytes
+from django.utils.translation import gettext_lazy as _
 from pykismet3 import Akismet, AkismetServerError
 
 logger = logging.getLogger(__name__)
@@ -16,18 +17,18 @@ logger = logging.getLogger(__name__)
 class BaseContactForm(ContactForm):
     message_subject = forms.CharField(
         max_length=100,
-        widget=forms.TextInput(attrs={'class': 'required', 'placeholder': 'Message subject'}),
-        label='Message subject',
+        widget=forms.TextInput(attrs={'class': 'required', 'placeholder': _('Message subject')}),
+        label=_('Message subject'),
     )
-    email = forms.EmailField(widget=forms.TextInput(attrs={'class': 'required', 'placeholder': 'E-mail'}))
-    name = forms.CharField(widget=forms.TextInput(attrs={'class': 'required', 'placeholder': 'Name'}))
-    body = forms.CharField(widget=forms.Textarea(attrs={'class': 'required', 'placeholder': 'Your message'}))
+    email = forms.EmailField(widget=forms.TextInput(attrs={'class': 'required', 'placeholder': _('E-mail')}))
+    name = forms.CharField(widget=forms.TextInput(attrs={'class': 'required', 'placeholder': _('Name')}))
+    body = forms.CharField(widget=forms.Textarea(attrs={'class': 'required', 'placeholder': _('Your message')}))
     captcha = ReCaptchaField(widget=ReCaptchaV3)
 
     def subject(self):
         # Strip all linebreaks from the subject string.
         subject = ''.join(self.cleaned_data["message_subject"].splitlines())
-        return "[Contact form] " + subject
+        return _("[Contact form] ") + subject
 
     def message(self):
         return "From: {name} <{email}>\n\n{body}".format(**self.cleaned_data)
@@ -61,7 +62,7 @@ class BaseContactForm(ContactForm):
                     # they should ignore the request so that test runs affect the heuristics
                     akismet_data['test'] = 1
                 if akismet_api.check(akismet_data):
-                    raise forms.ValidationError("Akismet thinks this message is spam")
+                    raise forms.ValidationError(_("Akismet thinks this message is spam"))
             except AkismetServerError:
                 logger.error('Akismet server error')
         return self.cleaned_data['body']

--- a/contact/tests.py
+++ b/contact/tests.py
@@ -23,7 +23,7 @@ has_network_connection = check_network_connection()
 @override_settings(AKISMET_TESTING=True)
 class ContactFormTests(TestCase):
     def setUp(self):
-        self.url = '/contact/foundation/'
+        self.url = '/en/contact/foundation/'
 
     @override_settings(AKISMET_API_KEY='')  # Disable Akismet in tests
     def test_invalid_email(self):
@@ -45,7 +45,7 @@ class ContactFormTests(TestCase):
             'body': 'Hello, World!',
             'captcha': 'TESTING',
         })
-        self.assertRedirects(response, '/contact/sent/')
+        self.assertRedirects(response, '/en/contact/sent/')
         self.assertEqual(mail.outbox[-1].subject, '[Contact form] Hello')
 
     @skipIf(not has_network_connection, 'Requires a network connection')
@@ -78,7 +78,7 @@ class ContactFormTests(TestCase):
             'body': 'Hello, World!',
             'captcha': 'TESTING',
         })
-        self.assertRedirects(response, '/contact/sent/')
+        self.assertRedirects(response, '/en/contact/sent/')
         self.assertEqual(mail.outbox[-1].subject, '[Contact form] Hello')
 
     @skipIf(not has_network_connection, 'Requires a network connection')

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -10,6 +10,7 @@ from django.contrib.contenttypes.fields import (
 )
 from django.contrib.contenttypes.models import ContentType
 from django.db import connections, models
+from django.utils.translation import gettext_lazy as _
 from django_hosts.resolvers import reverse
 
 METRIC_PERIOD_INSTANT = 'instant'
@@ -91,7 +92,7 @@ class Metric(models.Model):
 
     def _gather_data_periodic(self, since, period):
         """
-        Gather data from "periodic" merics.
+        Gather data from "periodic" metrics.
 
         Period metrics are reset every day/week/month and count up as the period
         goes on. Think "commits today" or "new tickets this week".
@@ -177,25 +178,29 @@ class JenkinsFailuresMetric(Metric):
     API.
     """
     jenkins_root_url = models.URLField(
-        verbose_name='Jenkins instance root URL',
+        verbose_name=_('Jenkins instance root URL'),
         max_length=1000,
         help_text='E.g. http://ci.djangoproject.com/',
     )
     build_name = models.CharField(
         max_length=100,
-        help_text='E.g. Django Python3',
+        help_text=_('E.g. Django Python3'),
     )
     is_success_cnt = models.BooleanField(
         default=False,
-        verbose_name='Should the metric be a value representing success ratio?',
-        help_text='E.g. if there are 50 tests of which 30 are failing the value of this metric '
-                  'will be 20 (or 40%.)',
+        verbose_name=_('Should the metric be a value representing success ratio?'),
+        help_text=_(
+            'E.g. if there are 50 tests of which 30 are failing the value of this metric '
+            'will be 20 (or 40%.)'
+        ),
     )
     is_percentage = models.BooleanField(
         default=False,
-        verbose_name='Should the metric be a percentage value?',
-        help_text='E.g. if there are 50 tests of which 30 are failing the value of this metric '
-                  'will be 60%.',
+        verbose_name=_('Should the metric be a percentage value?'),
+        help_text=_(
+            'E.g. if there are 50 tests of which 30 are failing the value of this metric '
+            'will be 60%.'
+        ),
     )
 
     def urljoin(self, *parts):

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.forms.models import model_to_dict
 from django.http.response import Http404, JsonResponse
 from django.shortcuts import render
+from django.utils.translation import gettext_lazy as _
 
 from .models import Metric
 from .utils import generation_key
@@ -65,4 +66,4 @@ def _find_metric_or_404(slug):
             return MC.objects.get(slug=slug)
         except MC.DoesNotExist:
             continue
-    raise Http404('Could not find metric with slug %s' % slug)
+    raise Http404(_('Could not find metric with slug %s' % slug))

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -3,6 +3,12 @@ import json
 import os
 from pathlib import Path
 
+
+def gettext(s):
+    """ i18n passthrough """
+    return s
+
+
 # Utilities
 PROJECT_PACKAGE = Path(__file__).resolve().parent.parent
 
@@ -90,7 +96,19 @@ INSTALLED_APPS = [
     'django_push.subscriber',
 ]
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
+
+LANGUAGES = (
+    ('en', gettext('English')),
+    ('fr', gettext('French')),
+    ('id', gettext('Indonesian')),
+    ('pl', gettext('Polish')),
+    ('pt-br', gettext('Portuguese (Brazil)')),
+)
+
+LOCALE_PATHS = [
+    str(BASE_DIR.joinpath('locale')),
+]
 
 LOGGING = {
     "version": 1,

--- a/djangoproject/static/js/mod/clippify.js
+++ b/djangoproject/static/js/mod/clippify.js
@@ -3,7 +3,8 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
         var header = $(this);
         var wrapper = header.parent();
         var code = $('.highlight', wrapper);
-        var btn = $('<span class="btn-clipboard" title="Copy this code">');
+		var copy_str = gettext("Copy this code");
+        var btn = $('<span class="btn-clipboard" title="' + copy_str + '">');
         btn.append('<i class="icon icon-clipboard">');
         btn.data('clipboard-text', $.trim(code.text()));
         header.append(btn);
@@ -11,7 +12,8 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
     // For Django 2.0 docs and older.
     $('.snippet').each(function() {
         var code = $('.highlight', this);
-        var btn = $('<span class="btn-clipboard" title="Copy this code">');
+		var copy_str = gettext("Copy this code");
+        var btn = $('<span class="btn-clipboard" title="' + copy_str + '">');
         var header = $('.snippet-filename', this);
 
         btn.append('<i class="icon icon-clipboard">');
@@ -24,14 +26,16 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
         }
     });
     clip.on('success', function(e) {
-        var success = $('<span class="clipboard-success">').text('Copied!')
+		var copy_str = gettext("Copied!");
+        var success = $('<span class="clipboard-success">').text(copy_str);
         success.prependTo(e.trigger).delay(1000).fadeOut();
     });
     clip.on('error', function(e) {
         // Safari doesn't support the execCommand (yet) but because clipboardjs
         // also uses Selection API, we can instruct users to just press the keyboard shortcut
         // See https://clipboardjs.com/#browser-support
-        var success = $('<span class="clipboard-success">').text('Press ⌘-C to copy');
+		var copy_str = gettext("Press ⌘-C to copy");
+        var success = $('<span class="clipboard-success">').text(copy_str);
         success.prependTo(e.trigger).delay(5000).fadeOut();
     });
 });

--- a/djangoproject/static/js/mod/fundraising-index.js
+++ b/djangoproject/static/js/mod/fundraising-index.js
@@ -28,7 +28,7 @@ define([
                 }
             },
             setDonateButtonText: function(event) {
-                var text = 'Donate';
+                var text = gettext('Donate');
                 var interval = $('#id_interval').val();
                 if (interval != 'onetime') {
                     text += ' ' + interval;

--- a/djangoproject/static/js/mod/list-collapsing.js
+++ b/djangoproject/static/js/mod/list-collapsing.js
@@ -16,8 +16,8 @@ define([
             this.items = this.list.children('li'); //get items
             this.headings = this.items.children('h2'); //get headings
 
-            this.buttonExpand = $('<span class="expandall">Expand All</span>'); //build buttons
-            this.buttonCollapse = $('<span class="collapseall">Collapse All</span>'); //build buttons
+            this.buttonExpand = $('<span class="expandall">' + gettext("Expand All") + '</span>'); //build buttons
+            this.buttonCollapse = $('<span class="collapseall">' + gettext("Collapse All") + '</span>'); //build buttons
             this.buttonContainer = $('<span class="form-controls label"></span>').insertBefore(this.list); //create a button container
             this.buttonContainer //append container to label
                 .append(this.buttonExpand)

--- a/djangoproject/static/js/mod/mobile-menu.js
+++ b/djangoproject/static/js/mod/mobile-menu.js
@@ -11,8 +11,9 @@ define([
     MobileMenuExport.prototype = {
         init: function(){
             var self = this;
+			var label = gettext('Menu');
             self.menu.addClass('nav-menu-on');
-            self.button = $('<div class="menu-button"><i class="icon icon-reorder"></i><span>Menu</span></div>');
+            self.button = $('<div class="menu-button"><i class="icon icon-reorder"></i><span>' + label + '</span></div>');
             self.button.insertBefore(self.menuBtn);
             self.button.on( 'click', function(){
                 self.menu.toggleClass('active');

--- a/djangoproject/static/js/mod/stripe-change-card.js
+++ b/djangoproject/static/js/mod/stripe-change-card.js
@@ -17,6 +17,7 @@ define([
                     'donation_id': donationId,
                     'csrfmiddlewaretoken': csrfToken
                 };
+				var success_copy = gettext('Card updated');
                 $.ajax({
                     type: "POST",
                     url: $heroForm.data('update-card-url'),
@@ -24,7 +25,7 @@ define([
                     dataType: 'json',
                     success: function (data) {
                         if (data.success) {
-                            $this.parent().find('.change-card-result').text('Card updated');
+                            $this.parent().find('.change-card-result').text(success_copy);
                         } else {
                             alert(data.error);
                         }

--- a/djangoproject/static/js/mod/stripe-donation.js
+++ b/djangoproject/static/js/mod/stripe-donation.js
@@ -28,11 +28,11 @@ define([
                     var stripe = Stripe($donationForm.data('stripeKey'))
                     return stripe.redirectToCheckout({sessionId: data.sessionId})
                 } else {
-                    msg = 'There was an error setting up your donation. '
+                    msg = gettext('There was an error setting up your donation. ');
                     if (data.error.amount) {
                         msg += data.error.amount
                     } else {
-                        msg += 'Sorry. Please refresh the page and try again.'
+                        msg += gettext('Sorry. Please refresh the page and try again.');
                     }
                     alert(msg);
                 }

--- a/djangoproject/templates/400.html
+++ b/djangoproject/templates/400.html
@@ -1,11 +1,12 @@
 {% extends 'base_error.html' %}
+{% load i18n %}
 
-{% block title %}Bad request{% endblock %}
+{% block title %}{% translate "Bad request" %}{% endblock %}
 
 {% block header %}<h1>400</h1>{% endblock %}
 
 {% block content %}
-<h2>Bad request</h2>
+<h2>{% translate "Bad request" %}</h2>
 
-<p>Yikes, this was a bad request. Not sure why, but it sure was bad.</p>
+<p>{% translate "Yikes, this was a bad request. Not sure why, but it sure was bad." %}</p>
 {% endblock %}

--- a/djangoproject/templates/403.html
+++ b/djangoproject/templates/403.html
@@ -1,11 +1,12 @@
 {% extends 'base_error.html' %}
+{% load i18n %}
 
-{% block title %}Permission denied{% endblock %}
+{% block title %}{% translate "Permission denied" %}{% endblock %}
 
 {% block header %}<h1>403</h1>{% endblock %}
 
 {% block content %}
-<h2>Permission denied</h2>
+<h2>{% translate "Permission denied" %}</h2>
 
-<p>Apologies, but it seems as if you're not allowed to access this page. We honestly hope this is just a mistake.</p>
+<p>{% translate "Apologies, but it seems as if you're not allowed to access this page. We honestly hope this is just a mistake." %}</p>
 {% endblock %}

--- a/djangoproject/templates/404.html
+++ b/djangoproject/templates/404.html
@@ -12,7 +12,7 @@
   Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/">let us know</a>.
 {% endblocktranslate %}</p>
   
-{% url 'homepage' with home_url %}
+{% url 'homepage' as home_url %}
 <p>{% blocktranslate %}Here's a link to the <a href="{{ home_url }}">homepage</a>. You know, just in case.{% endblocktranslate %}</p>
 
 

--- a/djangoproject/templates/404.html
+++ b/djangoproject/templates/404.html
@@ -1,14 +1,19 @@
 {% extends 'base_error.html' %}
+{% load i18n %}
 
-{% block title %}Page not found{% endblock %}
+{% block title %}{% translate "Page not found" %}{% endblock %}
 
 {% block header %}<h1>404</h1>{% endblock %}
 
 {% block content %}
-<h2>Page not found</h2>
+<h2>{% translate "Page not found" %}</h2>
 
-<p>Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/">let us know</a>.</p>
+<p>{% blocktranslate trimmed %}
+  Looks like you followed a bad link. If you think it's our fault, please <a href="https://code.djangoproject.com/">let us know</a>.
+{% endblocktranslate %}</p>
+  
+{% url 'homepage' with home_url %}
+<p>{% blocktranslate %}Here's a link to the <a href="{{ home_url }}">homepage</a>. You know, just in case.{% endblocktranslate %}</p>
 
-<p>Here's a link to the <a href="{% url 'homepage' %}">homepage</a>. You know, just in case.</p>
 
 {% endblock %}

--- a/djangoproject/templates/410.html
+++ b/djangoproject/templates/410.html
@@ -9,7 +9,7 @@
 <h2>{% translate "Page removed." %}</h2>
 
 <p>
-{% url 'homepage' host 'docs' with docs_url %}
+{% url 'homepage' host 'docs' as docs_url %}
 {% blocktranslate trimmed %}
   Sorry, we've removed some of parts of the site that were completely out
   of date. In most cases, that content has been moved into

--- a/djangoproject/templates/410.html
+++ b/djangoproject/templates/410.html
@@ -1,16 +1,23 @@
 {% extends 'base_error.html' %}
+{% load i18n %}
 
-{% block title %}Page removed{% endblock %}
+{% block title %}{% translate "Page removed" %}{% endblock %}
 
 {% block header %}<h1>410</h1>{% endblock %}
 
 {% block content %}
-<h2>Page removed.</h2>
+<h2>{% translate "Page removed." %}</h2>
 
-<p>Sorry, we've removed some of parts of the site that were completely out
-of date. In most cases, that content has been moved into
-<a href="{% url 'homepage' host 'docs' %}">the new documentation site</a>.</p>
+<p>
+{% url 'homepage' host 'docs' with docs_url %}
+{% blocktranslate wit %}
+  Sorry, we've removed some of parts of the site that were completely out
+  of date. In most cases, that content has been moved into
+  <a href="{{ docs_url }}">the new documentation site</a>.
+{% endblocktranslate %}
+</p>
 
-<p>Here's a link to the <a href="{% url 'homepage' %}">homepage</a>. You know, just in case.</p>
+{% url 'homepage' with home_url %}
+<p>{% blocktranslate %}Here's a link to the <a href="{{ home_url }}">homepage</a>. You know, just in case.{% endblocktranslate %}</p>
 
 {% endblock %}

--- a/djangoproject/templates/410.html
+++ b/djangoproject/templates/410.html
@@ -10,14 +10,14 @@
 
 <p>
 {% url 'homepage' host 'docs' with docs_url %}
-{% blocktranslate wit %}
+{% blocktranslate trimmed %}
   Sorry, we've removed some of parts of the site that were completely out
   of date. In most cases, that content has been moved into
   <a href="{{ docs_url }}">the new documentation site</a>.
 {% endblocktranslate %}
 </p>
 
-{% url 'homepage' with home_url %}
+{% url 'homepage' as home_url %}
 <p>{% blocktranslate %}Here's a link to the <a href="{{ home_url }}">homepage</a>. You know, just in case.{% endblocktranslate %}</p>
 
 {% endblock %}

--- a/djangoproject/templates/500.html
+++ b/djangoproject/templates/500.html
@@ -1,15 +1,16 @@
 {% extends 'base_error.html' %}
+{% load i18n %}
 
-{% block title %}Page unavailable{% endblock %}
+{% block title %}{% translate "Page unavailable" %}{% endblock %}
 
 {% block header %}<h1>500</h1>{% endblock %}
 
 {% block content %}
-<h2>Page unavailable</h2>
+<h2>{% translate "Page unavailable" %}</h2>
 
-<p>We're sorry, but the requested page is currently unavailable.</p>
+<p>{% translate "We're sorry, but the requested page is currently unavailable." %}</p>
 
-<p>We're messing around with things internally, and the server had a bit of a hiccup.</p>
+<p>{% translate "We're messing around with things internally, and the server had a bit of a hiccup." %}</p>
 
-<p>Please try again later.</p>
+<p>{% translate "Please try again later." %}</p>
 {% endblock %}

--- a/djangoproject/templates/accounts/edit_profile.html
+++ b/djangoproject/templates/accounts/edit_profile.html
@@ -1,14 +1,15 @@
 {% extends "registration/base.html" %}
+{% load i18n %}
 
-{% block title %}Edit your profile{% endblock %}
+{% block title %}{% translate "Edit your profile" %}{% endblock %}
 
 {% block content %}
 
     {% if form.errors %}
-        <p class="errors">Please correct the errors below: {{ form.non_field_errors }}</p>
+        <p class="errors">{% translate "Please correct the errors below:" %} {{ form.non_field_errors }}</p>
     {% endif %}
 
-    <h1>Edit your profile</h1>
+    <h1>{% translate "Edit your profile" %}</h1>
 
     <form method="post" action="" class="form-input">
         {% csrf_token %}
@@ -27,25 +28,27 @@
         </div>
 
         <div class="submit">
-            <input class="cta" type="submit" value="Save"/>
+            <input class="cta" type="submit" value="{% translate "Save" %}"/>
         </div>
     </form>
 {% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">Additional Information</h1>
+    <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
     <div role="complementary">
-        <h2>Help</h2>
+        <h2>{% translate "Help" %}</h2>
 
-        <p>Use this form to edit your profile.</p>
+        <p>{% translate "Use this form to edit your profile." %}</p>
 
-        <p>Use whatever name you'd like to be identified with on djangoproject.com. If
-            you leave it blank, we'll identify you as <b>{{ user.username }}</b>, your
-            username.</p>
+        <p>{% blocktranslate trimmed with username=user.username %}
+            Use whatever name you'd like to be identified with on djangoproject.com. If
+            you leave it blank, we'll identify you as <b>{{ username }}</b>, your
+            username.{% endblocktranslate %}</p>
 
-        <p>We hate spam as much as you do. We'll only use it to send you password reset
+        <p>{% blocktranslate trimmed %}
+            We hate spam as much as you do. We'll only use it to send you password reset
             emails. We'll also use this email to try to fetch a <a
                     href="https://en.gravatar.com/">Gravatar</a>. You can change the image for this
-            email at <a href="https://en.gravatar.com/">Gravatar</a>.</p>
+            email at <a href="https://en.gravatar.com/">Gravatar</a>.{% endblocktranslate %}</p>
     </div>
 {% endblock %}

--- a/djangoproject/templates/accounts/user_profile.html
+++ b/djangoproject/templates/accounts/user_profile.html
@@ -1,50 +1,50 @@
 {% extends "base_community.html" %}
-{% load humanize %}
+{% load humanize i18n %}
 
 {% block title %}{% firstof user_obj.profile.name user_obj.username %}{% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">Additional Information</h1>
+    <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
     <div role="complementary">
         <h2>
             {% if user_obj == user %}
-                This is you!
+                {% translate "This is you!" %}
             {% else %}
-                Is this you?
+                {% translate "Is this you?" %}
             {% endif %}
         </h2>
 
-        <p>Need to edit something? Here's how:</p>
+        <p>{% translate "Need to edit something? Here's how:" %}</p>
         <ul>
-            <li><a href="{% url 'edit_profile' %}">Edit your name and email here.</a></li>
-            <li>
+            <li><a href="{% url 'edit_profile' %}">{% translate "Edit your name and email here." %}</a></li>
+            <li>{% blocktranslate trimmed %}
                 The image is the <a href="https://en.gravatar.com/">Gravatar</a> linked
                 to the email address you signed up with. You can change the image over
                 at <a href="https://en.gravatar.com/">Gravatar</a>. If you see a robot, that's
                 because you don't have a Gravatar yet.
-                (Robots provided by <a href="https://robohash.org/">Robohash</a>.)
+                (Robots provided by <a href="https://robohash.org/">Robohash</a>.){% endblocktranslate %}
             </li>
-            <li>
+            <li>{% blocktranslate trimmed %}
                 The rest of the data is read-only for the time being. If you see
-                outrageous errors, please email <kbd>jacob</kbd> @ this domain.
+                outrageous errors, please email <kbd>jacob</kbd> @ this domain.{% endblocktranslate %}
             </li>
         </ul>
     </div>
 {% endblock %}
 
 {% block content %}
-    <div class  ="user-info">
+    <div class="user-info">
         <img class='avatar' width='150' height='150'
              src="https://secure.gravatar.com/avatar/{{ email_hash }}?s=150&amp;d=https%3A%2F%2Frobohash.org%2F{{ email_hash }}%3Fset%3Dset3%26size%3D150x150">
 
         <h1>
             {% firstof user_obj.profile.name user_obj.username %}
-            {% if user_can_commit %}<span class="badge" title="Core team member">core
+            {% if user_can_commit %}<span class="badge" title="{% translate "Core team member" %}">{% translate "core" %}
                 </span>{% endif %}
         </h1>
 
         {% if stats %}
-            <h2>Lies, damned lies, and statistics:</h2>
+            <h2>{% translate "Lies, damned lies, and statistics:" %}</h2>
             <ul>
                 {% for stat, value in stats.items %}
                     <li>{{ stat }}: {{ value|intcomma }}.</li>
@@ -54,7 +54,7 @@
 
         {% with user_obj.owned_feeds.all as feeds %}
             {% if feeds %}
-                <h2>Community feeds:</h2>
+                <h2>{% translate "Community feeds:" %}</h2>
                 <ul>
                     {% for f in feeds %}
                         <li><a href="{{ f.public_url }}">{{ f.title }}</a></li>

--- a/djangoproject/templates/aggregator/delete-confirm.html
+++ b/djangoproject/templates/aggregator/delete-confirm.html
@@ -1,17 +1,18 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content %}
-<h1>Community</h1>
+<h1>{% translate "Community" %}</h1>
 
-<h2 class="deck">Really delete {{ feed }}?</h2>
+<h2 class="deck">{% blocktranslate with feed=feed %}Really delete {{ feed }}?{% endblocktranslate %}</h2>
 
-<p>
+<p>{% blocktranslate trimmed %}
   All items in the aggregator will be deleted, too. Because Jacob's
-  lazy, there's no "undo"!
+  lazy, there's no "undo"!{% endblocktranslate %}
 </p>
 
 <form class="wide" action="." method="post">
   {% csrf_token %}
-  <p class="submit"><input class="cta" type="submit" value="Yes, delete the feed."></p>
+  <p class="submit"><input class="cta" type="submit" value="{% translate "Yes, delete the feed." %}"></p>
 </form>
 {% endblock %}

--- a/djangoproject/templates/aggregator/denied.html
+++ b/djangoproject/templates/aggregator/denied.html
@@ -1,7 +1,8 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content %}
-<h1>Community</h1>
+<h1>{% translate "Community" %}</h1>
 
-<h2>Sorry, you can't do that.</h2>
+<h2>{% translate "Sorry, you can't do that." %}</h2>
 {% endblock %}

--- a/djangoproject/templates/aggregator/edit-feed.html
+++ b/djangoproject/templates/aggregator/edit-feed.html
@@ -1,12 +1,13 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content %}
-<h1>Community</h1>
+<h1>{% translate "Community" %}</h1>
 
 {% if adding %}
-  <h2 class="deck">Add a {{ feed_type }} feed:</h2>
+  <h2 class="deck">{% blocktranslate with type=feed_type %}Add a {{ type }} feed:{% endblocktranslate %}</h2>
 {% else %}
-  <h2 class="deck">Edit {{ feed }}:</h2>
+  <h2 class="deck">{% blocktranslate with feed=feed %}Edit {{ feed }}:{% endblocktranslate %}</h2>
 {% endif %}
 
 <form method="POST" action="" id="add_feed_form" class="wide form-input">
@@ -20,9 +21,9 @@
     </p>
   {% endfor %}
   {% if adding %}
-    <p class="submit"><input class="cta" type="submit" value="Add Feed"></p>
+    <p class="submit"><input class="cta" type="submit" value="{% translate "Add Feed" %}"></p>
   {% else %}
-    <p class="submit"><input class="cta" type="submit" value="Save"></p>
+    <p class="submit"><input class="cta" type="submit" value="{% translate "Save" %}"></p>
   {% endif %}
 </form>
 

--- a/djangoproject/templates/aggregator/feeditem_list.html
+++ b/djangoproject/templates/aggregator/feeditem_list.html
@@ -1,22 +1,26 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content %}
-<h1>Django community: {{ feed_type.name }}
-  <a class="rss" href="{% url 'aggregator-feed' feed_type.slug %}">RSS</a></h1>
-<h2 class="deck">
-  This page, updated regularly, aggregates {{ feed_type.name }}
-  from the Django community.
+{% url 'aggregator-feed' feed_type.slug as feed_url %}
+<h1>{% blocktranslate trimmed with name=feed_type.name %}Django community: {{ feed_type.name }}
+  <a class="rss" href="{{ feed_url }}">RSS</a>{% endblocktranslate %}</h1>
+<h2 class="deck">{% blocktranslate trimmed with name=feed_type.name %}
+  This page, updated regularly, aggregates {{ name }}
+  from the Django community.{% endblocktranslate %}
 </h2>
 
 <ul class="list-news">
 {% for item in object_list %}
 <li>
 <h2><a href="{{ item.link }}">{{ item.title }}</a></h2>
-<span class='meta'>Posted on {{ item.date_modified|date:"F j, Y" }} at {{ item.date_modified|date:"g:i A" }} by <a href="{{ item.feed.public_url }}">{{ item.feed.title }}</a> <a class="rss" href="{{ item.feed.feed_url }}">RSS</a></span>
+<span class='meta'>{% blocktranslate trimmed with date_modified=item.date_modified|date:"F j, Y" time_modified=item.date_modified|date:"g:i A" public_url=item.feed.public_url title=item.feed.title feed_url=item.feed.feed_url %}
+  Posted on {{ date_modified }} at {{ time_modified }} by <a href="{{ public_url }}">{{ title }}</a> <a class="rss" href="{{ feed_url }}">RSS</a>
+{% endblocktranslate %}</span>
 <div>
 {{ item.summary|striptags|truncatewords:"200" }}
 </div>
-<p class="small"><a class="link-readmore" href="{{ item.link }}">Read this post in context</a></p>
+<p class="small"><a class="link-readmore" href="{{ item.link }}">{% translate "Read this post in context" %}</a></p>
 </li>
 {% endfor %}
 </ul>
@@ -27,13 +31,13 @@
     {% if page_obj.has_previous %}
         <li><a class="previous" href="?page={{ page_obj.previous_page_number }}">
             <i class="icon icon-chevron-left"></i>
-            <span class="visuallyhidden">Previous</span>
+            <span class="visuallyhidden">{% translate "Previous" %}</span>
         </a></li>
     {% endif %}
     {% if page_obj.has_next %}
         <li><a class="next" href="?page={{ page_obj.next_page_number }}">
             <i class="icon icon-chevron-right"></i>
-            <span class="visuallyhidden">Next</span>
+            <span class="visuallyhidden">{% translate "Next" %}</span>
         </a></li>
     {% endif %}
     </ul>

--- a/djangoproject/templates/aggregator/index.html
+++ b/djangoproject/templates/aggregator/index.html
@@ -1,15 +1,16 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content %}
 
-<h2>Forum</h2>
+<h2>{% translate "Forum" %}</h2>
 {% include "includes/forum.html" %}
 
-<h2>Mailing lists</h2>
+<h2>{% translate "Mailing lists" %}</h2>
 {% include "includes/mailing_lists.html" %}
 
 <div class="list-collapsing-header">
-  <h2>Django RSS feeds</h2>
+  <h2>{% translate "Django RSS feeds" %}</h2>
 </div>
 
 <ul class="list-collapsing">
@@ -25,14 +26,14 @@
         {% endfor %}
       </dl>
       <p class="meta">
-        {% if latest_feeds %}
-          <a href="{% url 'community-feed-list' feedtype.slug %}">View more</a>
+        {% if feed_type.list %}
+          <a href="{% url 'community-feed-list' feed_type.grouper.slug %}">{% translate "View more" %}</a>
         {% endif %}
-        {% if latest_feeds and feedtype.can_self_add %}
-          or
+        {% if feed_type.list and feed_type.grouper.can_self_add %}
+          {% translate "or" %}
         {% endif %}
-        {% if feedtype.can_self_add %}
-          <a href="{% url 'community-add-feed' feedtype.slug %}">Add your feed</a>
+        {% if feed_type.grouper.can_self_add %}
+          <a href="{% url 'community-add-feed' feed_type.grouper.slug %}">{% translate "Add your feed" %}</a>
         {% endif %}
       </p>
     </div>

--- a/djangoproject/templates/aggregator/my-feeds.html
+++ b/djangoproject/templates/aggregator/my-feeds.html
@@ -1,20 +1,21 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content %}
-<h1>Community</h1>
+<h1>{% translate "Community" %}</h1>
 
-<h2 class="deck">Manage your community aggregator feeds:</h2>
+<h2 class="deck">{% translate "Manage your community aggregator feeds:" %}</h2>
 
 <div id="s-feed">
 <ul class="simple">
   {% for feed in feeds %}
     <li>
     <strong>{{ feed }}</strong> (<code>{{ feed.feed_url }}</code> — <strong>{{ feed.get_approval_status_display }}</strong>) —
-    <a href="{% url 'community-edit-feed' feed.id %}">Edit</a> |
-    <a href="{% url 'community-delete-feed' feed.id %}">Delete</a>
+    <a href="{% url 'community-edit-feed' feed.id %}">{% translate "Edit" %}</a> |
+    <a href="{% url 'community-delete-feed' feed.id %}">{% translate "Delete" %}</a>
     </li>
   {% endfor %}
-  <li>Add a new feed:
+  <li>{% translate "Add a new feed:" %}
     {% for t in feed_types %}
       <a href="{% url 'community-add-feed' t.slug %}">{{ t }}</a>
       {% if not forloop.last %}|{% endif %}

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}<!DOCTYPE html>
+{% load i18n static %}<!DOCTYPE html>
 <html lang="{% block html_language_code %}en{% endblock %}">
   <head>
     <meta charset="utf-8">
@@ -63,7 +63,9 @@
   <body id="{% block sectionid %}generic{% endblock %}" class="{% block body_class %}{% endblock %}">
 
     {% include "includes/header.html" %}
-
+    
+    {% include "includes/language_selector.html" %}
+    
     <div class="copy-banner">
       <div class="container {% block header-classes %}{% endblock %}">
         {% block header %}{% endblock %}

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -57,6 +57,7 @@
     </script>
     <script src="{% static "js/lib/modernizr.js" %}"></script>
     <script src="{% static "js/mod/switch-dark-mode.js" %}"></script>
+    <script src="{% url 'javascript-catalog' %}"></script>
     {% block head_extra %}{% endblock head_extra %}
   </head>
 

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -37,7 +37,7 @@
     <meta property="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     {% endblock og_tags %}
 
-    <title>{% block title %}The web framework for perfectionists with deadlines{% endblock %} | Django</title>
+    <title>{% block title %}{% translate "The web framework for perfectionists with deadlines" %}{% endblock %} | Django</title>
 
     <link rel="stylesheet" href="{% static "css/output.css" %}" >
     <script src="{% static "js/lib/webfontloader/webfontloader.js" %}"></script>
@@ -90,7 +90,7 @@
         {% endblock %}
 
         {% block content %}{% endblock %}
-        <a href="#top" class="backtotop"><i class="icon icon-chevron-up"></i> Back to Top</a>
+        <a href="#top" class="backtotop"><i class="icon icon-chevron-up"></i> {% translate "Back to Top" %}</a>
       </div>
 
       {% block content-related %}{% endblock %}

--- a/djangoproject/templates/base_code.html
+++ b/djangoproject/templates/base_code.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load i18n %}
 
 {% block sectionid %}code{% endblock %}
 
 {% block og_title %}Django source code{% endblock %}
 {% block og_description %}Django source code{% endblock %}
 
-{% block title %}Code{% endblock %}
+{% block title %}{% translate "Code" %}{% endblock %}
 {% block layout_class %}full-width{% endblock %}
 
-{% block header %}<h1>Django source code</h1>{% endblock %}
+{% block header %}<h1>{% translate "Django source code" %}</h1>{% endblock %}

--- a/djangoproject/templates/base_community.html
+++ b/djangoproject/templates/base_community.html
@@ -1,61 +1,66 @@
 {% extends "base.html" %}
-{% load fundraising_extras %}
+{% load fundraising_extras i18n %}
 
 {% block og_title %}Django Community{% endblock %}
 {% block og_description %}Building the Django Community. Come join us!{% endblock %}
 
 {% block layout_class %}sidebar-right{% endblock %}
-{% block title %}Django Community{% endblock %}
+{% block title %}{% translate "Django Community" %}{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">Community</h1>
-  <p>Building the <em>Django</em> Community{% if community_stats %}
-  {% if community_stats.age %} for <em>{{ community_stats.age }}</em>{% endif %}{% endif %}. Come join us!</p>
+  <h1 class="visuallyhidden">{% translate "Community" %}</h1>
+  {% if community_stats and community_stats.age %}
+    {% blocktranslate trimmed with age=community_stats.age %}
+      <p>Building the <em>Django</em> Community {% if age %} for <em>{{ age }}</em>{% endif %}. Come join us!</p>
+    {% endblocktranslate %}
+  {% else %}
+    <p>{% blocktranslate %}Building the <em>Django</em> Community. Come join us!{% endblocktranslate %}</p>
+  {% endif %}
 {% endblock %}
 
 {% block content-related %}
-<h1 class="visuallyhidden">Additional Information</h1>
+<h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
 <div role="complementary">
   {% donation_snippet %}
 
-  <h2>Get Involved</h2>
+  <h2>{% translate "Get Involved" %}</h2>
   <dl class="list-links">
-    <dt><a href="https://code.djangoproject.com/">Ticket system</a></dt>
-    <dd>report bugs and make feature requests</dd>
-    <dt><a href="https://dashboard.djangoproject.com/">Development dashboard</a></dt>
-    <dd>see what's currently being worked on</dd>
+    <dt><a href="https://code.djangoproject.com/">{% translate "Ticket system" %}</a></dt>
+    <dd>{% translate "report bugs and make feature requests" %}</dd>
+    <dt><a href="https://dashboard.djangoproject.com/">{% translate "Development dashboard" %}</a></dt>
+    <dd>{% translate "see what's currently being worked on" %}</dd>
   </dl>
-  <h2>Get Help</h2>
+  <h2>{% translate "Get Help" %}</h2>
   <dl class="list-links">
-    <dt><a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">Check our FAQ first.</a></dt>
-    <dd>Try the FAQ — it's got answers to many common questions.</dd>
-    <dt><a href="irc://irc.libera.chat/django">#django IRC channel</a></dt>
-    <dd>chat with other Django users</dd>
-    <dt><a href="https://discord.gg/xcRH6mN4fa" target="_blank">Django Discord Server</a></dt>
-    <dd>Join the Django Discord Community</dd>
-    <dt><a href="https://forum.djangoproject.com/" target="_blank">Official Django Forum</a></dt>
-    <dd>Join the community on the Django Forum.</dd>
+    <dt><a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">{% translate "Check our FAQ first." %}</a></dt>
+    <dd>{% translate "Try the FAQ — it's got answers to many common questions." %}</dd>
+    <dt><a href="irc://irc.libera.chat/django">{% translate "#django IRC channel" %}</a></dt>
+    <dd>{% translate "chat with other Django users" %}</dd>
+    <dt><a href="https://discord.gg/xcRH6mN4fa" target="_blank">{% translate "Django Discord Server" %}</a></dt>
+    <dd>{% translate "Join the Django Discord Community" %}</dd>
+    <dt><a href="https://forum.djangoproject.com/" target="_blank">{% translate "Official Django Forum" %}</a></dt>
+    <dd>{% translate "Join the community on the Django Forum." %}</dd>
   </dl>
 
-  <h2>Tell the World</h2>
+  <h2>{% translate "Tell the World" %}</h2>
   <dl class="list-links">
-    <dt><a href="https://www.djangopackages.com/">Django-based packages</a></dt>
-    <dd>find Django based projects and packages</dd>
-    <dt><a href="https://www.djangosites.org/">Django-powered sites</a></dt>
-    <dd>add your site to the list</dd>
-    <dt><a href="/community/badges/">Django badges</a></dt>
-    <dd>show your support (or wish longingly)</dd>
-    <dt><a href="/community/logos/">Django logos </a></dt>
-    <dd>download official logos</dd>
-    <dt><a href="/community/desktops/">Django wallpaper</a></dt>
-    <dd>cover your desktop</dd>
+    <dt><a href="https://www.djangopackages.com/">{% translate "Django-based packages" %}</a></dt>
+    <dd>{% translate "find Django based projects and packages" %}</dd>
+    <dt><a href="https://www.djangosites.org/">{% translate "Django-powered sites" %}</a></dt>
+    <dd>{% translate "add your site to the list" %}</dd>
+    <dt><a href="/community/badges/">{% translate "Django badges" %}</a></dt>
+    <dd>{% translate "show your support (or wish longingly)" %}</dd>
+    <dt><a href="/community/logos/">{% translate "Django logos" %} </a></dt>
+    <dd>{% translate "download official logos" %}</dd>
+    <dt><a href="/community/desktops/">{% translate "Django wallpaper" %}</a></dt>
+    <dd>{% translate "cover your desktop" %}</dd>
   </dl>
-  <h2>Improve Django</h2>
+  <h2>{% translate "Improve Django" %}</h2>
   <dl class="list-links">
-    <dt><a href="https://groups.google.com/group/django-updates">django-updates mailing list</a></dt>
-    <dd>get updated for each code and ticket change (for the super-obsessed)</dd>
-    <dt><a href="https://code.djangoproject.com/wiki">Django wiki</a></dt>
-    <dd>contribute tips and documentation</dd>
+    <dt><a href="https://groups.google.com/group/django-updates">{% translate "django-updates mailing list" %}</a></dt>
+    <dd>{% translate "get updated for each code and ticket change (for the super-obsessed)" %}</dd>
+    <dt><a href="https://code.djangoproject.com/wiki">{% translate "Django wiki" %}</a></dt>
+    <dd>{% translate "contribute tips and documentation" %}</dd>
   </dl>
 </div>
 {% endblock %}

--- a/djangoproject/templates/base_community.html
+++ b/djangoproject/templates/base_community.html
@@ -11,7 +11,7 @@
   <h1 class="visuallyhidden">{% translate "Community" %}</h1>
   {% if community_stats and community_stats.age %}
     {% blocktranslate trimmed with age=community_stats.age %}
-      <p>Building the <em>Django</em> Community {% if age %} for <em>{{ age }}</em>{% endif %}. Come join us!</p>
+      <p>Building the <em>Django</em> Community for <em>{{ age }}</em>. Come join us!</p>
     {% endblocktranslate %}
   {% else %}
     <p>{% blocktranslate %}Building the <em>Django</em> Community. Come join us!{% endblocktranslate %}</p>

--- a/djangoproject/templates/base_foundation.html
+++ b/djangoproject/templates/base_foundation.html
@@ -1,29 +1,29 @@
 {% extends "base.html" %}
-{% load fundraising_extras %}
+{% load fundraising_extras i18n %}
 
 {% block og_title %}Django Software Foundation{% endblock %}
 
 {% block layout_class %}sidebar-right{% endblock %}
-{% block title %}Django Software Foundation{% endblock %}
+{% block title %}{% translate "Django Software Foundation" %}{% endblock %}
 
 {% block header %}
-  <h1>Django Software Foundation</h1>
+  <h1>{% translate "Django Software Foundation" %}</h1>
 {% endblock %}
 
 {% block content-related %}
 
 {# Always include <h1> label and <div> with aria role. #}
-<h1 class="visuallyhidden">Additional Information</h1>
+<h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
 <div role="complementary">
   {% donation_snippet %}
 
-  <h2>About the foundation</h2>
+  <h2>{% translate "About the foundation" %}</h2>
   <ul class="list-links">
-    <li><a href="/foundation/faq/">FAQ</a></li>
-    <li><a href="/foundation/records/">Records</a></li>
-    <li><a href="{% url 'contact_foundation' %}">Contact us</a></li>
-    <li><a href="/foundation/cla/">Contributor license agreements</a></li>
-    <li><a href="/foundation/conferences/">Organizing a Django conference</a></li>
+    <li><a href="/foundation/faq/">{% translate "FAQ" %}</a></li>
+    <li><a href="/foundation/records/">{% translate "Records" %}</a></li>
+    <li><a href="{% url 'contact_foundation' %}">{% translate "Contact us" %}</a></li>
+    <li><a href="/foundation/cla/">{% translate "Contributor license agreements" %}</a></li>
+    <li><a href="/foundation/conferences/">{% translate "Organizing a Django conference" %}</a></li>
   </ul>
 </div>
 {% endblock %}

--- a/djangoproject/templates/base_weblog.html
+++ b/djangoproject/templates/base_weblog.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% load weblog fundraising_extras %}
+{% load weblog fundraising_extras i18n %}
 {% block layout_class %}sidebar-right{% endblock %}
-{% block title %}News &amp; Events{% endblock %}
+{% block title %}{% translate "News &amp; Events" %}{% endblock %}
 
 {% block og_title %}News &amp; Events{% endblock %}
 
 {% block header %}
-  <h1><a href="{% url 'weblog:index' %}">News &amp; Events</a></h1>
+  <h1><a href="{% url 'weblog:index' %}">{% translate "News &amp; Events" %}</a></h1>
 {% endblock %}
 
 {% block head_extra %}
@@ -14,12 +14,12 @@
 {% endblock %}
 
 {% block content-related %}
-  <h1 class="visuallyhidden">Additional Information</h1>
+  <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
   <div role="complementary">
     {% donation_snippet %}
 
     {% if events %}
-    <h2>Upcoming Events</h2>
+    <h2>{% translate "Upcoming Events" %}</h2>
     <ul class="list-events">
       {% for event in events %}
         <li>
@@ -30,7 +30,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <p><a href="/foundation/conferences/">Want your event listed here?</a></p>
+    <p><a href="/foundation/conferences/">{% translate "Want your event listed here?" %}</a></p>
 
     {% comment %}
     {# tags not implemented in backend yet #}
@@ -44,13 +44,13 @@
     </ul>
     {% endcomment %}
 
-    <h2><span>Archives</span></h2>
+    <h2><span>{% translate "Archives" %}</span></h2>
     {% render_month_links %}
 
-    <h2><span>RSS Feeds</span></h2>
+    <h2><span>{% translate "RSS Feeds" %}</span></h2>
     <ul class="list-links-small rss-list">
-      <li><a href="{% url 'weblog-feed' %}">Latest news entries</a></li>
-      <li><a href="https://code.djangoproject.com/timeline?daysback=90&max=50&wiki=on&ticket=on&changeset=on&milestone=on&format=rss">Recent code changes</a></li>
+      <li><a href="{% url 'weblog-feed' %}">{% translate "Latest news entries" %}</a></li>
+      <li><a href="https://code.djangoproject.com/timeline?daysback=90&max=50&wiki=on&ticket=on&changeset=on&milestone=on&format=rss">{% translate "Recent code changes" %}</a></li>
     </ul>
 </div>
 {% endblock %}

--- a/djangoproject/templates/blog/blog_pagination.html
+++ b/djangoproject/templates/blog/blog_pagination.html
@@ -1,19 +1,20 @@
+{% load i18n %}
 {% if is_paginated %}
 <div class="pagination">
   <ul class="nav-pagination" role="navigation">
     {% if page_obj.has_previous %}
     <li><a class="previous" href="?page={{ page_obj.previous_page_number }}">
       <i class="icon icon-chevron-left"></i>
-      <span class="visuallyhidden">Previous</span>
+      <span class="visuallyhidden">{% translate "Previous" %}</span>
     </a></li>
     {% endif %}
-    <span class="page-current">
-      Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-    </span>
+    <span class="page-current">{% blocktranslate trimmed with page_number=page_obj.number pages=page_obj.paginator.num_pages %}
+      Page {{ page_number }} of {{ pages }}
+    {% endblocktranslate %}</span>
     {% if page_obj.has_next %}
     <li><a class="next" href="?page={{ page_obj.next_page_number }}">
       <i class="icon icon-chevron-right"></i>
-      <span class="visuallyhidden">Next</span>
+      <span class="visuallyhidden">{% translate "Next" %}</span>
     </a></li>
     {% endif %}
   </ul>

--- a/djangoproject/templates/blog/entry_archive_day.html
+++ b/djangoproject/templates/blog/entry_archive_day.html
@@ -1,12 +1,13 @@
 {% extends "base_weblog.html" %}
+{% load i18n %}
 
 {% block title %}{{ day|date:"F j" }} | Weblog{% endblock %}
 
-{% block og_title %}Django news: {{ day|date:"F j" }} archive{% endblock %}
+{% block og_title %}{% blocktranslate with day=day|date:"F j" %}Django news: {{ day }} archive{% endblocktranslate %}{% endblock %}
 
 {% block content %}
 
-<h1>{{ day|date:"F j" }} archive</h1>
+<h1>{% blocktranslate with day=day|date:"F j" %}{{ day }} archive{% endblocktranslate %}</h1>
 
 <ul class="list-news">
 

--- a/djangoproject/templates/blog/entry_archive_month.html
+++ b/djangoproject/templates/blog/entry_archive_month.html
@@ -1,4 +1,5 @@
 {% extends "base_weblog.html" %}
+{% load i18n %}
 
 {% block title %}{{ month|date:"F" }} | Weblog{% endblock %}
 
@@ -6,7 +7,7 @@
 
 {% block content %}
 
-<h1>{{ month|date:"F Y" }} archive</h1>
+<h1>{% blocktranslate with month=month|date:"F Y" %}{{ month }} archive{% endblocktranslate %}</h1>
 
 <ul class="list-news">
 

--- a/djangoproject/templates/blog/entry_archive_year.html
+++ b/djangoproject/templates/blog/entry_archive_year.html
@@ -1,4 +1,5 @@
 {% extends "base_weblog.html" %}
+{% load i18n %}
 
 {% block title %}{{ year|date:"Y" }} | Weblog{% endblock %}
 
@@ -6,7 +7,7 @@
 
 {% block content %}
 
-<h1>{{ year|date:"Y" }} archive</h1>
+<h1>{% blocktranslate with year=year|date:"Y" %}{{ year }} archive{% endblocktranslate %}</h1>
 
 <ul class="list-news">
 

--- a/djangoproject/templates/blog/entry_detail.html
+++ b/djangoproject/templates/blog/entry_detail.html
@@ -1,4 +1,5 @@
 {% extends "base_weblog.html" %}
+{% load i18n %}
 
 {% block title %}{{ object.headline|escape }} | Weblog{% endblock %}
 
@@ -8,7 +9,9 @@
 {% block content %}
 <h2>{{ object.headline|safe }}</h2>
 
-<span class="meta">Posted by <strong>{{ object.author }}</strong> on {{ object.pub_date|date:"F j, Y" }} {% comment %}in <a href="#">Release Announcements</a>{% endcomment %}</span>
+<span class="meta">{% blocktranslate trimmed with author=object.author pub_date=object.pub_date|date:"F j, Y" %}
+  Posted by <strong>{{ author }}</strong> on {{ pub_date }} {% comment %}in <a href="#">Release Announcements</a>{% endcomment %}
+{% endblocktranslate %}</span>
 
 {{ object.body_html|safe }}
 {% endblock %}

--- a/djangoproject/templates/blog/entry_detail.html
+++ b/djangoproject/templates/blog/entry_detail.html
@@ -10,8 +10,8 @@
 <h2>{{ object.headline|safe }}</h2>
 
 <span class="meta">{% blocktranslate trimmed with author=object.author pub_date=object.pub_date|date:"F j, Y" %}
-  Posted by <strong>{{ author }}</strong> on {{ pub_date }} {% comment %}in <a href="#">Release Announcements</a>{% endcomment %}
-{% endblocktranslate %}</span>
+  Posted by <strong>{{ author }}</strong> on {{ pub_date }} 
+{% endblocktranslate %}{% comment %}in <a href="#">Release Announcements</a>{% endcomment %}</span>
 
 {{ object.body_html|safe }}
 {% endblock %}

--- a/djangoproject/templates/blog/news_summary.html
+++ b/djangoproject/templates/blog/news_summary.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <li{% if not object.is_published %} class="unpublished"{% endif %}>
   <{{ header_tag|default:'h2' }}>
     <a href="{{ object.get_absolute_url }}">{{ object.headline|safe }}</a>
@@ -5,13 +6,13 @@
   {% if summary_first %}
     {{ object.summary_html|safe }}
   {% endif %}
-  <span class="meta">
-    Posted by <strong>{{ object.author }}</strong> on {{ object.pub_date|date:"F j, Y" }}
-  </span>
+  <span class="meta">{% blocktranslate trimmed with author=object.author pub_date=object.pub_date|date:"F j, Y" %}
+    Posted by <strong>{{ author }}</strong> on {{ pub_date }}
+  {% endblocktranslate %}</span>
   {% if not summary_first %}
     {{ object.summary_html|safe }}
   {% endif %}
   {% if not hide_readmore %}
-  <a class="link-readmore" href="{{ object.get_absolute_url }}">Read more</a>
+  <a class="link-readmore" href="{{ object.get_absolute_url }}">{% translate "Read more" %}</a>
   {% endif %}
 </li>

--- a/djangoproject/templates/conduct/base.html
+++ b/djangoproject/templates/conduct/base.html
@@ -1,27 +1,29 @@
 {% extends "base_community.html" %}
+{% load i18n %}
+
 {% block header %}
-  <h1 class="visuallyhidden">Code of Conduct</h1>
-  <p>Code of Conduct</p>
+  <h1 class="visuallyhidden">{% translate "Code of Conduct" %}</h1>
+  <p>{% translate "Code of Conduct" %}</p>
 {% endblock %}
 
 {% block content-related %}
 <div role="complementary">
-  <h2>Django Community Code of Conduct</h2>
+  <h2>{% translate "Django Community Code of Conduct" %}</h2>
 
   <ul class="list-links">
-    <li><a href="{% url 'code_of_conduct' %}">Code of Conduct</a></li>
-    <li><a href="/foundation/committees/#conduct">Committee</a></li>
-    <li><a href="{% url 'conduct_faq' %}">Frequently Asked Questions</a></li>
-    <li><a href="{% url 'conduct_reporting' %}">Reporting Guide</a></li>
-    <li><a href="{% url 'conduct_enforcement' %}">Enforcement Manual</a></li>
-    <li><a href="{% url 'conduct_changes' %}">Changes</a></li>
+    <li><a href="{% url 'code_of_conduct' %}">{% translate "Code of Conduct" %}</a></li>
+    <li><a href="/foundation/committees/#conduct">{% translate "Committee" %}</a></li>
+    <li><a href="{% url 'conduct_faq' %}">{% translate "Frequently Asked Questions" %}</a></li>
+    <li><a href="{% url 'conduct_reporting' %}">{% translate "Reporting Guide" %}</a></li>
+    <li><a href="{% url 'conduct_enforcement' %}">{% translate "Enforcement Manual" %}</a></li>
+    <li><a href="{% url 'conduct_changes' %}">{% translate "Changes" %}</a></li>
   </ul>
 
-  <h2>License</h2>
-  <p>
+  <h2>{% translate "License" %}</h2>
+  <p>{% blocktranslate trimmed %}
     All content on this page is licensed under a
     <a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons
-    Attribution </a> license.
+    Attribution </a> license.{% endblocktranslate %}
   </p>
   <p>
     <a href="https://creativecommons.org/licenses/by/3.0/">
@@ -31,4 +33,4 @@
 </div>
 {% endblock %}
 
-{% block title %}Django Code of Conduct{% endblock %}
+{% block title %}{% translate "Django Code of Conduct" %}{% endblock %}

--- a/djangoproject/templates/conduct/changes.html
+++ b/djangoproject/templates/conduct/changes.html
@@ -1,16 +1,19 @@
 {% extends "conduct/base.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct - Changes{% endblock %}
+{% block title %}{% translate "Django Code of Conduct - Changes" %}{% endblock %}
 
 {% block og_title %}Django Code of Conduct - Changes{% endblock %}
 {% block og_description %}Changes to the Code of Conduct{% endblock %}
 
 {% block content %}
-<h1>Django Code of Conduct - Changes</h1>
+<h1>{% translate "Django Code of Conduct - Changes" %}</h1>
 
-<h2>Change control process</h2>
+<h2>{% translate "Change control process" %}</h2>
 
-<p>We're (mostly) programmers, so we'll track changes to the code of conduct and
+{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' as dev_bugs_features_url %}
+<p>{% blocktranslate trimmed %}
+We're (mostly) programmers, so we'll track changes to the code of conduct and
 associated documents the same way we track changes to code. All changes will
 proposed via a pull request to the
 <a href="https://github.com/django/djangoproject.com">djangoproject.com repository
@@ -18,35 +21,35 @@ on GitHub</a>. Changes will be reviewed by the conduct committee first, and then
 sent to the DSF, the Django core team, and the Django community for comment.
 We'll hold a comment period of at least one week,  and then each group will vote
 on the change using its normal process (a board for the DSF,
-<a href="{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' %}#how-we-make-decisions">
+<a href="{{ dev_bugs_features_url }}#how-we-make-decisions">
 a core dev vote</a> for the core team).
-Approved changes will be merged, published, and noted below.</p>
+Approved changes will be merged, published, and noted below.{% endblocktranslate %}</p>
 
-<p>This only applies to material changes; changes that don't effect the intent
-(typo fixes, re-wordings, etc.) can be made immediately.</p>
+<p>{% blocktranslate trimmed %}This only applies to material changes; changes that don't effect the intent
+(typo fixes, re-wordings, etc.) can be made immediately.{% endblocktranslate %}</p>
 
-<p>A complete list of changes can always be found
+<p>{% blocktranslate trimmed %}A complete list of changes can always be found
 <a href="https://github.com/django/djangoproject.com/commits/main/templates/conduct">on GitHub</a>;
-major changes and releases are summarized below.</p>
+major changes and releases are summarized below.{% endblocktranslate %}</p>
 
-<h2>Changelog</h2>
+<h2>{% translate "Changelog" %}</h2>
 
 <dl>
-  <dt>October 3, 2014</dt>
-  <dd><a href="https://github.com/django/djangoproject.com/commit/577a02bbe968de79f8e111d6139f0c1299e994e9">
-  Revised text</a> to clarify that behavior outside the community is a contributing factor to involvement in the Django community; and explicitly provided a non-exhaustive list of diversity groups we consider included under the policy.</dd>
+  <dt>{% translate "October 3, 2014" %}</dt>
+  <dd>{% blocktranslate trimmed %}<a href="https://github.com/django/djangoproject.com/commit/577a02bbe968de79f8e111d6139f0c1299e994e9">
+  Revised text</a> to clarify that behavior outside the community is a contributing factor to involvement in the Django community; and explicitly provided a non-exhaustive list of diversity groups we consider included under the policy.{% endblocktranslate %}</dd>
 
-  <dt>July 31, 2013</dt>
-  <dd>Documents approved and officially published.</dd>
+  <dt>{% translate "July 31, 2013" %}</dt>
+  <dd>{% translate "Documents approved and officially published." %}</dd>
 
-  <dt>July 15, 2013</dt>
-  <dd><a href="https://github.com/django/djangoproject.com/commit/ae21fb5cb1f7edfca5b5556d92fb86186d92aeb3">
+  <dt>{% translate "July 15, 2013" %}</dt>
+  <dd>{% blocktranslate trimmed %}<a href="https://github.com/django/djangoproject.com/commit/ae21fb5cb1f7edfca5b5556d92fb86186d92aeb3">
   Added the reporting guide and enforcement manual</a>. Final draft presented
-  to the board and core membership for vote.</dd>
+  to the board and core membership for vote.{% endblocktranslate %}</dd>
 
-  <dt>April 1, 2013</dt>
-  <dd><a href="https://github.com/django/djangoproject.com/commit/1a0aae11a331bfbf36d6f4091d77413b780454e5">
-  Initial "beta" release and public call for comments</a>.</dd>
+  <dt>{% translate "April 1, 2013" %}</dt>
+  <dd>{% blocktranslate trimmed %}<a href="https://github.com/django/djangoproject.com/commit/1a0aae11a331bfbf36d6f4091d77413b780454e5">
+  Initial "beta" release and public call for comments</a>.{% endblocktranslate %}</dd>
 
 </dl>
 

--- a/djangoproject/templates/conduct/enforcement.html
+++ b/djangoproject/templates/conduct/enforcement.html
@@ -1,79 +1,81 @@
 {% extends "conduct/base.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct - Enforcement Manual{% endblock %}
+{% block title %}{% translate "Django Code of Conduct - Enforcement Manual" %}{% endblock %}
 
 {% block og_title %}Django Code of Conduct - Enforcement Manual{% endblock %}
 {% block og_description %}This is the enforcement manual followed by Django's Code of Conduct Committee{% endblock %}
 
 {% block content %}
-<h1>Django Code of Conduct - Enforcement Manual</h1>
+{% url 'conduct_reporting' as reporting_url %}
+<h1>{% translate "Django Code of Conduct - Enforcement Manual" %}</h1>
 
-<h2 class="deck">This is the enforcement manual followed by Django's Code of
+<h2 class="deck">{% blocktranslate trimmed %}This is the enforcement manual followed by Django's Code of
 Conduct Committee. It's used when we respond to an issue to make sure we're
 consistent and fair. It should be considered an internal document, but we're
-publishing it publicly in the interests of transparency.</h2>
+publishing it publicly in the interests of transparency.{% endblocktranslate %}</h2>
 
-<h3>The Code of Conduct Committee</h3>
+<h3>{% translate "The Code of Conduct Committee" %}</h3>
 
-<p>All responses to reports of conduct violations will be managed by a
-<a href="/foundation/committees/">Code of Conduct Committee</a> ("the committee").</p>
+<p>{% blocktranslate trimmed %}All responses to reports of conduct violations will be managed by a
+<a href="/foundation/committees/">Code of Conduct Committee</a> ("the committee").{% endblocktranslate %}</p>
 
-<p>The Django Software Foundation's Board of Directors ("the board") will establish
+<p>{% blocktranslate trimmed %}The Django Software Foundation's Board of Directors ("the board") will establish
 this committee, comprised of at least three members. One member will be
 designated chair of the committee and will be responsible for all reports back to
-the board. The board will review membership on a regular basis.</p>
+the board. The board will review membership on a regular basis.{% endblocktranslate %}</p>
 
-<h3>How the committee will respond to reports</h3>
+<h3>{% translate "How the committee will respond to reports" %}</h3>
 
-<p>When a report is sent to the committee they will immediately reply to the
+<p>{% blocktranslate trimmed %}When a report is sent to the committee they will immediately reply to the
 report to confirm receipt. This reply must be sent within 24 hours, and the
-committee should strive to respond much quicker than that.</p>
+committee should strive to respond much quicker than that.{% endblocktranslate %}</p>
 
-<p>See the <a href="{% url 'conduct_reporting' %}">reporting guidelines</a> for details of
+<p>{% blocktranslate trimmed %}See the <a href="{{ reporting_url }}">reporting guidelines</a> for details of
 what reports should contain. If a report doesn't contain enough information, the
 committee will obtain all relevant data before acting. The committee is
 empowered to act on the DSF's behalf in contacting any individuals involved to
-get a more complete account of events.</p>
+get a more complete account of events.{% endblocktranslate %}</p>
 
-<p>The committee will then review the incident and determine, to the best of their ability:
+<p>{% blocktranslate %}The committee will then review the incident and determine, to the best of their ability:
 <ul>
     <li>what happened</li>
     <li>whether this event constitutes a code of conduct violation</li>
     <li>who, if anyone, was the bad actor</li>
     <li>whether this is an ongoing situation, and there is a threat to anyone's physical safety</li>
 </ul>
-</p>
+{% endblocktranslate %}</p>
 
-<p>This information will be collected in writing, and whenever possible the
+<p>{% blocktranslate trimmed %}This information will be collected in writing, and whenever possible the
 committee's deliberations will be recorded and retained (i.e. IRC transcripts, email
-discussions, recorded voice conversations, etc).</p>
+discussions, recorded voice conversations, etc).{% endblocktranslate %}</p>
 
-<p>The committee should aim to have a resolution agreed upon within one week.
+<p>{% blocktranslate trimmed %}The committee should aim to have a resolution agreed upon within one week.
 In the event that a resolution can't be determined in that time, the committee will
-respond to the reporter(s) with an update and projected timeline for resolution.</p>
+respond to the reporter(s) with an update and projected timeline for resolution.{% endblocktranslate %}</p>
 
-<h3>Acting Unilaterally</h3>
+<h3>{% translate "Acting Unilaterally" %}</h3>
 
-<p>If the act is ongoing (such as someone engaging in harassment in #django), or involves
+<p>{% blocktranslate trimmed %}If the act is ongoing (such as someone engaging in harassment in #django), or involves
 a threat to anyone's safety (e.g. threats of violence), any committee member
 may act immediately (before reaching consensus) to end the situation. In ongoing
 situations, any member may at their discretion employ any of the tools available
-to the committee, including bans and blocks.</p>
+to the committee, including bans and blocks.{% endblocktranslate %}</p>
 
-<p>If the incident involves physical danger, any member of the committee may --
+<p>{% blocktranslate trimmed %}If the incident involves physical danger, any member of the committee may --
 and should -- act unilaterally to protect safety. This can include contacting
-law enforcement (or other local personnel) and speaking on behalf of the DSF.</p>
+law enforcement (or other local personnel) and speaking on behalf of the DSF.{% endblocktranslate %}</p>
 
-<p>In situations where an individual committee member acts unilaterally, they must
-report their actions to the committee for review within 24 hours.</p>
+<p>{% blocktranslate trimmed %}In situations where an individual committee member acts unilaterally, they must
+report their actions to the committee for review within 24 hours.{% endblocktranslate %}</p>
 
-<h3>Resolutions</h3>
+<h3>{% translate "Resolutions" %}</h3>
 
-<p>The committee must agree on a resolution by consensus. If the committee cannot
+<p>{% blocktranslate trimmed %}The committee must agree on a resolution by consensus. If the committee cannot
 reach consensus and deadlocks for over a week, the committee will turn the matter
-over to the board for resolution.</p>
+over to the board for resolution.{% endblocktranslate %}</p>
 
-<p>Possible responses may include:
+<p>{% blocktranslate %}Possible responses may include:
 <ul>
     <li>Taking no further action (if we determine no violation occurred).</li>
     <li>A private reprimand from the committee to the individual(s) involved.
@@ -95,33 +97,37 @@ over to the board for resolution.</p>
         the committee may ask a violator to apologize in order to retain his or her membership
         on a mailing list.</li>
 </ul>
-</p>
+{% endblocktranslate %}</p>
 
-<p>Once a resolution is agreed upon, but before it is enacted, the committee
+<p>{% blocktranslate trimmed %}
+Once a resolution is agreed upon, but before it is enacted, the committee
 will contact the original reporter and any other affected parties and explain
 the proposed resolution. The committee will ask if this resolution is
 acceptable, and must note feedback for the record. However, the committee is
-not required to act on this feedback.</p>
+not required to act on this feedback.{% endblocktranslate %}</p>
 
-<p>Finally the committee will make a report for the DSF board. In case the
+<p>{% blocktranslate trimmed %}
+Finally the committee will make a report for the DSF board. In case the
 incident or report involves a current member of the board, the committee will
-provide the report only to the other board members.</p>
+provide the report only to the other board members.{% endblocktranslate %}</p>
 
-<p>The committee will never publicly discuss the issue; all public statements
-will be made by the DSF board.</p>
+<p>{% blocktranslate trimmed %}The committee will never publicly discuss the issue; all public statements
+will be made by the DSF board.{% endblocktranslate %}</p>
 
-<h3>Conflicts of Interest</h3>
+<h3>{% translate "Conflicts of Interest" %}</h3>
 
-<p>In the event of any conflict of interest a committee member must immediately
+<p>{% blocktranslate trimmed %}
+In the event of any conflict of interest a committee member must immediately
 notify the other members, and recuse themselves if necessary. If a report concerns
 a possible violation by a current committee member, this member should be 
 excluded from the response process. For these cases, anyone can make a report
 directly to any of the committee chairs, as documented in the
-<a href="{% url 'conduct_reporting' %}">reporting guidelines</a>.</p>
+<a href="{{ reporting_url }}">reporting guidelines</a>.{% endblocktranslate %}</p>
 
 <hr>
 
-<p><i>Editor's note: Writing this document posed a unique challenge. Most
+<p><i>{% blocktranslate trimmed %}
+Editor's note: Writing this document posed a unique challenge. Most
 similar guides are written on the assumption of an in-person event. However, the
 Django community doesn't exist in one place, and most of the time we're spread
 out across the world and interact online. This makes trying to define and
@@ -130,6 +136,6 @@ adapted from the <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-har
 Handling Harassment Incidents</a>, but changed to reflect the nature of our
 community. It is our expectation that this will be a living document and change
 as we grow to understand how to meet this challenge and best serve our community
-and ideals.</i></p>
+and ideals.{% endblocktranslate %}</i></p>
 
 {% endblock %}

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -1,106 +1,112 @@
 {% extends "conduct/base.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct - FAQ{% endblock %}
+{% block title %}{% translate "Django Code of Conduct - FAQ" %}{% endblock %}
 
 {% block og_title %}Django Code of Conduct - FAQ{% endblock %}
 {% block og_description %}Common questions and concerns around the Django community's Code of Conduct{% endblock %}
 
 {% block content %}
-<h1>Django Code of Conduct - FAQ</h1>
+<h1>{% translate "Django Code of Conduct - FAQ" %}</h1>
 
-<h2 class="deck">
+{% url 'code_of_conduct' as coc_url %}
+<h2 class="deck">{% blocktranslate trimmed %}
 This FAQ attempts to address common questions and concerns around the Django
-community's <a href="{% url 'code_of_conduct' %}">Code of Conduct</a>. If you still have
+community's <a href="{{ coc_url }}">Code of Conduct</a>. If you still have
 questions after reading it, please feel free to
-<a href="mailto:conduct@djangoproject.com">contact us</a>.
+<a href="mailto:conduct@djangoproject.com">contact us</a>.{% endblocktranslate %}
 </h2>
 
-<h3 id="why-adopt">Why have you adopted a Code of Conduct? <a class="plink" href="#why-adopt">¶</a></h3>
+<h3 id="why-adopt">{% translate "Why have you adopted a Code of Conduct?" %} <a class="plink" href="#why-adopt">¶</a></h3>
 
-    <p>We think the Django community is awesome. If you're familiar with the Django
+    <p>{% blocktranslate trimmed %}
+    We think the Django community is awesome. If you're familiar with the Django
     community, you'll probably notice that the Code basically matches what
     we already do. Think of this as documentation: we're taking implicit
-    expectations about behavior and making them explicit.</p>
+    expectations about behavior and making them explicit.{% endblocktranslate %}</p>
 
-    <p>We're doing this because the Django community is growing faster than any of
+    <p>{% blocktranslate trimmed %}
+    We're doing this because the Django community is growing faster than any of
     us could have anticipated. This is on balance a very positive thing, but
     as we've grown past the point where it's possible to know the whole community
-    we think it's very important to be clear about our values.</p>
+    we think it's very important to be clear about our values.{% endblocktranslate %}</p>
 
-    <p>We know that the Django community is open, friendly, and welcoming. We want to
-    make sure everyone else knows it too.</p>
+    <p>{% blocktranslate trimmed %}
+    We know that the Django community is open, friendly, and welcoming. We want to
+    make sure everyone else knows it too.{% endblocktranslate %}</p>
 
-<h3 id="what-does-it-mean">What does it mean to "adopt" a Code of Conduct? <a class="plink" href="#what-does-it-mean">¶</a></h3>
+<h3 id="what-does-it-mean">{% translate 'What does it mean to "adopt" a Code of Conduct?' %} <a class="plink" href="#what-does-it-mean">¶</a></h3>
 
-    <p>For the most part, we don't think it means large changes. We think that the text
+    <p>{% blocktranslate trimmed %}
+    For the most part, we don't think it means large changes. We think that the text
     does a really good job describing the way the Django community already conducts
     itself. We expect that most people will simply continue to behave in the
-    awesome way they have for years.</p>
+    awesome way they have for years.{% endblocktranslate %}</p>
 
-    <p>However, we do expect that people will abide by the spirit and words of the CoC
+    <p>{% blocktranslate trimmed %}However, we do expect that people will abide by the spirit and words of the CoC
     when in "official" Django spaces. This code has been adopted by both the Django core
     team and by the Django Software Foundation. That means that it'll apply both in community
-    spaces <em>and</em> at DSF events.</p>
+    spaces <em>and</em> at DSF events.{% endblocktranslate %}</p>
 
-    <p>In practice, this means mailing lists (django-users, django-developers, etc.),
+    <p>{% blocktranslate trimmed %}In practice, this means mailing lists (django-users, django-developers, etc.),
     the various Django IRC channels (<tt>#django</tt>, <tt>#django-dev</tt>, etc.), bug
     tracking and code review tools, and "official" Django events such as sprints.
     In addition, violations of this code outside these spaces may affect a person's
-    ability to participate within them.</p>
+    ability to participate within them.{% endblocktranslate %}</p>
 
-<h3 id="dsf-events">What about events funded by the Django Software Foundation? <a class="plink" href="#dsf-events">¶</a></h3>
+<h3 id="dsf-events">{% translate "What about events funded by the Django Software Foundation?" %} <a class="plink" href="#dsf-events">¶</a></h3>
 
-    <p>This Code of Conduct also covers any events that the DSF funds. However, events
+    <p>{% blocktranslate trimmed %}This Code of Conduct also covers any events that the DSF funds. However, events
     funded by the DSF already
-    <a class="plink" href="{% url 'code_of_conduct' %}">require a code of conduct</a>.
-    Isn't this redundant?</p>
+    <a class="plink" href="{{ coc_url }}">require a code of conduct</a>.
+    Isn't this redundant?{% endblocktranslate %}</p>
 
-    <p>No: there's a difference between the two, and they're complementary.</p>
+    <p>{% translate "No: there's a difference between the two, and they're complementary." %}</p>
 
-    <p>This Code of Conduct is all about how we interact as a community. It's about
+    <p>{% blocktranslate trimmed %}This Code of Conduct is all about how we interact as a community. It's about
     saying that the Django community will be open, friendly, and welcoming.
     The core issue is about ensuring the conversations we have are productive
-    and inviting for all.</p>
+    and inviting for all.{% endblocktranslate %}</p>
 
-    <p>Real-life events, however, require a bit more care. The DSF wants to be sure
+    <p>{% blocktranslate trimmed %}Real-life events, however, require a bit more care. The DSF wants to be sure
     that any events it funds have policies and procedures in place for handling
     harassment. It's especially important to us that real-life events take steps to
-    protect the physical and mental security of their participants.</p>
+    protect the physical and mental security of their participants.{% endblocktranslate %}</p>
 
-    <p>So the DSF will require that any events it funds have some sort of anti-
+    <p>{% blocktranslate trimmed %}So the DSF will require that any events it funds have some sort of anti-
     harassment policy in place. The DSF thinks the
     <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">Ada Initiative's template</a>
-    is pretty good, but we're open to alternatives.</p>
+    is pretty good, but we're open to alternatives.{% endblocktranslate %}</p>
 
-<h3 id="violations">What happens if someone violates the Code of Conduct? <a class="plink" href="#violations">¶</a></h3>
-
-    <p>Our intent is that anyone in the community can stand up for this code,
+<h3 id="violations">{% translate "What happens if someone violates the Code of Conduct?" %} <a class="plink" href="#violations">¶</a></h3>
+    {% url 'conduct_reporting' as reporting_url %}
+    <p>{% blocktranslate trimmed %}Our intent is that anyone in the community can stand up for this code,
     and direct people who're unaware to this document. If that doesn't work,
     or if you need more help, you can contact
     <a href="mailto:conduct@djangoproject.com">conduct@djangoproject.com</a>.
     For more details please see our
-    <a href="{% url 'conduct_reporting' %}">Reporting Guidelines</a></p>
+    <a href="{{ reporting_url }}">Reporting Guidelines</a>{% endblocktranslate %}</p>
 
-<h3 id="why-do-we-need">Why do we need a Code of Conduct? Everyone knows not to be a jerk. <a class="plink" href="#why-do-we-need">¶</a></h3>
+<h3 id="why-do-we-need">{% translate "Why do we need a Code of Conduct? Everyone knows not to be a jerk." %} <a class="plink" href="#why-do-we-need">¶</a></h3>
 
-    <p>Sadly, not everyone knows this.</p>
+    <p>{% translate "Sadly, not everyone knows this." %}</p>
 
-    <p>However, even if everyone was kind, everyone was compassionate, and everyone was
+    <p>{% blocktranslate trimmed %}However, even if everyone was kind, everyone was compassionate, and everyone was
     familiar with codes of conduct it would still be incumbent upon our community to
     publish our own. Maintaining a code of conduct forces us to consider and
     articulate what kind of community we want to be, and serves as a constant
     reminder to put our best foot forward. But most importantly, it serves as a
     signpost to people looking to join our community that we feel these values are
-    important.</p>
+    important.{% endblocktranslate %}</p>
 
-<h3 id="free-speech">This is censorship! I have the right to say whatever I want! <a class="plink" href="#free-speech">¶</a></h3>
+<h3 id="free-speech">{% translate "This is censorship! I have the right to say whatever I want!" %} <a class="plink" href="#free-speech">¶</a></h3>
 
-    <p>You do -- in <em>your</em> space. If you'd like to hang out in <em>our</em> spaces (as
+    <p>{% blocktranslate trimmed %}You do -- in <em>your</em> space. If you'd like to hang out in <em>our</em> spaces (as
     clarified above), we have some simple guidelines to follow. If you want to, for
     example, form a group where Django is discussed using language inappropriate for
     general channels then nobody's stopping you. We respect your right to establish
     whatever codes of conduct you want in the spaces that belong to you. Please
-    honor this Code of Conduct in our spaces.</p>
+    honor this Code of Conduct in our spaces.{% endblocktranslate %}</p>
 
 {% endblock %}
 

--- a/djangoproject/templates/conduct/index.html
+++ b/djangoproject/templates/conduct/index.html
@@ -1,65 +1,67 @@
 {% extends "conduct/base.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct{% endblock %}
+{% block title %}{% translate "Django Code of Conduct" %}{% endblock %}
 
 {% block og_title %}Django Code of Conduct{% endblock %}
 {% block og_description %}Some ground rules for the community{% endblock %}
 
 {% block content %}
 
-<h1>Django Code of Conduct</h1>
+<h1>{% translate "Django Code of Conduct" %}</h1>
 
-<p>Like the technical community as a whole, the Django team and community is made up
+<p>{% blocktranslate trimmed %}Like the technical community as a whole, the Django team and community is made up
 of a mixture of professionals and volunteers from all over the world, working on
 every aspect of the mission - including mentorship, teaching, and connecting
-people.</p>
+people.{% endblocktranslate %}</p>
 
-<p>Diversity is one of our huge strengths, but it can also lead to communication
+<p>{% blocktranslate trimmed %}Diversity is one of our huge strengths, but it can also lead to communication
 issues and unhappiness. To that end, we have a few ground rules that we ask
 people to adhere to. This code applies equally to founders, mentors and those
-seeking help and guidance.</p>
+seeking help and guidance.{% endblocktranslate %}</p>
 
-<p>This isn’t an exhaustive list of things that you can’t do. Rather, take it in
+<p>{% blocktranslate trimmed %}This isn’t an exhaustive list of things that you can’t do. Rather, take it in
 the spirit in which it’s intended - a guide to make it easier to enrich all of
-us and the technical communities in which we participate.</p>
+us and the technical communities in which we participate.{% endblocktranslate %}</p>
 
-<p>This code of conduct applies to all spaces managed by the Django project or
+<p>{% blocktranslate trimmed %}This code of conduct applies to all spaces managed by the Django project or
 Django Software Foundation. This includes IRC, the mailing lists, the issue
 tracker, DSF events, and any other forums created by the project team
 which the community uses for communication. In addition, violations of this code
-outside these spaces may affect a person's ability to participate within them.</p>
+outside these spaces may affect a person's ability to participate within them.{% endblocktranslate %}</p>
 
-<p>If you believe someone is violating the code of conduct, we ask that you
+{% url 'conduct_reporting' as reporting_url %}
+<p>{% blocktranslate trimmed %}If you believe someone is violating the code of conduct, we ask that you
 report it by emailing
 <a href="mailto:conduct@djangoproject.com">conduct@djangoproject.com</a>.
 For more details please see our
-<a href="{% url 'conduct_reporting' %}">Reporting Guidelines</a></p>
+<a href="{{ reporting_url }}">Reporting Guidelines</a>{% endblocktranslate %}</p>
 
 <ul class="simple">
-  <li><strong>Be friendly and patient.</strong></li>
+  <li><strong>{% translate "Be friendly and patient." %}</strong></li>
 
-  <li><strong>Be welcoming.</strong> We strive to be a community that welcomes
+  <li>{% blocktranslate trimmed %}<strong>Be welcoming.</strong> We strive to be a community that welcomes
   and supports people of all backgrounds and identities. This includes, but
   is not limited to members of any race, ethnicity, culture, national origin,
   colour, immigration status, social and economic class, educational level, sex,
   sexual orientation, gender identity and expression, age, size, family status,
-  political belief, religion, and mental and physical ability.</li>
+  political belief, religion, and mental and physical ability.{% endblocktranslate %}</li>
 
-  <li><strong>Be considerate.</strong> Your work will be used by other people, and you in turn will
+  <li>{% blocktranslate trimmed %}<strong>Be considerate.</strong> Your work will be used by other people, and you in turn will
   depend on the work of others. Any decision you take will affect users and
   colleagues, and you should take those consequences into account when making
   decisions. Remember that we're a world-wide community, so you might not be
-  communicating in someone else's primary language.</li>
+  communicating in someone else's primary language.{% endblocktranslate %}</li>
 
-  <li><strong>Be respectful.</strong> Not all of us will agree all the time, but disagreement is no
+  <li>{% blocktranslate trimmed %}<strong>Be respectful.</strong> Not all of us will agree all the time, but disagreement is no
   excuse for poor behavior and poor manners. We might all experience some
   frustration now and then, but we cannot allow that frustration to turn into a
   personal attack. It’s important to remember that a community where people feel
   uncomfortable or threatened is not a productive one. Members of the Django
   community should be respectful when dealing with other members as well as with
-  people outside the Django community.</li>
+  people outside the Django community.{% endblocktranslate %}</li>
 
-  <li><strong>Be careful in the words that you choose.</strong> We are a community of professionals,
+  <li>{% blocktranslate %}<strong>Be careful in the words that you choose.</strong> We are a community of professionals,
   and we conduct ourselves professionally. Be kind to others. Do not insult or
   put down other participants. Harassment and other exclusionary behavior
   aren't acceptable. This includes, but is not limited to:
@@ -72,26 +74,27 @@ For more details please see our
     <li>Unwelcome sexual attention.</li>
     <li>Advocating for, or encouraging, any of the above behavior.</li>
     <li>Repeated harassment of others. In general, if someone asks you to stop, then stop.</li>
-  </ul>
+  </ul>{% endblocktranslate %}
   </li>
 
-  <li><strong>When we disagree, try to understand why.</strong> Disagreements, both social and
+  <li>{% blocktranslate trimmed %}<strong>When we disagree, try to understand why.</strong> Disagreements, both social and
   technical, happen all the time and Django is no exception. It is important that
   we resolve disagreements and differing views constructively. Remember that we’re
   different. The strength of Django comes from its varied community, people from a
   wide range of backgrounds. Different people have different perspectives on
   issues. Being unable to understand why someone holds a viewpoint doesn’t mean
   that they’re wrong. Don’t forget that it is human to err and blaming each other
-  doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.</li>
+  doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.{% endblocktranslate %}</li>
 </ul>
 
-<p>Original text courtesy of the
+<p>{% blocktranslate trimmed %}Original text courtesy of the
 <a href="http://web.archive.org/web/20141109123859/http://speakup.io/coc.html">
-Speak Up! project</a>.</p>
+Speak Up! project</a>.{% endblocktranslate %}</p>
 
-<h2>Questions?</h2>
-<p>If you have questions, please see <a href="{% url 'conduct_faq' %}">the FAQ</a>. If
+<h2>{% translate "Questions?" %}</h2>
+{% url 'conduct_faq' as faq_url %}
+<p>{% blocktranslate trimmed %}If you have questions, please see <a href="{{ faq_url }}">the FAQ</a>. If
 that doesn't answer your questions, feel free to
-<a href="mailto:conduct@djangoproject.com">contact us</a>.</p>
+<a href="mailto:conduct@djangoproject.com">contact us</a>.{% endblocktranslate %}</p>
 
 {% endblock %}

--- a/djangoproject/templates/conduct/reporting.html
+++ b/djangoproject/templates/conduct/reporting.html
@@ -1,67 +1,69 @@
 {% extends "conduct/base.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct - Reporting Guide{% endblock %}
+{% block title %}{% translate "Django Code of Conduct - Reporting Guide" %}{% endblock %}
 
 {% block og_title %}Django Code of Conduct - Reporting Guide{% endblock %}
 {% block og_description %}A guide to reporting issues in the community{% endblock %}
 
 {% block content %}
-<h1>Django Code of Conduct - Reporting Guide</h1>
+<h1>{% translate "Django Code of Conduct - Reporting Guide" %}</h1>
 
-<p>If you believe someone is violating the code of conduct we ask that you report
+<p>{% blocktranslate trimmed %}
+If you believe someone is violating the code of conduct we ask that you report
 it to the Django Software Foundation by emailing <a
 href="mailto:conduct@djangoproject.com">conduct@djangoproject.com</a>.
 <strong>All reports will be kept confidential.</strong> In some cases we may
 determine that a public statement will need to be made. If that's the case, the
 identities of all victims and reporters will remain confidential unless those
-individuals instruct us otherwise.</p>
+individuals instruct us otherwise.{% endblocktranslate %}</p>
 
-<p><strong>If you believe anyone is in physical danger, please notify appropriate
+<p>{% blocktranslate trimmed %}<strong>If you believe anyone is in physical danger, please notify appropriate
 law enforcement first.</strong> If you are unsure what law enforcement agency is
 appropriate, please include this in your report and we will attempt to notify
-them.</p>
+them.{% endblocktranslate %}</p>
 
-<p>If you are unsure whether the incident is a violation, or whether the space
+<p>{% blocktranslate trimmed %}If you are unsure whether the incident is a violation, or whether the space
 where it happened is covered by this Code of Conduct, we encourage you to still
 report it. We would much rather have a few extra reports where we decide to take
 no action, rather than miss a report of an actual violation. We do not look 
 negatively on you if we find the incident is not a violation. And knowing
 about incidents that are not violations, or happen outside our spaces, can also
-help us to improve the Code of Conduct or the processes surrounding it.</p>
+help us to improve the Code of Conduct or the processes surrounding it.{% endblocktranslate %}</p>
 
-<p>In your report please include:
+<p>{% translate "In your report please include:" %}
 <ul>
-    <li>Your contact info (so we can get in touch with you if we need to follow up)</li>
-    <li>Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.</li>
-    <li>When and where the incident occurred. Please be as specific as possible.</li>
-    <li>Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.</li>
-    <li>Any extra context you believe existed for the incident.</li>
-    <li>If you believe this incident is ongoing.</li>
-    <li>Any other information you believe we should have.</li>
+    <li>{% translate "Your contact info (so we can get in touch with you if we need to follow up)" %}</li>
+    <li>{% translate "Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well." %}</li>
+    <li>{% translate "When and where the incident occurred. Please be as specific as possible." %}</li>
+    <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link." %}</li>
+    <li>{% translate "Any extra context you believe existed for the incident." %}</li>
+    <li>{% translate "If you believe this incident is ongoing." %}</li>
+    <li>{% translate "Any other information you believe we should have." %}</li>
 </ul>
 </p>
 
-<h3>What happens after you file a report?</h3>
+<h3>{% translate "What happens after you file a report?" %}</h3>
 
-<p>You will receive an email from the DSF Code of Conduct Working Group
+<p>{% blocktranslate trimmed %}You will receive an email from the DSF Code of Conduct Working Group
 acknowledging receipt immediately. We promise to acknowledge receipt within 24
-hours (and will aim for much quicker than that).</p>
+hours (and will aim for much quicker than that).{% endblocktranslate %}</p>
 
-<p>The working group will immediately meet to review the incident and determine:
+<p>{% blocktranslate %}The working group will immediately meet to review the incident and determine:
 <ul>
     <li>What happened.</li>
     <li>Whether this event constitutes a code of conduct violation.</li>
     <li>Who the bad actor was.</li>
     <li>Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.</li>
 </ul>
-</p>
+{% endblocktranslate %}</p>
 
-<p>If this is determined to be an ongoing incident or a threat to physical safety,
+<p>{% blocktranslate trimmed %}If this is determined to be an ongoing incident or a threat to physical safety,
 the working groups' immediate priority will be to protect everyone involved.
 This means we may delay an "official" response until we believe that the
-situation has ended and that everyone is physically safe.</p>
+situation has ended and that everyone is physically safe.{% endblocktranslate %}</p>
 
-<p>Once the working group has a complete account of the events they will make a
+<p>{% blocktranslate trimmed %}Once the working group has a complete account of the events they will make a
 decision as to how to response. Responses may include:
 <ul>
     <li>Nothing (if we determine no violation occurred).</li>
@@ -71,42 +73,42 @@ decision as to how to response. Responses may include:
     <li>A permanent or temporary ban from some or all Django spaces (mailing lists, IRC, etc.)</li>
     <li>A request for a public or private apology.</li>
 </ul>
-</p>
+{% endblocktranslate %}</p>
 
-<p>We'll respond within one week to the person who filed the report with either a
-resolution or an explanation of why the situation is not yet resolved.</p>
+<p>{% blocktranslate trimmed %}We'll respond within one week to the person who filed the report with either a
+resolution or an explanation of why the situation is not yet resolved.{% endblocktranslate %}</p>
 
-<p>Once we've determined our final action, we'll contact the original reporter to
+<p>{% blocktranslate trimmed %}Once we've determined our final action, we'll contact the original reporter to
 let them know what action (if any) we'll be taking. We'll take into account
 feedback from the reporter on the appropriateness of our response, but we don't
-guarantee we'll act on it.</p>
+guarantee we'll act on it.{% endblocktranslate %}</p>
 
-<p>Finally, the Working Group will make a report on the situation to the DSF board.
-The board may choose to a public report of the incident.</p>
+<p>{% blocktranslate trimmed %}Finally, the Working Group will make a report on the situation to the DSF board.
+The board may choose to a public report of the incident.{% endblocktranslate %}</p>
 
-<h3>What if your report concerns a possible violation by a committee member?</h3>
+<h3>{% translate "What if your report concerns a possible violation by a committee member?" %}</h3>
 
-<p>If your report concerns a current member of the Code of Conduct committee, you
+<p>{% blocktranslate trimmed %}If your report concerns a current member of the Code of Conduct committee, you
 may not feel comfortable sending your report to the committee, as all members will 
-see the report.</p>
+see the report.{% endblocktranslate %}</p>
 
-<p>In that case, you can make a report directly to any or all of the current
+<p>{% blocktranslate trimmed %}In that case, you can make a report directly to any or all of the current
 (vice/co) chairs of the Code of Conduct committee. Their e-mail addresses are
 listed on the <a href="/foundation/committees/">Code of Conduct Committee</a>
 page. The chairs will follow the usual enforcement process with the other 
 members, but will exclude the member(s) that the report concerns from any
-discussion or decision making.</p>
+discussion or decision making.{% endblocktranslate %}</p>
 
-<p>If your report concerns all current (vice/co) chairs of the committee, please
+<p>{% blocktranslate trimmed %}If your report concerns all current (vice/co) chairs of the committee, please
 send your report directly to the DSF board at 
 <a href="mailto:foundation@djangoproject.com">foundation@djangoproject.com</a>
-instead.</p>
+instead.{% endblocktranslate %}</p>
 
-<h3>Reconsideration</h3>
+<h3>{% translate "Reconsideration" %}</h3>
 
-<p>Any of the parties directly involved or affected can request reconsideration 
+<p>{% blocktranslate trimmed %}Any of the parties directly involved or affected can request reconsideration 
 of the committee’s decision. To make such a request, contact the DSF Board at
 <a href="mailto:foundation@djangoproject.com">foundation@djangoproject.com</a>
-with your request and motivation and the DSF board will review the case.</p>
+with your request and motivation and the DSF board will review the case.{% endblocktranslate %}</p>
 
 {% endblock %}

--- a/djangoproject/templates/contact/coc.html
+++ b/djangoproject/templates/contact/coc.html
@@ -1,8 +1,9 @@
 {% extends "base_3col.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct Feedback{% endblock %}
+{% block title %}{% translate "Django Code of Conduct Feedback" %}{% endblock %}
 
 {% block content %}
-<h1>Django Code of Conduct Feedback</h1>
+<h1>{% translate "Django Code of Conduct Feedback" %}</h1>
 {% include "contact/coc_form.html" %}
 {% endblock %}

--- a/djangoproject/templates/contact/coc_form.html
+++ b/djangoproject/templates/contact/coc_form.html
@@ -1,22 +1,23 @@
+{% load i18n %}
 <form action="{% url "contact_coc" %}" method="post" accept-charset="utf-8" class="wide">
 {% csrf_token %}
 
 {# hardcoding inputs because they'll be included on the CoC page itself #}
   <p>
-    <label for="id_name">Your name (optional):</label>
+    <label for="id_name">{% translate "Your name (optional):" %}</label>
     {% if form.name.errors %}<p class="errors">{{ form.name.errors.as_text }}</p>{% endif %}
     <input id="id_name" class="required" type="text" name="name">
   </p>
   <p>
-    <label for="id_email">Your email address (optional):</label>
+    <label for="id_email">{% translate "Your email address (optional):" %}</label>
     {% if form.email.errors %}<p class="errors">{{ form.email.errors.as_text }}</p>{% endif %}
     <input id="id_email" class="required" type="text" name="email">
   </p>
   <p>
-    <label for="id_body">Your message:</label>
+    <label for="id_body">{% translate "Your message:" %}</label>
     {% if form.body.errors %}<p class="errors">{{ form.body.errors.as_text }}</p>{% endif %}
     <textarea id="id_body" class="required" rows="10" name="body" cols="40"></textarea>
   </p>
-  <p class="submit"><input type="submit" value="Send &rarr;"></p>
+  <p class="submit"><input type="submit" value="{% translate "Send" %} &rarr;"></p>
 
 </form>

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -1,17 +1,18 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
-{% block title %}Contact the Django Software Foundation{% endblock %}
+{% block title %}{% translate "Contact the Django Software Foundation" %}{% endblock %}
 
 {% block content %}
-<h1>Contact the Django Software Foundation</h1>
-<p>This contact form is for the Django Software Foundation - the legal and
-  fundraising arm of the Django project.</p>
-<p>If you want to report a bug, feature request, or documentation issue in Django,
-  use the <a href="https://code.djangoproject.com">ticket tracker</a>.</p>
-<p>If you want to report a problem with this website, use the
-  <a href="https://github.com/django/djangoproject.com">GitHub repo</a>.</p>
-<p>If you've got questions about how to use Django, use the
-  <a href="https://groups.google.com/forum/#!forum/django-users">django-users mailing list</a>.</p>
+<h1>{% translate "Contact the Django Software Foundation" %}</h1>
+<p>{% blocktranslate trimmed %}This contact form is for the Django Software Foundation - the legal and
+  fundraising arm of the Django project.{% endblocktranslate %}</p>
+<p>{% blocktranslate trimmed %}If you want to report a bug, feature request, or documentation issue in Django,
+  use the <a href="https://code.djangoproject.com">ticket tracker</a>.{% endblocktranslate %}</p>
+<p>{% blocktranslate trimmed %}If you want to report a problem with this website, use the
+  <a href="https://github.com/django/djangoproject.com">GitHub repo</a>.{% endblocktranslate %}</p>
+<p>{% blocktranslate trimmed %}If you've got questions about how to use Django, use the
+  <a href="https://groups.google.com/forum/#!forum/django-users">django-users mailing list</a>.{% endblocktranslate %}</p>
 <form action="." method="post" accept-charset="utf-8" class="form-input">
 {% csrf_token %}
   <p>
@@ -31,6 +32,6 @@
     {{ form.body }}
   </p>
   <p>{{ form.captcha }}</p>
-  <p class="submit"><input type="submit" class="cta" value="Send &rarr;"></p>
+  <p class="submit"><input type="submit" class="cta" value="{% translate "Send" %} &rarr;"></p>
 </form>
 {% endblock %}

--- a/djangoproject/templates/contact/sent.html
+++ b/djangoproject/templates/contact/sent.html
@@ -1,18 +1,19 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
-{% block title %}Message sent{% endblock %}
+{% block title %}{% translate "Message sent" %}{% endblock %}
 
 {% block content %}
-  <h1>Message sent</h1>
-  <h2 class="deck">Your message has been sent; thanks!</h2>
-  <p>
+  <h1>{% translate "Message sent" %}</h1>
+  <h2 class="deck">{% translate "Your message has been sent; thanks!" %}</h2>
+  <p>{% blocktranslate trimmed %}
     Your mail <em>will</em> be read by a real, live human being. We can't
     guarantee when or whether you'll get a reply, but your message
-    <em>will</em> be read, generally within the next couple of days.
+    <em>will</em> be read, generally within the next couple of days.{% endblocktranslate %}
   </p>
-  <p>
+  <p>{% blocktranslate trimmed %}
     If you're expecting a reply and don't get one, please feel free
     to send a reminder. Please wait a few days, however, unless
-    it's an emergency.
+    it's an emergency.{% endblocktranslate %}
   </p>
 {% endblock %}

--- a/djangoproject/templates/diversity/base.html
+++ b/djangoproject/templates/diversity/base.html
@@ -1,27 +1,28 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block og_title %}Django Community Diversity Statement{% endblock %}
 {% block og_description %}We welcome you.{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">Community Diversity Statement</h1>
-  <p>Community Diversity Statement</p>
+  <h1 class="visuallyhidden">{% translate "Community Diversity Statement" %}</h1>
+  <p>{% translate "Community Diversity Statement" %}</p>
 {% endblock %}
 
 {% block content-related %}
 <div role="complementary">
-  <h2>Django Community Diversity Statement</h2>
+  <h2>{% translate "Django Community Diversity Statement" %}</h2>
 
   <ul class="list-links">
-    <li><a href="{% url 'diversity' %}">Diversity Statement</a></li>
-    <li><a href="{% url 'diversity_changes' %}">Changes</a></li>
+    <li><a href="{% url 'diversity' %}">{% translate "Diversity Statement" %}</a></li>
+    <li><a href="{% url 'diversity_changes' %}">{% translate "Changes" %}</a></li>
   </ul>
 
-  <h2>License</h2>
-  <p>
+  <h2>{% translate "License" %}</h2>
+  <p>{% blocktranslate trimmed %}
     All content on this page is licensed under a
     <a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons
-    Attribution </a> license.
+    Attribution </a> license.{% endblocktranslate %}
   </p>
   <p>
     <a href="https://creativecommons.org/licenses/by/3.0/">
@@ -31,4 +32,4 @@
 </div>
 {% endblock %}
 
-{% block title %}Django Community Diversity Statement{% endblock %}
+{% block title %}{% translate "Django Community Diversity Statement" %}{% endblock %}

--- a/djangoproject/templates/diversity/changes.html
+++ b/djangoproject/templates/diversity/changes.html
@@ -1,14 +1,17 @@
 {% extends "diversity/base.html" %}
+{% load i18n %}
 
 {% block title %}Django Community Diversity Statement - Changes{% endblock %}
 {% block og_title %}Django Community Diversity Statement - Changes{% endblock %}
 
 {% block content %}
-<h1>Django Community Diversity Statement - Changes</h1>
+<h1>{% translate "Django Community Diversity Statement - Changes" %}</h1>
 
-<h2>Change control process</h2>
+<h2>{% translate "Change control process" %}</h2>
 
-<p>We're (mostly) programmers, so we'll track changes to the diversity statement
+{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' as dev_docs_features_url %}
+<p>{% blocktranslate trimmed %}
+We're (mostly) programmers, so we'll track changes to the diversity statement
 the same way we track changes to code. All changes will proposed via a pull request
 to the
 <a href="https://github.com/django/djangoproject.com">djangoproject.com repository
@@ -16,23 +19,23 @@ on GitHub</a>. Changes will be reviewed by the membership first, and then
 sent to the DSF, the Django core team, and the Django community for comment.
 We'll hold a comment period of at least one week,  and then each group will vote
 on the change using its normal process (a board for the DSF,
-<a href="{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' %}#how-we-make-decisions">
+<a href="{{ dev_docs_features_url }}#how-we-make-decisions">
 a core dev vote</a> for the core team).
-Approved changes will be merged, published, and noted below.</p>
+Approved changes will be merged, published, and noted below.{% endblocktranslate %}</p>
 
-<p>This only applies to material changes; changes that don't effect the intent
-(typo fixes, re-wordings, etc.) can be made immediately.</p>
+<p>{% blocktranslate trimmed %}This only applies to material changes; changes that don't effect the intent
+(typo fixes, re-wordings, etc.) can be made immediately.{% endblocktranslate %}</p>
 
-<p>A complete list of changes can always be found
+<p>{% blocktranslate trimmed %}A complete list of changes can always be found
 <a href="https://github.com/django/djangoproject.com/commits/main/djangoproject/templates/diversity">on GitHub</a>;
-major changes and releases are summarized below.</p>
+major changes and releases are summarized below.{% endblocktranslate %}</p>
 
-<h2>Changelog</h2>
+<h2>{% translate "Changelog" %}</h2>
 
 <dl>
-  <dt>Jun 16, 2015</dt>
+  <dt>{% translate "Jun 16, 2015" %}</dt>
   <dd><a href="https://github.com/django/djangoproject.com/commit/da5f784cf737c6d74c1233c3db3442732fd87d6d">
-  Initial release</a>.</dd>
+  {% translate "Initial release" %}</a>.</dd>
 
 </dl>
 

--- a/djangoproject/templates/diversity/index.html
+++ b/djangoproject/templates/diversity/index.html
@@ -1,26 +1,27 @@
 {% extends "diversity/base.html" %}
+{% load i18n %}
 
-{% block title %}Django Community Diversity Statement{% endblock %}
+{% block title %}{% translate "Django Community Diversity Statement" %}{% endblock %}
 
 {% block content %}
 
-<h1>Django Community Diversity Statement</h1>
+<h1>{% translate "Django Community Diversity Statement" %}</h1>
 
-<p>Platitudes are cheap. We've all heard organizations say they're committed to
+<p>{% blocktranslate trimmed %}Platitudes are cheap. We've all heard organizations say they're committed to
 "diversity" and "tolerance" without ever getting specific, so here's our
-stance on it:</p>
+stance on it:{% endblocktranslate %}</p>
 
-<p>We welcome you.</p>
+<p>{% translate "We welcome you." %}</p>
 
-<p>We welcome people of any gender identity or expression, race, skin color,
+<p>{% blocktranslate trimmed %}We welcome people of any gender identity or expression, race, skin color,
 ethnicity, age, size, nationality, sexual orientation, ability level,
 neurotype, religion, elder status, family structure, culture, subculture,
 political opinion, education level, identity, and self-identification. We
 welcome activists, artists, bloggers, crafters, coders, wannabe-coders,
 designers, entrepreneurs, documentation writers, journalists, sysadmins,
-teachers, ordinary people, extraordinary people, and everyone in between. </p>
+teachers, ordinary people, extraordinary people, and everyone in between.{% endblocktranslate %}</p>
 
-<p>We welcome you. You may wear a baby sling, hijab, a kippah, leather, an XXXL
+<p>{% blocktranslate trimmed %}We welcome you. You may wear a baby sling, hijab, a kippah, leather, an XXXL
 t-shirt, a pentacle, a political badge, a rainbow, a rosary, tattoos, or
 something we can only dream of. You may carry a guitar or walking cane or a
 15 year old laptop. Conservative or liberal, libertarian or socialist — we
@@ -28,49 +29,50 @@ believe it's possible for people of all viewpoints and persuasions to come
 together and learn from each other. We believe in the broad spectrum of
 individual and collective experience and in the inherent dignity of all
 people. We believe that amazing things happen when people from different
-worlds and world-views approach each other to create a conversation.</p>
+worlds and world-views approach each other to create a conversation.{% endblocktranslate %}</p>
 
-<p>We get excited about web development — from professional to amateur, from
+<p>{% blocktranslate trimmed %}We get excited about web development — from professional to amateur, from
 giant projects to simple apps, from the coder who's been doing this since
 the day Django was conceived in Kansas to the newbie who just started
-studying the Django tutorial today. </p>
+studying the Django tutorial today.{% endblocktranslate %}</p>
 
-<p>We think accessibility for people with disabilities is a priority, not an
+<p>{% blocktranslate trimmed %}We think accessibility for people with disabilities is a priority, not an
 afterthought. We think neurodiversity is a feature, not a bug. We believe in
 being inclusive, welcoming, and supportive of anyone who comes to us with
-good faith and the desire to build a community.</p>
+good faith and the desire to build a community.{% endblocktranslate %}</p>
 
-<p>There are a few diversity initiatives in the Django community, but there
+{% url 'code_of_conduct' as coc_url %}
+<p>{% blocktranslate trimmed %}There are a few diversity initiatives in the Django community, but there
 can always be more. We protect our diversity through our
-<a href="{% url 'code_of_conduct' %}">Code of Conduct</a> and the team that applies
+<a href="{{ coc_url }}">Code of Conduct</a> and the team that applies
 it. We also call on you, as a member of the Django community, to proudly show
 your support. Be generous, understanding and respectful to your fellow
 Djangonauts. Seek out newcomers and help them feel like they belong. Listen
 with empathy when someone has a different perspective. Talk to someone if
-you notice that something could be better. </p>
+you notice that something could be better.{% endblocktranslate %}</p>
 
-<p>We have enough experience to know that we won't get any of this perfect on
+<p>{% blocktranslate trimmed %}We have enough experience to know that we won't get any of this perfect on
 the first try. But we have enough hope, energy, and idealism to want to learn
 things we don't know now. We may not be able to satisfy everyone, but we can
 certainly work to avoid excluding anyone. And we promise that if we get it
 wrong, we'll listen carefully and respectfully to you when you point it out
-to us, and we'll do our best to make good on our mistakes.</p>
+to us, and we'll do our best to make good on our mistakes.{% endblocktranslate %}</p>
 
-<p>We think our technical experience is important, but we think our community
+<p>{% blocktranslate trimmed %}We think our technical experience is important, but we think our community
 experience is more important. We know what goes wrong when organizations
 say one thing and do another, or when they refuse to say anything at all.
 We believe that keeping the Django Software Foundation transparent is just
-as important as keeping our servers stable.</p>
+as important as keeping our servers stable.{% endblocktranslate %}</p>
 
-<p>We work with the Django web framework, and we invite everyone to contribute,
-to the core Django code, the ecosystem of Django packages, and the community.</p>
+<p>{% blocktranslate trimmed %}We work with the Django web framework, and we invite everyone to contribute,
+to the core Django code, the ecosystem of Django packages, and the community.{% endblocktranslate %}</p>
 
-<p>Come build the web with us.</p>
+<p>{% translate "Come build the web with us." %}</p>
 
-<p>Original text courtesy of the <a href="https://www.dreamwidth.org/legal/diversity">Dreamwidth</a>.</p>
+<p>{% blocktranslate %}Original text courtesy of the <a href="https://www.dreamwidth.org/legal/diversity">Dreamwidth</a>.{% endblocktranslate %}</p>
 
-<h2>Questions?</h2>
-<p>If you have questions, feel free to
-<a href="mailto:conduct@djangoproject.com">contact us</a>.</p>
+<h2>{% translate "Questions?" %}</h2>
+<p>{% blocktranslate trimmed %}If you have questions, feel free to
+<a href="mailto:conduct@djangoproject.com">contact us</a>.{% endblocktranslate %}</p>
 
 {% endblock %}

--- a/djangoproject/templates/donate_thanks.html
+++ b/djangoproject/templates/donate_thanks.html
@@ -1,18 +1,19 @@
 {% extends "flatpages/foundation.html" %}
+{% load i18n %}
 
-{% block title %}Thanks for your support!{% endblock %}
+{% block title %}{% translate "Thanks for your support!" %}{% endblock %}
 
 {% block content %}
-  <h1>Thanks for your support!</h1>
-  <h2 class="deck">Thank you for supporting Django. If you like, you can use one of the badges below to show your support and help us bring in other donors.</h2>
+  <h1>{% translate "Thanks for your support!" %}</h1>
+  <h2 class="deck">{% translate "Thank you for supporting Django. If you like, you can use one of the badges below to show your support and help us bring in other donors." %}</h2>
 
-  <p>Copy and paste the source below each image to link to our donation page.</p>
+  <p>{% translate "Copy and paste the source below each image to link to our donation page." %}</p>
 
   <h3><a href="https://www.djangoproject.com/foundation/donate/"><img src="https://www.djangoproject.com/s/img/badges/djangodonated126x54.gif" border="0" alt="I donated to Django" width="126" height="54" /></a></h3>
 
-  <p><textarea rows="3" cols="60" class="codedump"><a href="https://www.djangoproject.com/foundation/donate/"><img src="https://www.djangoproject.com/s/img/badges/djangodonated126x54.gif" border="0" alt="I donated to Django" width="126" height="54" /></a></textarea><br /><strong>126x54</strong> I donated to Django (green)</p>
+  <p><textarea rows="3" cols="60" class="codedump"><a href="https://www.djangoproject.com/foundation/donate/"><img src="https://www.djangoproject.com/s/img/badges/djangodonated126x54.gif" border="0" alt="I donated to Django" width="126" height="54" /></a></textarea><br /><strong>126x54</strong> {% translate "I donated to Django (green)" %}</p>
 
   <h3><a href="https://www.djangoproject.com/foundation/donate/"><img src="https://www.djangoproject.com/s/img/badges/djangodonated126x54_grey.png" border="0" alt="I donated to Django" width="126" height="54" /></a></h3>
 
-  <p><textarea rows="3" cols="60" class="codedump"><a href="https://www.djangoproject.com/foundation/donate/"><img src="https://www.djangoproject.com/s/img/badges/djangodonated126x54_grey.png" border="0" alt="I donated to Django" width="126" height="54" /></a></textarea><br /><strong>126x54</strong> I donated to Django (grey)</p>
+  <p><textarea rows="3" cols="60" class="codedump"><a href="https://www.djangoproject.com/foundation/donate/"><img src="https://www.djangoproject.com/s/img/badges/djangodonated126x54_grey.png" border="0" alt="I donated to Django" width="126" height="54" /></a></textarea><br /><strong>126x54</strong> {% translate "I donated to Django (grey)" %}</p>
 {% endblock %}

--- a/djangoproject/templates/foundation/coreawardcohort_list.html
+++ b/djangoproject/templates/foundation/coreawardcohort_list.html
@@ -1,17 +1,18 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Django Core Developers{% endblock %}
 {% block og_description %}Former Django Core Team dissolved on March 12, 2020.{% endblock %}
 
 {% block content %}
-<h1>Django Core Developers</h1>
+<h1>{% translate "Django Core Developers" %}</h1>
 
-<p>
+<p>{% blocktranslate trimmed %}
     The title &ldquo;Django Core Developer&rdquo; is awarded to individuals
     who have made significant contributions, over an extended period of time,
     to Django or to major parts of its ecosystem. The title is awarded by the
     Board of Directors of the Django Software Foundation.
-    A list of recipients is below.
+    A list of recipients is below.{% endblocktranslate %}
 </p>
 {% for cohort in object_list %}
   <h2>{{ cohort }}</h2>

--- a/djangoproject/templates/foundation/meeting_archive.html
+++ b/djangoproject/templates/foundation/meeting_archive.html
@@ -1,12 +1,13 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Meeting minutes archive{% endblock %}
 {% block og_description %}View meeting minutes{% endblock %}
 
 {% block content %}
-<h1>Meeting minutes archive</h1>
+<h1>{% translate "Meeting minutes archive" %}</h1>
 
-<p>Select a year to view meeting minutes:</p>
+<p>{% translate "Select a year to view meeting minutes:" %}</p>
 
 <ul>
   {% for year in date_list %}

--- a/djangoproject/templates/foundation/meeting_archive_day.html
+++ b/djangoproject/templates/foundation/meeting_archive_day.html
@@ -1,10 +1,11 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Meeting minutes archive{% endblock %}
 {% block og_description %}View meeting minutes for {{ day|date:"F j, Y" }}{% endblock %}
 
 {% block content %}
-<h1>Meeting minutes archive: {{ day|date:"F j, Y" }}</h1>
+<h1>{% blocktranslate with day=day|date:"F j, Y" %}Meeting minutes archive: {{ day }}{% endblocktranslate %}</h1>
 
 <ul>
   {% for meeting in object_list %}

--- a/djangoproject/templates/foundation/meeting_archive_month.html
+++ b/djangoproject/templates/foundation/meeting_archive_month.html
@@ -1,10 +1,11 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Meeting minutes archive{% endblock %}
 {% block og_description %}View meeting minutes for {{ month|date:"F, Y" }}{% endblock %}
 
 {% block content %}
-<h1>Meeting minutes archive: {{ month|date:"F, Y" }}</h1>
+<h1>{% blocktranslate with month=month|date:"F, Y" %}Meeting minutes archive: {{ month }}{% endblocktranslate %}</h1>
 
 <ul>
   {% for meeting in object_list %}

--- a/djangoproject/templates/foundation/meeting_archive_year.html
+++ b/djangoproject/templates/foundation/meeting_archive_year.html
@@ -1,10 +1,11 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Meeting minutes archive{% endblock %}
 {% block og_description %}View meeting minutes for {{ year|date:"Y" }}{% endblock %}
 
 {% block content %}
-<h1>Meeting minutes archive: {{ year|date:"Y" }}</h1>
+<h1>{% blocktranslate with year=year|date:"Y" %}Meeting minutes archive: {{ year }}{% endblocktranslate %}</h1>
 
 <ul>
   {% for meeting in object_list %}

--- a/djangoproject/templates/foundation/meeting_detail.html
+++ b/djangoproject/templates/foundation/meeting_detail.html
@@ -1,4 +1,5 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Meeting minutes: {{ meeting }}{% endblock %}
 {% block og_description %}Meeting minutes for {{ meeting }}{% endblock %}
@@ -8,9 +9,9 @@
 
 <h1>{{ meeting }}</h1>
 
-<p>The meeting was led by {{ meeting.leader.account.get_full_name }}.</p>
+<p>{% blocktranslate with name=meeting.leader.account.get_full_name %}The meeting was led by {{ name }}.{% endblocktranslate %}</p>
 
-<p>Board members in attendance were:</p>
+<p>{% translate "Board members in attendance were:" %}</p>
 
 <ul>
   {% for attendee in meeting.board_attendees.all %}
@@ -19,7 +20,7 @@
 </ul>
 
 {% if meeting.non_board_attendees.all %}
-<p>Also in attendance were:</p>
+<p>{% translate "Also in attendance were:" %}</p>
 
 <ul>
   {% for attendee in meeting.non_board_attendees.all %}
@@ -28,19 +29,19 @@
 </ul>
 {% endif %}
 
-<h2>Finances</h2>
+<h2>{% translate "Finances" %}</h2>
 
-<h3>Balance</h3>
+<h3>{% translate "Balance" %}</h3>
 
 <p>{{ meeting.treasurer_balance|currency }}</p>
 
 {% if meeting.treasurer_report %}
-<h3>Treasurer&#8217;s report</h3>
+<h3>{% translate "Treasurer's report" %}</h3>
 {{ meeting.treasurer_report_html|safe }}
 {% endif %}
 
 {% if meeting.grants_approved %}
-<h2>Grants approved </h2>
+<h2>{% translate "Grants approved" %}</h2>
 
 <ul>
   {% for grant in meeting.grants_approved.all %}
@@ -50,7 +51,7 @@
 {% endif %}
 
 {% if meeting.individual_members_approved.all %}
-<h2>Individual members approved</h2>
+<h2>{% translate "Individual members approved" %}</h2>
 
 <ul>
   {% for member in meeting.individual_members_approved.all %}
@@ -60,7 +61,7 @@
 {% endif %}
 
 {% if meeting.corporate_members_approved %}
-<h2>Corporate members approved</h2>
+<h2>{% translate "Corporate members approved" %}</h2>
 
 <ul>
   {% for member in meeting.corporate_members_approved.all %}
@@ -70,27 +71,27 @@
 {% endif %}
 
 {% if ongoing_business %}
-<h2>Ongoing business</h2>
+<h2>{% translate "Ongoing business" %}</h2>
 
 {% for business in ongoing_business %}
-<h3>{{ business.title }}</h2>
+<h3>{{ business.title }}</h3>
 
 {{ business.body|safe }}
 {% endfor %}
 {% endif %}
 
 {% if new_business %}
-<h2>New business</h2>
+<h2>{% translate "New business" %}</h2>
 
 {% for business in new_business %}
-<h3>{{ business.title }}</h2>
+<h3>{{ business.title }}</h3>
 
 {{ business.body_html|safe }}
 {% endfor %}
 {% endif %}
 
 {% if meeting.action_items.all %}
-<h2>Action items</h2>
+<h2>{% translate "Action items" %}</h2>
 
 <ul>
   {% for action_item in meeting.action_items.all %}

--- a/djangoproject/templates/fundraising/includes/display_django_heroes.html
+++ b/djangoproject/templates/fundraising/includes/display_django_heroes.html
@@ -1,9 +1,12 @@
-{% load humanize %}
+{% load humanize i18n %}
 <div class="heroes">
   {% if corporate_members.diamond %}
-  <h3>Diamond Corporate Members (${{ corporate_membership_amounts.diamond|intcomma }}+)</h3>
-  <p>Our diamond <a href="/foundation/corporate-membership/">corporate
-    members</a> include mega corporations and foundations.</p>
+  <h3>{% blocktranslate trimmed with diamond=corporate_membership_amounts.diamond %}
+    Diamond Corporate Members (${{ diamond|intcomma }}+)
+  {% endblocktranslate %}</h3>
+  <p>{% blocktranslate trimmed %}
+    Our diamond <a href="/foundation/corporate-membership/">corporate
+    members</a> include mega corporations and foundations.{% endblocktranslate %}</p>
   <div>
   {% for obj in corporate_members.diamond %}
     {% include "fundraising/includes/_hero_with_logo.html" %}
@@ -12,9 +15,13 @@
   {% endif %}
 
   {% if corporate_members.platinum %}
-  <h3>Platinum Corporate Members (${{ corporate_membership_amounts.platinum|intcomma }}+)</h3>
-  <p>Our platinum <a href="/foundation/corporate-membership/">corporate
-    members</a> include organizations of ~500 people.</p>
+  <h3>{% blocktranslate trimmed with platinum=corporate_membership_amounts.platinum %}
+    Platinum Corporate Members (${{ platinum|intcomma }}+)
+  {% endblocktranslate %}</h3>
+  <p>{% blocktranslate trimmed %}
+    Our platinum <a href="/foundation/corporate-membership/">corporate
+    members</a> include organizations of ~500 people.
+    {% endblocktranslate %}</p>
   <div>
   {% for obj in corporate_members.platinum %}
     {% include "fundraising/includes/_hero_with_logo.html" %}
@@ -23,9 +30,11 @@
   {% endif %}
 
   {% if corporate_members.gold %}
-  <h3>Gold Corporate Members (${{ corporate_membership_amounts.gold|intcomma }}+)</h3>
-  <p>Our gold <a href="/foundation/corporate-membership/">corporate
-    members</a> include organizations of ~200 people.</p>
+  <h3>{% blocktranslate with gold=corporate_membership_amounts.gold %}Gold Corporate Members (${{ gold|intcomma }}+){% endblocktranslate %}</h3>
+  <p>{% blocktranslate trimmed %}
+    Our gold <a href="/foundation/corporate-membership/">corporate
+    members</a> include organizations of ~200 people.
+    {% endblocktranslate %}</p>
   <div>
   {% for obj in corporate_members.gold %}
     {% include "fundraising/includes/_hero_with_logo.html" %}
@@ -34,9 +43,10 @@
   {% endif %}
 
   {% if corporate_members.silver %}
-  <h3>Silver Corporate Members (${{ corporate_membership_amounts.silver|intcomma }}+)</h3>
-  <p>Our silver <a href="/foundation/corporate-membership/">corporate
-    members</a> include organizations of ~50 people.</p>
+  <h3>{% blocktranslate with silver=corporate_membership_amounts.silver %}Silver Corporate Members (${{ silver|intcomma }}+){% endblocktranslate %}</h3>
+  <p>{% blocktranslate trimmed %}Our silver <a href="/foundation/corporate-membership/">corporate
+    members</a> include organizations of ~50 people.
+  {% endblocktranslate %}</p>
   <div>
   {% for obj in corporate_members.silver %}
     {% include "fundraising/includes/_hero_with_logo.html" %}
@@ -45,9 +55,10 @@
   {% endif %}
 
   {% if corporate_members.bronze %}
-  <h3>Bronze Corporate Members (${{ corporate_membership_amounts.bronze|intcomma }}+)</h3>
-  <p>Our bronze <a href="/foundation/corporate-membership/">corporate
-    members</a> include organizations of ~10 people.</p>
+  <h3>{% blocktranslate with bronze=corporate_membership_amounts.bronze %}Bronze Corporate Members (${{ bronze|intcomma }}+){% endblocktranslate %}</h3>
+  <p>{% blocktranslate trimmed %}Our bronze <a href="/foundation/corporate-membership/">corporate
+    members</a> include organizations of ~10 people.
+  {% endblocktranslate %}</p>
   <div>
   {% for obj in corporate_members.bronze %}
     {% include "fundraising/includes/_hero_with_logo.html" %}
@@ -55,8 +66,8 @@
   </div>
   {% endif %}
 
-  <h3><a id="in-kind-donors" href="#in-kind-donors">In-kind donors</a></h3>
-  <p>These donors help with significant non-cash contributions.</p>
+  <h3><a id="in-kind-donors" href="#in-kind-donors">{% translate "In-kind donors" %}</a></h3>
+  <p>{% translate "These donors help with significant non-cash contributions." %}</p>
   <div>
   {% with show_description=True %}
   {% for obj in inkind_donors %}
@@ -65,17 +76,20 @@
   {% endwith %}
   </div>
 
-  <h3>Leaders (${{ display_logo_amount|intcomma }}+)</h3>
-  <p>Leadership-level donors contribute ${{ display_logo_amount|intcomma }} or
-    more in a calendar year.</p>
+  <h3>{% blocktranslate with amount=display_logo_amount %}Leaders (${{ amount|intcomma }}+){% endblocktranslate %}</h3>
+  <p>{% blocktranslate trimmed with amount=display_logo_amount %}
+    Leadership-level donors contribute ${{ amount|intcomma }} or
+    more in a calendar year.{% endblocktranslate %}</p>
   <div>
   {% for obj in leaders %}
     {% include "fundraising/includes/_hero_with_logo.html" %}
   {% endfor %}
   </div>
 
-  <h3>Heroes</h3>
-  <p>Our donor roll for all donations made in the last {{ display_donor_days }} days.</p>
+  <h3>{% translate "Heroes" %}</h3>
+  <p>{% blocktranslate trimmed with donor_days=display_donor_days %}
+    Our donor roll for all donations made in the last {{ donor_days }} days.
+  {% endblocktranslate %}</p>
   <div>
   {% for donor in heroes %}
     <div class="no-logo-hero">

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -27,7 +27,7 @@
         <strong>${{ donated_amount|intcomma }} donated</strong> of US&nbsp;${{ goal_amount|intcomma }} goal for
         {{ goal_start_date|date:"Y" }}{% endblocktranslate %}
       </li>
-      <li><strong>{% blocktranslate donors=total_donors %}
+      <li><strong>{% blocktranslate trimmed with donors=total_donors %}
         {{ donors }} donor{{ donors|pluralize:",s" }}
       {% endblocktranslate %}</strong></li>
     </ul>

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -1,4 +1,4 @@
-{% load static fundraising_extras humanize %}
+{% load fundraising_extras humanize i18n static %}
 
 {% with goal_percent=donated_amount|as_percentage:goal_amount %}
 <div class="fundraising-index" id="donate">
@@ -21,10 +21,15 @@
 
   <div class="description">
     <ul>
-      <li><strong>{{ goal_percent }}% funded</strong></li>
-      <li><strong>${{ donated_amount|intcomma }} donated</strong> of US&nbsp;${{ goal_amount|intcomma }} goal for
-        {{ goal_start_date|date:"Y" }}</li>
-      <li><strong>{{ total_donors }} donor{{ total_donors|pluralize:",s" }}</strong></li>
+      <li><strong>{% blocktranslate with goal_percent=goal_percent %}{{ goal_percent }}% funded{% endblocktranslate %}</strong></li>
+      <li>
+        {% blocktranslate trimmed with donated_amount=donated_amount goal_amount=goal_amount goal_start_date=goal_start_date %}
+        <strong>${{ donated_amount|intcomma }} donated</strong> of US&nbsp;${{ goal_amount|intcomma }} goal for
+        {{ goal_start_date|date:"Y" }}{% endblocktranslate %}
+      </li>
+      <li><strong>{% blocktranslate total_donors=total_donors %}
+        {{ total_donors }} donor{{ total_donors|pluralize:",s" }}
+      {% endblocktranslate %}</strong></li>
     </ul>
 
     <div class="donate">
@@ -41,18 +46,17 @@
         {{ form.interval }}
         {{ form.amount }}
         <div class="custom-donation">
-          <span class="prefix">US $ (integer only)</span>
+          <span class="prefix">US $ ({% translate "integer only" %})</span>
         </div>
         {{ form.captcha }}
-        <input id="donate-button" type="submit" value="Donate monthly" class="cta" />
+        <input id="donate-button" type="submit" value="{% translate "Donate monthly" %}" class="cta" />
       </form>
     </div>
   </div>
   <div class="cls"></div>
-  <p class="footnote">
-    Your logo will be visible below if you contribute at least
-    US&nbsp;${{ display_logo_amount|intcomma }}.<br>
-  </p>
+  <p class="footnote">{% blocktranslate trimmed with amount=display_logo_amount %}
+    Your logo will be visible below if you contribute at least US&nbsp;${{ amount|intcomma }}.<br>
+  {% endblocktranslate %}</p>
 </div>
 {% endwith %}
 

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -27,8 +27,8 @@
         <strong>${{ donated_amount|intcomma }} donated</strong> of US&nbsp;${{ goal_amount|intcomma }} goal for
         {{ goal_start_date|date:"Y" }}{% endblocktranslate %}
       </li>
-      <li><strong>{% blocktranslate total_donors=total_donors %}
-        {{ total_donors }} donor{{ total_donors|pluralize:",s" }}
+      <li><strong>{% blocktranslate donors=total_donors %}
+        {{ donors }} donor{{ donors|pluralize:",s" }}
       {% endblocktranslate %}</strong></li>
     </ul>
 

--- a/djangoproject/templates/fundraising/includes/donation_snippet.html
+++ b/djangoproject/templates/fundraising/includes/donation_snippet.html
@@ -1,8 +1,8 @@
-{% load humanize static %}
+{% load humanize i18n static %}
 
 {% if donation %}
   <div class="fundraising-sidebar">
-    <h2>Support Django!</h2>
+    <h2>{% translate "Support Django!" %}</h2>
 
     <div class="small-heart">
       <img src="{% static "img/fundraising-heart.svg" %}" alt="Support Django!" />
@@ -11,8 +11,10 @@
     <div class="small-cta">
       <ul class="list-links-small">
         <li><a href="{% url "fundraising:index" %}">
-          {{ donation.name }} donated to the Django Software Foundation to
-          support Django development. Donate today!
+          {% blocktranslate trimmed with name=donation.name %}
+            {{ name }} donated to the Django Software Foundation to
+            support Django development. Donate today!
+          {% endblocktranslate %}
         </a></li>
       </ul>
     </div>

--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -1,15 +1,19 @@
 {% extends 'base.html' %}
-{% load fundraising_extras humanize static %}
+{% load fundraising_extras humanize i18n static %}
 
-{% block title %}Support Django{% endblock %}
+{% block title %}{% translate "Support Django" %}{% endblock %}
 {% block layout_class %}full-width{% endblock %}
 
 {% block og_title %}Support Django{% endblock %}
 {% block og_description %}Support Django development by donating to the Django Software Foundation{% endblock %}
 
 {% block header %}
-<h1 class="visuallyhidden">Support Django</h1>
-<p><em>Support Django development</em> by donating to the <em>Django Software Foundation</em>.</p>
+<h1 class="visuallyhidden">{% translate "Support Django" %}</h1>
+<p>
+  {% blocktranslate trimmed %}
+    <em>Support Django development</em> by donating to the <em>Django Software Foundation</em>.
+  {% endblocktranslate %}
+</p>
 {% endblock %}
 
 {% block messages %}
@@ -25,67 +29,113 @@
 
 {% block content %}
 
-<h1>Support the Django Software Foundation!</h1>
+<h1>{% translate "Support the Django Software Foundation!" %}</h1>
 
 {% donation_form_with_heart %}
   
-<h1>Other ways to give</h1>
+<h1>{% translate "Other ways to give" %}</h1>
 <ul>
-  <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a> - 
-    Buy official t-shirts, accessories, and more to support Django.</li>
-  <li><a href="https://github.com/sponsors/django" target="_blank">Sponsor Django via GitHub Sponsors</a>.</li>
-  <li><a href="/foundation/donate/#amazon-smile">Amazon Smile</a> - When you
-    shop at Amazon, you can nominate for 0.5% of the purchase price of your
-    eligible purchases to be donated to the DSF.</li>
-  <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving
-    Program</a> - If your employer participates, you can make donations to the
-    DSF via payroll deduction.</li>
+  <li>
+    {% blocktranslate trimmed %}
+      <a href="https://django.threadless.com/" target="_blank">Official merchandise store</a> - 
+      Buy official t-shirts, accessories, and more to support Django.
+    {% endblocktranslate %}
+  </li>
+  <li>
+    {% blocktranslate trimmed %}
+      <a href="https://github.com/sponsors/django" target="_blank">Sponsor Django via GitHub Sponsors</a>.
+    {% endblocktranslate %}
+  </li>
+  <li>
+    {% blocktranslate trimmed %}
+      <a href="/foundation/donate/#amazon-smile">Amazon Smile</a> - When you
+      shop at Amazon, you can nominate for 0.5% of the purchase price of your
+      eligible purchases to be donated to the DSF.
+    {% endblocktranslate %}
+  </li>
+  <li>
+    {% blocktranslate trimmed %}
+      <a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving
+      Program</a> - If your employer participates, you can make donations to the
+      DSF via payroll deduction.
+    {% endblocktranslate %}
+  </li>
 </ul>
 
-<h2 id="why-give">Why give to the Django Software Foundation?</h2>
+<h2 id="why-give">{% translate "Why give to the Django Software Foundation?" %}</h2>
 
-<p>Our main focus is direct support of Django's developers. This means:</p>
+<p>{% translate "Our main focus is direct support of Django's developers. This means:" %}</p>
 <ul>
-<li>Organizing and funding development sprints so that Django's developers can
-meet in person.</li>
-<li>Helping key developers attend these sprints and other community events by
-covering travel expenses to official Django events.</li>
-<li>Providing financial assistance to community development and outreach
-projects such as <a href="#django-girls">Django Girls</a>.</li>
-<li>Providing financial assistance to individuals so they can attend major
-conferences and events.</li>
-<li>Funding the <a href="#fellowship-program">Django Fellowship program</a>,
-which provides full-time staff to perform community management tasks in the
-Django community.</li>
+  <li>
+    {% translate "Organizing and funding development sprints so that Django's developers can meet in person." %}
+  </li>
+  <li>
+    {% translate "Helping key developers attend these sprints and other community events by covering travel expenses to official Django events." %}
+  </li>
+  <li>
+    {% blocktranslate trimmed %}
+      Providing financial assistance to community development and outreach
+      projects such as <a href="#django-girls">Django Girls</a>.
+    {% endblocktranslate %}
+  </li>
+  <li>
+    {% translate "Providing financial assistance to individuals so they can attend major conferences and events." %}
+  </li>
+  <li>
+    {% blocktranslate trimmed %}
+      Funding the <a href="#fellowship-program">Django Fellowship program</a>,
+      which provides full-time staff to perform community management tasks in the
+      Django community.
+    {% endblocktranslate %}
+  </li>
 </ul>
 
-<p>Still curious? See our <a href="/foundation/donate/">Frequently Asked Questions</a>
-about donations.</p>
-
-<h2 id="fellowship-program">Django Fellowship Program</h2>
-
-<p>The biggest expense of the <abbr title="Django Software Foundation">DSF</abbr>
-  is the Django Fellowship program. It's a project where
-  <a href="#who-are-the-django-fellows">paid contractors</a> are engaged to
-  manage some of the administrative and community management tasks of the
-  Django project to support rapid development of Django itself.</p>
-
-<p><strong>The Django Fellowship program has a major positive impact on how
-  Django is developed and maintained.</strong>
-  The Django Fellows triage 10-15 new tickets each week and review and merge
-  around fifteen non-trivial patches a week from the community. Release
-  blocking and severe bugs aren't postponed indefinitely. Major releases happen
-  according to an 8 month schedule and bug fix releases occur monthly.</p>
-
-<p>For more details, you can read retrospectives for the
-  <a href="/weblog/2015/jan/21/django-fellowship-retrospective/"> first three
-  months of the program</a>,
-  <a href="/weblog/2015/dec/17/fellowship-2015-retrospective/">2015</a>, and
-  <a href="/weblog/2016/dec/28/fellowship-2016-retrospective/">2016</a>.
+<p>
+  {% blocktranslate trimmed %}
+    Still curious? See our <a href="/foundation/donate/">Frequently Asked Questions</a>
+    about donations.
+  {% endblocktranslate %}
 </p>
 
-<p>The Django Fellows are a resource to help review patches and contributions
-   from the community, and the community loves that:</p>
+<h2 id="fellowship-program">{% translate "Django Fellowship Program" %}</h2>
+
+<p>
+  {% blocktranslate trimmed %}
+    The biggest expense of the <abbr title="Django Software Foundation">DSF</abbr>
+    is the Django Fellowship program. It's a project where
+    <a href="#who-are-the-django-fellows">paid contractors</a> are engaged to
+    manage some of the administrative and community management tasks of the
+    Django project to support rapid development of Django itself.
+  {% endblocktranslate %}
+</p>
+
+<p>
+  {% blocktranslate trimmed %}
+    <strong>The Django Fellowship program has a major positive impact on how
+    Django is developed and maintained.</strong>
+    The Django Fellows triage 10-15 new tickets each week and review and merge
+    around fifteen non-trivial patches a week from the community. Release
+    blocking and severe bugs aren't postponed indefinitely. Major releases happen
+    according to an 8 month schedule and bug fix releases occur monthly.
+{% endblocktranslate %}
+</p>
+
+<p>
+  {% blocktranslate trimmed %}
+    For more details, you can read retrospectives for the
+    <a href="/weblog/2015/jan/21/django-fellowship-retrospective/"> first three
+    months of the program</a>,
+    <a href="/weblog/2015/dec/17/fellowship-2015-retrospective/">2015</a>, and
+    <a href="/weblog/2016/dec/28/fellowship-2016-retrospective/">2016</a>.
+  {% endblocktranslate %}
+</p>
+
+<p>
+  {% blocktranslate trimmed %}
+    The Django Fellows are a resource to help review patches and contributions
+    from the community, and the community loves that:
+  {% endblocktranslate %}
+</p>
 
    {% if testimonial %}
    <blockquote>
@@ -94,73 +144,104 @@ about donations.</p>
    </blockquote>
    {% endif %}
 
-<p><strong>If you use Django on a daily basis and care about the development of Django
-   itself, you should donate today</strong> (may be <a href="/foundation/donate/#tax-deductible">tax deductible</a>).
-   Only with your support can we make sure that the web framework you base your work on
-   can grow to be even better in the coming years.</p>
+<p>
+  {% blocktranslate trimmed %}
+    <strong>If you use Django on a daily basis and care about the development of Django
+    itself, you should donate today</strong> (may be <a href="/foundation/donate/#tax-deductible">tax deductible</a>).
+    Only with your support can we make sure that the web framework you base your work on
+    can grow to be even better in the coming years.
+  {% endblocktranslate %}
+</p>
 
-<h2 id="django-girls">Django Girls Outreach</h2>
+<h2 id="django-girls">{% translate "Django Girls Outreach" %}</h2>
 
-<p>Supporting <a href="https://djangogirls.org/">Django Girls workshops</a> is
-a significant priority for the Django Software Foundation. Django Girls
-workshops are organized by volunteers and are provided as free events for women
-who want to learn to code. The workshop serves as an introduction to Python and
-Django, where attendees learn usable skills to build their first web app.</p>
+<p>
+  {% blocktranslate trimmed %}
+    Supporting <a href="https://djangogirls.org/">Django Girls workshops</a> is
+    a significant priority for the Django Software Foundation. Django Girls
+    workshops are organized by volunteers and are provided as free events for women
+    who want to learn to code. The workshop serves as an introduction to Python and
+    Django, where attendees learn usable skills to build their first web app.
+  {% endblocktranslate %}
+</p>
 
-<p>Django Girls workshop attendees go on to organize their own workshops, lead
-in their community, and secure full-time jobs as developers. Read their stories
-in the “Your Django Story” series on the <a href="http://blog.djangogirls.org/">
-Django Girls blog</a>.</p>
+<p>
+  {% blocktranslate trimmed %}
+    Django Girls workshop attendees go on to organize their own workshops, lead
+    in their community, and secure full-time jobs as developers. Read their stories
+    in the “Your Django Story” series on the <a href="http://blog.djangogirls.org/">
+    Django Girls blog</a>.
+  {% endblocktranslate %}
+</p>
 
-<p>In 2015, the Django Software Foundation contributed $5,400 to eighteen
-Django Girls workshops around the world. Here's what some of the organizers had
-to say about the impact:</p>
+<p>
+  {% blocktranslate trimmed %}
+    In 2015, the Django Software Foundation contributed $5,400 to eighteen
+    Django Girls workshops around the world. Here's what some of the organizers had
+    to say about the impact:
+  {% endblocktranslate %}
+</p>
 
 <blockquote>
-<p>Sponsorship from the DSF allowed us to have on-site child care for our Django
-Girls Portland workshop. We hosted 2 young children and an infant, and provided
-them with healthy snacks, games, sidewalk chalk, finger paint, and emoji
-stickers. Without our nanny, 3 of our attendees wouldn't have been able to come
-to the workshop. Finger paint photo is
-<a href="http://blog.djangogirls.org/post/124680859493/django-girls-portland-a-retrospective">
-on the blog</a>!</p>
-<em>Lacey - Portland, Oregon, US</em>
+<p>
+  {% blocktranslate trimmed %}
+    Sponsorship from the DSF allowed us to have on-site child care for our Django
+    Girls Portland workshop. We hosted 2 young children and an infant, and provided
+    them with healthy snacks, games, sidewalk chalk, finger paint, and emoji
+    stickers. Without our nanny, 3 of our attendees wouldn't have been able to come
+    to the workshop. Finger paint photo is
+    <a href="http://blog.djangogirls.org/post/124680859493/django-girls-portland-a-retrospective">
+    on the blog</a>!
+  {% endblocktranslate %}
+</p>
+<em>{% translate "Lacey - Portland, Oregon, US" %}</em>
 </blockquote>
 
 <blockquote>
-<p>The DSF supported <a href="https://djangogirls.org/warsaw/">Django Girls
-Poland</a> four times this year and the impact was enormous! In Poland, diversity
-awareness is not a very common topic. When we approached different local
-companies about our workshops they usually didn't get what we were actually
-doing and why it is important. If not for the DSF, we probably would not have
-been able to hold our workshops at all. Our first workshops were the only until
-now workshops that were 100% female - female only coaches and female only
-attendees. Thanks to you, we were able to focus on gathering female mentors
-instead of searching for sponsors!</p>
-<em>Ania - Wrocław, Poland</em>
+<p>
+  {% blocktranslate trimmed %}
+    The DSF supported <a href="https://djangogirls.org/warsaw/">Django Girls
+    Poland</a> four times this year and the impact was enormous! In Poland, diversity
+    awareness is not a very common topic. When we approached different local
+    companies about our workshops they usually didn't get what we were actually
+    doing and why it is important. If not for the DSF, we probably would not have
+    been able to hold our workshops at all. Our first workshops were the only until
+    now workshops that were 100% female - female only coaches and female only
+    attendees. Thanks to you, we were able to focus on gathering female mentors
+    instead of searching for sponsors!
+  {% endblocktranslate %}
+</p>
+<em>{% translate "Ania - Wrocław, Poland" %}</em>
 </blockquote>
 
 <blockquote>
-<p><a href="https://pyfound.blogspot.kr/2015/10/django-girls-seoul-great-success.html">
-Django Girls Seoul</a> had 425 applicants from 11 different countries ages
-ranging from 16 to 50 years old. After acceptances, we had about 105 people to
-feed and caffeinate! Thanks to Django's sponsorship we could get all of our
-participants coffee for the day. It really made a huge difference because we
-all know how a cup of coffee can change the atmosphere and mood! We were so
-grateful to the sponsorship we received from abroad. We tried to get sponsorship
-from a lot of Korean companies but the same generosity doesn't translate well
-into a Korean Business culture, I guess. This made us even more thankful for
-our friends at the DSF!</p>
-<em>Rachell - Seoul, South Korea</em>
+<p>
+  {% blocktranslate trimmed %}
+    <a href="https://pyfound.blogspot.kr/2015/10/django-girls-seoul-great-success.html">
+    Django Girls Seoul</a> had 425 applicants from 11 different countries ages
+    ranging from 16 to 50 years old. After acceptances, we had about 105 people to
+    feed and caffeinate! Thanks to Django's sponsorship we could get all of our
+    participants coffee for the day. It really made a huge difference because we
+    all know how a cup of coffee can change the atmosphere and mood! We were so
+    grateful to the sponsorship we received from abroad. We tried to get sponsorship
+    from a lot of Korean companies but the same generosity doesn't translate well
+    into a Korean Business culture, I guess. This made us even more thankful for
+    our friends at the DSF!
+  {% endblocktranslate %}
+</p>
+<em>{% translate "Rachell - Seoul, South Korea" %}</em>
 </blockquote>
 
 <hr style="margin: 40px 0" />
 
 <div class="heroes-section">
-  <h1>DSF Supporters</h1>
-  <p>Our donors make our work possible! We are incredibly grateful for the
-  financial support from the following individuals and organizations in our
-  community.</p>
+  <h1>{% translate "DSF Supporters" %}</h1>
+  <p>
+    {% blocktranslate trimmed %}
+      Our donors make our work possible! We are incredibly grateful for the
+      financial support from the following individuals and organizations in our community.
+    {% endblocktranslate %}
+  </p>
 
   {% display_django_heroes %}
 </div>
@@ -169,47 +250,64 @@ our friends at the DSF!</p>
 {% block content-extra %}
   <div class="layout-tertiary" id="about">
     <div class="container">
-      <h2>What is the Django Software Foundation?</h2>
-      <p>Development of Django is supported by an independent foundation
-        established as a 501(c)(3) non-profit. Like most open-source foundations,
-        the goal of the <a href="/foundation/">Django Software Foundation</a>
-        is to promote, support, and advance the Django web framework. If you're
-        interested in how the Django Software Foundation supports the Django
-        web framework, we published a
-        <a href="/weblog/2015/jan/08/django-software-foundation-2014/">Summary
-          of 2014. </a>
+      <h2>{% translate "What is the Django Software Foundation?" %}</h2>
+      <p>
+        {% blocktranslate trimmed %}
+          Development of Django is supported by an independent foundation
+          established as a 501(c)(3) non-profit. Like most open-source foundations,
+          the goal of the <a href="/foundation/">Django Software Foundation</a>
+          is to promote, support, and advance the Django web framework. If you're
+          interested in how the Django Software Foundation supports the Django
+          web framework, we published a
+          <a href="/weblog/2015/jan/08/django-software-foundation-2014/">Summary of 2014. </a>
+        {% endblocktranslate %}
       </p>
 
-      <h2 id="who-are-the-django-fellows">Who are the Django Fellows?</h2>
+      <h2 id="who-are-the-django-fellows">{% translate "Who are the Django Fellows?" %}</h2>
 
-      <p>There are currently two Django Fellows:</p>
+      <p>{% translate "There are currently two Django Fellows:" %}</p>
 
-      <p><strong><a href="https://github.com/carltongibson">Carlton Gibson</a>
-        (2018-present)</strong> - a longtime Django user, core contributor to
-        Django REST Framework, maintainer of Django Filter and Django Crispy
-        Forms, and a contributor to many other packages in the Django ecosystem.
-        Carlton <a href="https://www.djangoproject.com/weblog/2018/jan/12/dsf-welcomes-carlton-gibson-its-newest-fellow/">
-        began as a part-time Fellow in January 2018</a>.</p>
-      <p><strong><a href="https://github.com/felixxm">Mariusz Felisiak</a>
-        (2019-present)</strong> - a member of the Django team since 2017,
-        focusing on the ORM and Oracle back-end, along with triaging tickets,
-        reviewing pull requests, and backporting changes. He has contributed to
-        more than a dozen open-source projects. Mariusz
-        <a href="https://www.djangoproject.com/weblog/2019/jan/29/dsf-welcomes-mariusz-felisiak-its-newest-fellow/">
-        began as a full-time Fellow in April 2019</a>.
+      <p>
+        {% blocktranslate trimmed %}
+          <strong><a href="https://github.com/carltongibson">Carlton Gibson</a>
+          (2018-present)</strong> - a longtime Django user, core contributor to
+          Django REST Framework, maintainer of Django Filter and Django Crispy
+          Forms, and a contributor to many other packages in the Django ecosystem.
+          Carlton <a href="https://www.djangoproject.com/weblog/2018/jan/12/dsf-welcomes-carlton-gibson-its-newest-fellow/">
+          began as a part-time Fellow in January 2018</a>.
+        {% endblocktranslate %}
+      </p>
+      <p>
+        {% blocktranslate trimmed %}
+          <strong><a href="https://github.com/felixxm">Mariusz Felisiak</a>
+          (2019-present)</strong> - a member of the Django team since 2017,
+          focusing on the ORM and Oracle back-end, along with triaging tickets,
+          reviewing pull requests, and backporting changes. He has contributed to
+          more than a dozen open-source projects. Mariusz
+          <a href="https://www.djangoproject.com/weblog/2019/jan/29/dsf-welcomes-mariusz-felisiak-its-newest-fellow/">
+          began as a full-time Fellow in April 2019</a>.
+        {% endblocktranslate %}
       </p>
 
-      <p>Former Django Fellows:</p>
+      <p>{% translate "Former Django Fellows:" %}</p>
 
-      <p><strong><a href="https://github.com/timgraham">Tim Graham</a> (2014-
-        2019)</strong> - the inaugural Django Fellow, a member of the Django
-        team since 2010, and a longtime major contributor and reviewer. In 2018
-        Tim transitioned to part-time and in 2019 retired after four years of
-        service.</p>
-      <p><strong><a href="https://github.com/berkerpeksag">Berker Peksağ</a>
-        (2014)</strong> - a core developer on CPython and Gunicorn, Berker
-        worked as Fellow during the 3 month pilot, supporting Tim
-        part-time.</p>
+      <p>
+        {% blocktranslate trimmed %}
+          <strong><a href="https://github.com/timgraham">Tim Graham</a> (2014-
+          2019)</strong> - the inaugural Django Fellow, a member of the Django
+          team since 2010, and a longtime major contributor and reviewer. In 2018
+          Tim transitioned to part-time and in 2019 retired after four years of
+          service.
+        {% endblocktranslate %}
+      </p>
+      <p>
+        {% blocktranslate trimmed %}
+          <strong><a href="https://github.com/berkerpeksag">Berker Peksağ</a>
+          (2014)</strong> - a core developer on CPython and Gunicorn, Berker
+          worked as Fellow during the 3 month pilot, supporting Tim
+          part-time.
+        {% endblocktranslate %}
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/djangoproject/templates/fundraising/manage-donations.html
+++ b/djangoproject/templates/fundraising/manage-donations.html
@@ -1,5 +1,5 @@
 {% extends 'fundraising/index.html' %}
-{% load static %}
+{% load i18n static %}
 
 {% block messages %}
 
@@ -14,27 +14,31 @@
 
 {% block content %}
 
-<h1>Manage your donations to the Django Software Foundation</h1>
-<p>Your support is <strong>invaluable</strong> to continue the rapid development
-  of Django and helps the <strong>Django Fellowship</strong> program in particular.
-  Thank you!</p>
+<h1>{% translate "Manage your donations to the Django Software Foundation" %}</h1>
+<p>
+  {% blocktranslate trimmed %}
+    Your support is <strong>invaluable</strong> to continue the rapid development
+    of Django and helps the <strong>Django Fellowship</strong> program in particular.
+    Thank you!
+  {% endblocktranslate %}
+</p>
 
 <form enctype="multipart/form-data" action="" method="post" class="form-input django-hero-form"
     data-stripe-key="{{ stripe_publishable_key }}" data-stripe-icon="{% static 'img/dj-stripe-icon.jpg' %}"
     data-update-card-url="{% url 'fundraising:update-card' %}">
-  <h2>Manage your participation in the fundraising campaigns</h2>
-  <p>Information entered below will be visible on all of your donations to the Django Project.</p>
+  <h2>{% translate "Manage your participation in the fundraising campaigns" %}</h2>
+  <p>{% translate "Information entered below will be visible on all of your donations to the Django Project." %}</p>
   {% csrf_token %}
   {% include 'fundraising/includes/_form.html' with form=hero_form %}
   <p class="submit">
-    <input type="submit" class="cta" value="Save &rarr;">
+    <input type="submit" class="cta" value="{% translate "Save" %} &rarr;">
   </p>
   {# Always include to avoid "Management form has been tampered with" if no recurring donations exist #}
   {{ modify_donations_formset.management_form }}
   {% if recurring_donations %}
     <hr />
-    <h2>Modify your recurring donations</h2>
-    <p>Update the time interval or amount of your recurring donation here:</p>
+    <h2>{% translate "Modify your recurring donations" %}</h2>
+    <p>{% translate "Update the time interval or amount of your recurring donation here:" %}</p>
     {% for form in modify_donations_formset %}
       {% include 'fundraising/includes/_form.html' %}
       <div class="change-card-container">
@@ -44,20 +48,22 @@
       </div>
     {% endfor %}
     <p class="submit">
-      <input type="submit" class="cta" value="Save &rarr;">
+      <input type="submit" class="cta" value="{% translate "Save" %} &rarr;">
     </p>
 </form>
     <hr />
-    <h2>Cancel your recurring donations</h2>
-    <p>You can cancel your recurring donation to the Django Software Foundation anytime.</p>
+    <h2>{% translate "Cancel your recurring donations" %}</h2>
+    <p>{% translate "You can cancel your recurring donation to the Django Software Foundation anytime." %}</p>
     <ul>
     {% for donation in recurring_donations %}
       <li>
-        Your {{ donation.interval }} recurring donation of ${{ donation.subscription_amount }}.
+        {% blocktranslate with interval=donation.interval subscription_amount=donation.subscription_amount %}
+          Your {{ interval }} recurring donation of ${{ subscription_amount }}.
+        {% endblocktranslate %}
         <form method="POST" action="{% url 'fundraising:cancel-donation' hero.pk %}">
           {% csrf_token %}
           <input name="donation" type="hidden" value="{{ donation.pk }}">
-          <input type="submit" value="cancel this donation">
+          <input type="submit" value="{% translate "cancel this donation" %}">
         </form>
       </li>
     {% endfor %}
@@ -67,7 +73,7 @@
   {% endif %}
   {% if past_payments %}
   <hr />
-    <h2>Your past donations</h2>
+    <h2>{% translate "Your past donations" %}</h2>
     <ul>
     {% for payment in past_payments %}
       <li>

--- a/djangoproject/templates/fundraising/thank-you.html
+++ b/djangoproject/templates/fundraising/thank-you.html
@@ -1,30 +1,42 @@
 {% extends 'fundraising/index.html' %}
-{% load humanize static %}
+{% load humanize i18n static %}
 
 {% block content %}
-<h1>Thank you for supporting the Django Project!</h1>
-<p>Your support is <strong>invaluable</strong> to continue the rapid development
-  of Django and helps the <strong>Django Fellowship</strong> program in particular.</p>
+<h1>{% translate "Thank you for supporting the Django Project!" %}</h1>
+<p>
+{% blocktranslate trimmed %}
+  Your support is <strong>invaluable</strong> to continue the rapid development
+  of Django and helps the <strong>Django Fellowship</strong> program in particular.
+{% endblocktranslate %}
+</p>
 
-<p>Please help us spread the word and encourage your friends and colleagues to
-  donate. Thank you!</p>
+<p>
+  {% translate "Please help us spread the word and encourage your friends and colleagues to donate. Thank you!" %}
+</p>
 
 <a href="https://twitter.com/intent/tweet?button_hashtag=SupportDjango&text=I+just+donated+to+support+the+Django+Software+Foundation.+Join+me!+https%3A%2F%2Fwww.djangoproject.com%2Ffundraising%2F"
   class="twitter-hashtag-button" data-related="djangoproject">Tweet #SupportDjango</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 
 <p>
-You should receive an email shortly, with confirmation of your donation,
-details of badges you can display to show you support of Django, managing your
-donation,  and how you can have your name or company displayed on the
-Fundraising page and in the sidebar on the Django Project website.
+{% blocktranslate trimmed %}
+  You should receive an email shortly, with confirmation of your donation,
+  details of badges you can display to show you support of Django, managing your
+  donation,  and how you can have your name or company displayed on the
+  Fundraising page and in the sidebar on the Django Project website.
+{% endblocktranslate %}
 </p>
 
-<p>Welcome aboard! ⛵️</p>
+<p>{% translate "Welcome aboard!" %} ⛵️</p>
 
 <hr>
 
-<p>If you have any <strong>problems</strong> with your donation please email <a href="mailto:donations@djangoproject.com">donations@djangoproject.com</a> for help.</p>
+<p>
+  {% blocktranslate trimmed %}
+    If you have any <strong>problems</strong> with your donation please email 
+    <a href="mailto:donations@djangoproject.com">donations@djangoproject.com</a> for help.
+  {% endblocktranslate %}
+</p>
 
 {% endblock %}
 

--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -1,5 +1,5 @@
 {% extends "base_3col.html" %}
-{% load weblog fundraising_extras %}
+{% load weblog fundraising_extras i18n %}
 
 {% block sectionid %}homepage{% endblock %}
 {% block body_class %}homepage{% endblock %}
@@ -8,39 +8,40 @@
 {% block header %}
   <h1 class="visuallyhidden">Django</h1>
     <p>
-        <em>Django makes it easier to build better web apps more quickly and with less code.</em>
+        <em>{% translate "Django makes it easier to build better web apps more quickly and with less code." %}</em>
     </p>
     <p>
-        <a href="{% url 'start' %}" class="cta">Get started with Django</a>
+        <a href="{% url 'start' %}" class="cta">{% translate "Get started with Django" %}</a>
     </p>
 {% endblock %}
 
 {% block content %}
     <div class="section">
-        <h1>Meet Django</h1>
-        <p>
+        <h1>{% translate "Meet Django" %}</h1>
+        <p>{% blocktranslate trimmed %}
           Django is a high-level Python web framework that encourages rapid development and clean, pragmatic design.
           Built by experienced developers, it takes care of much of the hassle of web development, so you can focus
           on writing your app without needing to reinvent the wheel. It’s free and open source.
+        {% endblocktranslate %}
         </p>
         <dl class="list-features">
-          <dt><i class="icon icon-bolt"></i> Ridiculously fast.</dt>
+          <dt><i class="icon icon-bolt"></i> {% translate "Ridiculously fast." %}</dt>
           <dd>
-            <p>Django was designed to help developers take applications from concept to completion as quickly as possible.</p>
+            <p>{% translate "Django was designed to help developers take applications from concept to completion as quickly as possible." %}</p>
           </dd>
 
-          <dt><i class="icon icon-lock"></i> Reassuringly secure.</dt>
+          <dt><i class="icon icon-lock"></i> {% translate "Reassuringly secure." %}</dt>
           <dd>
-            <p>Django takes security seriously and helps developers avoid many common security mistakes.</p>
+            <p>{% translate "Django takes security seriously and helps developers avoid many common security mistakes." %}</p>
           </dd>
 
-          <dt><i class="icon icon-dashboard"></i> Exceedingly scalable.</dt>
+          <dt><i class="icon icon-dashboard"></i> {% translate "Exceedingly scalable." %}</dt>
           <dd>
-            <p>Some of the busiest sites on the web leverage Django’s ability to quickly and flexibly scale.</p>
+            <p>{% translate "Some of the busiest sites on the web leverage Django’s ability to quickly and flexibly scale." %}</p>
           </dd>
         </dl>
 
-        <a href="{% url 'overview' %}" class="cta outline">Learn more about Django</a>
+        <a href="{% url 'overview' %}" class="cta outline">{% translate "Learn more about Django" %}</a>
     </div>
 
     {% comment %}
@@ -77,8 +78,8 @@
     {% endcomment %}
 
     <div class="section">
-    <h1>Stay in the loop</h1>
-    <p>Subscribe to one of our mailing lists to stay up to date with everything in the Django community:</p>
+    <h1>{% translate "Stay in the loop" %}</h1>
+    <p>{% translate "Subscribe to one of our mailing lists to stay up to date with everything in the Django community:" %}</p>
     {% include "includes/mailing_lists.html" %}
     </div>
 
@@ -88,79 +89,81 @@
 {% block content-related %}
   <div role="complementary">
       <a href="{% url 'download' %}" class="cta">
-          Download <em>latest release: {{ DJANGO_VERSION }}</em>
+          {% blocktranslate trimmed with version=DJANGO_VERSION %}
+            Download <em>latest release: {{ version }}</em>
+          {% endblocktranslate %}
       </a>
-      <a href="{% block doc_url %}{% url 'homepage' host 'docs' %}{% endblock %}" class="link-readmore">Django documentation</a>
+      <a href="{% block doc_url %}{% url 'homepage' host 'docs' %}{% endblock %}" class="link-readmore">{% translate "Django documentation" %}</a>
 
       {% donation_snippet %}
 
-      <h3>Latest news</h3>
+      <h3>{% translate "Latest news" %}</h3>
       {% render_latest_blog_entries 2 hide_readmore=True summary_first=True header_tag='h4' %}
-      <a href="{% url 'weblog:index' %}" class="link-readmore">More news</a>
+      <a href="{% url 'weblog:index' %}" class="link-readmore">{% translate "More news" %}</a>
 
-      <h3>New to Django?</h3>
+      <h3>{% translate "New to Django?" %}</h3>
       <ul class="list-links-small docs-list">
-          <li><a href="{% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' %}">Installation guide</a></li>
-          <li><a href="{% url 'document-detail' lang='en' version='stable' url='intro/tutorial01' host 'docs' %}">Write your first Django app</a></li>
+          <li><a href="{% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' %}">{% translate "Installation guide" %}</a></li>
+          <li><a href="{% url 'document-detail' lang='en' version='stable' url='intro/tutorial01' host 'docs' %}">{% translate "Write your first Django app" %}</a></li>
       </ul>
-      <a href="{% url 'start' %}" class="link-readmore">Getting started with Django</a>
+      <a href="{% url 'start' %}" class="link-readmore">{% translate "Getting started with Django" %}</a>
 
-      <h3>The power of Django</h3>
+      <h3>{% translate "The power of Django" %}</h3>
       <ul class="list-links-small docs-list">
-          <li><a href="{% url 'document-detail' lang='en' version='stable' url='topics/db/models' host 'docs' %}">Object-relational mapper</a></li>
-          <li><a href="{% url 'document-detail' lang='en' version='stable' url='intro/tutorial02' host 'docs' %}">Automatic admin interface</a></li>
-          <li><a href="{% url 'document-detail' lang='en' version='stable' url='topics/templates' host 'docs' %}">Robust template system</a></li>
-          <li><a href="{% url 'document-detail' lang='en' version='stable' url='topics/i18n' host 'docs' %}">Quick internationalization</a></li>
+          <li><a href="{% url 'document-detail' lang='en' version='stable' url='topics/db/models' host 'docs' %}">{% translate "Object-relational mapper" %}</a></li>
+          <li><a href="{% url 'document-detail' lang='en' version='stable' url='intro/tutorial02' host 'docs' %}">{% translate "Automatic admin interface" %}</a></li>
+          <li><a href="{% url 'document-detail' lang='en' version='stable' url='topics/templates' host 'docs' %}">{% translate "Robust template system" %}</a></li>
+          <li><a href="{% url 'document-detail' lang='en' version='stable' url='topics/i18n' host 'docs' %}">{% translate "Quick internationalization" %}</a></li>
       </ul>
-      <a href="{% url 'overview' %}" class="link-readmore">Explore more features</a>
+      <a href="{% url 'overview' %}" class="link-readmore">{% translate "Explore more features" %}</a>
 
-      <h3>Get involved</h3>
+      <h3>{% translate "Get involved" %}</h3>
       <dl class="list-links-small">
-          <dt><a href="https://code.djangoproject.com/">Ticket system</a></dt>
+          <dt><a href="https://code.djangoproject.com/">{% translate "Ticket system" %}</a></dt>
           <dd>
-            Report bugs and make feature requests
+            {% translate "Report bugs and make feature requests" %}
           </dd>
-          <dt><a href="https://dashboard.djangoproject.com/">Development dashboard</a></dt>
+          <dt><a href="https://dashboard.djangoproject.com/">{% translate "Development dashboard" %}</a></dt>
           <dd>
-            see what's currently being worked on
+            {% translate "See what's currently being worked on" %}
           </dd>
       </dl>
-      <a href="{% url 'community-index' %}" class="link-readmore">Inside the Django community</a>
+      <a href="{% url 'community-index' %}" class="link-readmore">{% translate "Inside the Django community" %}</a>
       
       <h3>Get Help</h3>
       <dl class="list-links-small">
-         <dt><a href="irc://irc.libera.chat/django">#django IRC channel</a></dt>
+         <dt><a href="irc://irc.libera.chat/django">{% translate "#django IRC channel" %}</a></dt>
           <dd>
-            Chat with other Django users
+            {% translate "Chat with other Django users" %}
           </dd>
 
-          <dt><a href="https://discord.gg/xcRH6mN4fa" target="_blank">Django Discord Server</a></dt>
+          <dt><a href="https://discord.gg/xcRH6mN4fa" target="_blank">{% translate "Django Discord Server" %}</a></dt>
           <dd>
-            Join the Django Discord Community
+            {% translate "Join the Django Discord Community" %}
           </dd>
 
-          <dt><a href="https://forum.djangoproject.com/" target="_blank">Official Django Forum</a></dt>
+          <dt><a href="https://forum.djangoproject.com/" target="_blank">{% translate "Official Django Forum" %}</a></dt>
           <dd>
-            Join the community on the Django Forum.
+            {% translate "Join the community on the Django Forum." %}
           </dd>
       </dl>
 
-      <h3>The Django Software Foundation</h3>
+      <h3>{% translate "The Django Software Foundation" %}</h3>
       <dl class="list-links-small">
-        <dt><a href="/foundation/">About the Foundation</a></dt>
+        <dt><a href="/foundation/">{% translate "About the Foundation" %}</a></dt>
         <dd>
-          Our non-profit supports the project
+          {% translate "Our non-profit supports the project" %}
         </dd>
 
-        <dt><a href="/foundation/donate/">Support Django</a></dt>
+        <dt><a href="/foundation/donate/">{% translate "Support Django" %}</a></dt>
         <dd>
-          Your contribution makes Django stronger
+          {% translate "Your contribution makes Django stronger" %}
         </dd>
 
-        <dt><a href="/contact/foundation/">Contact the Django Software Foundation</a></dt>
+        <dt><a href="/contact/foundation/">{% translate "Contact the Django Software Foundation" %}</a></dt>
         <dd></dd>
       </dl>
-      <a href="/foundation/" class="link-readmore">More about the DSF</a>
+      <a href="/foundation/" class="link-readmore">{% translate "More about the DSF" %}</a>
       {% comment %}
       <h3>Upcoming Events</h3>
       <dl class="list-links-small news-list">

--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -1,65 +1,80 @@
+{% load i18n %}
+
 <div role="contentinfo">
   <div class="subfooter">
     <div class="container">
-      <h1 class="visuallyhidden">Django Links</h1>
+      <h1 class="visuallyhidden">{% translate "Django Links" %}</h1>
       <div class="column-container">
         <div class="col-learn-more">
-          <h2>Learn More</h2>
+          <h2>{% translate "Learn More" %}</h2>
           <ul>
-            <li><a href="{% url 'overview' %}">About Django</a></li>
-            {% comment %}<li><a href="{% url 'case_study_index' %}">Case Studies</a></li>{% endcomment %}
-            <li><a href="{% url 'start' %}">Getting Started with Django</a></li>
-            <li><a href="{% url 'document-detail' lang='en' version='dev' url="internals/organization" host 'docs' %}">Team
-              Organization</a></li>
-            <li><a href="{% url 'homepage' %}foundation/">Django Software Foundation</a></li>
-            <li><a href="{% url 'code_of_conduct' %}">Code of Conduct</a></li>
-            <li><a href="{% url 'diversity' %}">Diversity Statement</a></li>
+            <li><a href="{% url 'overview' %}">{% translate "About Django" %}</a></li>
+            {% comment %}<li><a href="{% url 'case_study_index' %}">{% translate "Case Studies" %}</a></li>{% endcomment %}
+            <li><a href="{% url 'start' %}">{% translate "Getting Started with Django" %}</a></li>
+            <li>
+              <a href="{% url 'document-detail' lang='en' version='dev' url="internals/organization" host 'docs' %}">
+                {% translate "Team Organization" %}
+              </a>
+            </li>
+            <li><a href="{% url 'homepage' %}foundation/">{% translate "Django Software Foundation" %}</a></li>
+            <li><a href="{% url 'code_of_conduct' %}">{% translate "Code of Conduct" %}</a></li>
+            <li><a href="{% url 'diversity' %}">{% translate "Diversity Statement" %}</a></li>
           </ul>
         </div>
 
         <div class="col-get-involved">
-          <h2>Get Involved</h2>
+          <h2>{% translate "Get Involved" %}</h2>
           <ul>
-            <li><a href="{% url 'community-index' %}">Join a Group</a></li>
-            <li><a href="{% url 'document-detail' lang='en' version='dev' url="internals/contributing" host 'docs' %}">Contribute
-              to Django</a></li>
-            <li><a
-              href="{% url 'document-detail' lang='en' version='dev' url="internals/contributing/bugs-and-features" host 'docs' %}">Submit
-              a Bug</a></li>
-            <li><a
-              href="{% url 'document-detail' lang='en' version='dev' url="internals/security" host 'docs' %}#reporting-security-issues">Report
-              a Security Issue</a></li>
+            <li><a href="{% url 'community-index' %}">{% translate "Join a Group" %}</a></li>
+            <li>
+              <a href="{% url 'document-detail' lang='en' version='dev' url="internals/contributing" host 'docs' %}">
+                {% translate "Contribute to Django" %}
+              </a>
+            </li>
+            <li>
+              <a href="{% url 'document-detail' lang='en' version='dev' url="internals/contributing/bugs-and-features" host 'docs' %}">
+                {% translate "Submit a Bug" %}
+              </a>
+            </li>
+            <li>
+              <a href="{% url 'document-detail' lang='en' version='dev' url="internals/security" host 'docs' %}#reporting-security-issues">
+                {% translate "Report a Security Issue" %}
+              </a>
+            </li>
           </ul>
         </div>
 
         <div class="col-get-help">
-          <h2>Get Help</h2>
+          <h2>{% translate "Get Help" %}</h2>
           <ul>
-            <li><a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">Getting Help FAQ</a>
+            <li>
+              <a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">
+                {% translate "Getting Help FAQ" %}
+              </a>
             </li>
-            <li><a href="irc://irc.libera.chat/django">#django IRC channel</a></li>
-            <li><a href="https://discord.gg/xcRH6mN4fa" target="_blank">Django Discord</a></li>
-            <li><a href="https://forum.djangoproject.com/" target="_blank">Official Django Forum</a></li>
+            <li><a href="irc://irc.libera.chat/django">{% translate "#django IRC channel" %}</a></li>
+            <li><a href="https://discord.gg/xcRH6mN4fa" target="_blank">{% translate "Django Discord" %}</a></li>
+            <li><a href="https://forum.djangoproject.com/" target="_blank">{% translate "Official Django Forum" %}</a></li>
           </ul>
         </div>
 
         <div class="col-follow-us">
-          <h2>Follow Us</h2>
+          <h2>{% translate "Follow Us" %}</h2>
           <ul>
             <li><a href="https://github.com/django">GitHub</a></li>
             <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
-            <li><a href="{% url 'weblog-feed' %}">News RSS</a></li>
-            <li><a href="https://groups.google.com/forum/#!forum/django-users">Django Users Mailing List</a></li>
+            <li><a href="{% url 'weblog-feed' %}">{% translate "News RSS" %}</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/django-users">{% translate "Django Users Mailing List" %}</a></li>
           </ul>
         </div>
 
         <div class="col-support-us">
-          <h2>Support Us</h2>
+          <h2>{% translate "Support Us" %}</h2>
           <ul>
-            <li><a href="{% url "fundraising:index" %}">Sponsor Django</a></li>
-            <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a></li>
+            <li><a href="{% url "fundraising:index" %}">{% translate "Sponsor Django" %}</a></li>
+            <li><a href="https://django.threadless.com/" target="_blank">{% translate "Official merchandise store" %}</a></li>
             <li><a href="/foundation/donate/#amazon-smile">Amazon Smile</a></li>
-            <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving Program</a></li>
+            <li><a href="/foundation/donate/#benevity-giving">{% translate "Benevity Workplace Giving Program" %}</a></li>
           </ul>
         </div>
       </div>
@@ -72,17 +87,22 @@
       </div>
       <ul class="thanks">
         <li>
-          <span>Hosting by</span> <a class="in-kind-donors" href="{% url 'fundraising:index' %}#in-kind-donors">In-kind
-          donors</a>
+          {% url 'fundraising:index' as fundraising_url %}
+          {% blocktranslate trimmed %}
+            <span>Hosting by</span> <a class="in-kind-donors" href="{{ fundraising_url }}#in-kind-donors">In-kind donors</a>
+          {% endblocktranslate %}
         </li>
-        <li class="design"><span>Design by</span> <a class="threespot" href="https://www.threespot.com">Threespot</a>
+        <li class="design"><span>{% translate "Design by" %}</span> <a class="threespot" href="https://www.threespot.com">Threespot</a>
           <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/">andrevv</a></li>
       </ul>
       <p class="copyright">&copy; 2005-{% now "Y" %}
-        <a href="{% url 'homepage' %}foundation/"> Django Software
+        {% url 'homepage' as homepage %}
+        {% blocktranslate trimmed %}
+        <a href="{{ homepage }}foundation/"> Django Software
           Foundation</a> and individual contributors. Django is a
-        <a href="{% url 'homepage' %}trademarks/">registered
+        <a href="{{ homepage }}trademarks/">registered
           trademark</a> of the Django Software Foundation.
+        {% endblocktranslate %}
       </p>
     </div>
   </div>

--- a/djangoproject/templates/includes/forum.html
+++ b/djangoproject/templates/includes/forum.html
@@ -1,6 +1,7 @@
-<p>
+{% load i18n %}
+<p>{% blocktranslate trimmed %}
   <a href="https://forum.djangoproject.com/">Django forum</a> is a place for
   discussing the Django framework and applications and projects that use it.
   This is also a good place to ask and answer any questions related to
-  installing, using, or contributing to Django.
+  installing, using, or contributing to Django.{% endblocktranslate %}
 </p>

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -1,38 +1,40 @@
+{% load i18n %}
+
 <div role="banner" id="top">
   <div class="container">
     <a class="logo" href="{% url 'homepage' %}">Django</a>
-    <p class="meta">The web framework for perfectionists with deadlines.</p>
+    <p class="meta">{% translate "The web framework for perfectionists with deadlines." %}</p>
     <div class="mobile-toggle">
       {% include "includes/toggle_theme.html" %}
     </div>
     <div role="navigation">
       <ul>
         <li{% if 'start' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'overview' %}">Overview</a>
+          <a href="{% url 'overview' %}">{% translate "Overview" %}</a>
         </li>
         <li{% if 'download' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'download' %}">Download</a>
+          <a href="{% url 'download' %}">{% translate "Download" %}</a>
         </li>
         <li{% if request.host.name == 'docs' %} class="active"{% endif %}>
-          <a href="{% block doc_url %}{% url 'homepage' host 'docs' %}{% endblock %}">Documentation</a>
+          <a href="{% block doc_url %}{% url 'homepage' host 'docs' %}{% endblock %}">{% translate "Documentation" %}</a>
         </li>
         <li{% if 'weblog' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'weblog:index' %}">News</a>
+          <a href="{% url 'weblog:index' %}">{% translate "News" %}</a>
         </li>
         <li{% if 'community' in request.path or 'conduct' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'community-index' %}">Community</a>
+          <a href="{% url 'community-index' %}">{% translate "Community" %}</a>
         </li>
         <li>
-          <a href="https://github.com/django/django" target="_blank" rel="noopener">Code</a>
+          <a href="https://github.com/django/django" target="_blank" rel="noopener">{% translate "Code" %}</a>
         </li>
         <li>
-          <a href="https://code.djangoproject.com/">Issues</a>
+          <a href="https://code.djangoproject.com/">{% translate "Issues" %}</a>
         </li>
         <li{% if 'foundation' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'homepage' %}foundation/">About</a>
+          <a href="{% url 'homepage' %}foundation/">{% translate "About" %}</a>
         </li>
         <li{% if 'fundraising' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'fundraising:index' %}">&#9829; Donate</a>
+          <a href="{% url 'fundraising:index' %}">&#9829; {% translate "Donate" %}</a>
         </li>
         <li>
           {% include "includes/toggle_theme.html" %}

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -11,9 +11,11 @@
   {% endif %}
   {% endfor %}
   {% get_language_info for LANGUAGE_CODE as lang %}
+  {% if lang %}
     <li class="current"
         title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
       <span>{% trans "Language:" %} <strong>{{ lang.name_local }}</strong></span>
     </li>
+  {% endif %}
   </ul>
 </div>

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+<div id="version-switcher">
+  <ul id="doc-languages" class="language-switcher doc-switcher">
+  {% get_available_languages as languages %}
+  {% for available_lang in languages %}
+  {% if lang != available_lang %}
+  <li class="other">
+    {% url 'change_language' lang_code=available_lang.0 as language_url %}
+    <a href="{{ language_url }}">{{ available_lang.1 }}</a>
+  </li>
+  {% endif %}
+  {% endfor %}
+    <li class="current"
+        title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
+      <span>{% trans "Language:" %} <strong>{{ LANGUAGE_CODE|language_name_translated }}</strong></span>
+    </li>
+  </ul>
+</div>

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -10,9 +10,10 @@
   </li>
   {% endif %}
   {% endfor %}
+  {% get_language_info for LANGUAGE_CODE as lang %}
     <li class="current"
         title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
-      <span>{% trans "Language:" %} <strong>{{ LANGUAGE_CODE|language_name_translated }}</strong></span>
+      <span>{% trans "Language:" %} <strong>{{ lang.name_local }}</strong></span>
     </li>
   </ul>
 </div>

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -10,8 +10,8 @@
   </li>
   {% endif %}
   {% endfor %}
+  {% if LANGUAGE_CODE %}
   {% get_language_info for LANGUAGE_CODE as lang %}
-  {% if lang %}
     <li class="current"
         title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
       <span>{% trans "Language:" %} <strong>{{ lang.name_local }}</strong></span>

--- a/djangoproject/templates/includes/mailing_lists.html
+++ b/djangoproject/templates/includes/mailing_lists.html
@@ -1,49 +1,52 @@
+{% load i18n %}
+
 <div class="layout-2col">
   <div class="col form-email">
-    <h3><a href="https://groups.google.com/group/django-users">Using Django</a></h3>
-    <p class="meta">Get help with Django and follow announcements.</p>
+    <h3><a href="https://groups.google.com/group/django-users">{% translate "Using Django" %}</a></h3>
+    <p class="meta">{% translate "Get help with Django and follow announcements." %}</p>
     <form class="form-input" action="https://groups.google.com/group/django-users/boxsubscribe">
-      <input type="email" name="email" placeholder="Enter email">
+      <input type="email" name="email" placeholder="{% translate "Enter email" %}">
       <button type="submit">
         <i class="icon icon-envelope-o"></i>
-        <span class="visuallyhidden">Subscribe</span>
+        <span class="visuallyhidden">{% translate "Subscribe" %}</span>
       </button>
     </form>
-    <p class="meta">
+    <p class="meta">{% blocktranslate trimmed %}
       You can also subscribe by sending an email to
       <a href="mailto:django-users+subscribe@googlegroups.com">
       django-users+subscribe@googlegroups.com</a> and following the
-      instructions that will be sent to you.
+      instructions that will be sent to you.{% endblocktranslate %}
     </p>
   </div>
   <div class="col form-email last-child">
-    <h3><a href="https://groups.google.com/group/django-developers">Contributing to Django</a></h3>
-    <p class="meta">Contribute to the development of Django itself.</p>
+    <h3><a href="https://groups.google.com/group/django-developers">{% translate "Contributing to Django" %}</a></h3>
+    <p class="meta">{% translate "Contribute to the development of Django itself." %}</p>
     <form class="form-input" action="https://groups.google.com/group/django-developers/boxsubscribe">
-      <input type="email" name="email" placeholder="Enter email">
+      <input type="email" name="email" placeholder="{% translate "Enter email" %}">
       <button type="submit">
         <i class="icon icon-envelope-o"></i>
-        <span class="visuallyhidden">Subscribe</span>
+        <span class="visuallyhidden">{% translate "Subscribe" %}</span>
       </button>
     </form>
-    <p class="meta">
+    <p class="meta">{% blocktranslate trimmed %}
       Before asking a question about how to contribute, read
       <a href="https://docs.djangoproject.com/en/dev/internals/contributing/">
-      Contributing to Django</a>. Many frequently asked questions are answered there.
+      Contributing to Django</a>. Many frequently asked questions are answered there.{% endblocktranslate %}
     </p>
     <hr>
-    <p class="meta">
+    <p class="meta">{% blocktranslate trimmed %}
       You can also subscribe by sending an email to
       <a href="mailto:django-developers+subscribe@googlegroups.com">
       django-developers+subscribe@googlegroups.com</a> and following the
-      instructions that will be sent to you.
+      instructions that will be sent to you.{% endblocktranslate %}
     </p>
   </div>
 
 </div>
-<p>
+{% url 'document-detail' url='internals/mailing-lists' lang='en' version='dev' host 'docs' as dev_mailing_list_url %}
+<p>{% blocktranslate trimmed %}
     We have a few other specialized lists (announce, i18n, ...). You can
     find more information about them in our
-    <a href="{% url 'document-detail' url='internals/mailing-lists' lang='en' version='dev' host 'docs' %}">
-    mailing list documentation</a>.
+    <a href="{{ dev_mailing_list_url }}">
+    mailing list documentation</a>.{% endblocktranslate %}
   </p>

--- a/djangoproject/templates/members/corporate_member_badges.html
+++ b/djangoproject/templates/members/corporate_member_badges.html
@@ -1,5 +1,5 @@
 {% extends "base_foundation.html" %}
-{% load static %}
+{% load i18n static %}
 
 {% block head_extra %}
   <style type="text/css">
@@ -28,9 +28,9 @@
 {% endblock head_extra %}
 
 {% block content %}
-  <h1>Corporate member badges</h1>
+  <h1>{% translate "Corporate member badges" %}</h1>
   <p>
-    <a href="/foundation/corporate-membership/">Corporate members</a> of the Django Software Foundation may display these badges on their site to show their support.
+    {% blocktranslate %}<a href="/foundation/corporate-membership/">Corporate members</a> of the Django Software Foundation may display these badges on their site to show their support.{% endblocktranslate %}
   </p>
   {% for level, variants in badges.items %}
     <h3>{{ level|title }}</h3>

--- a/djangoproject/templates/members/corporate_members_join_thanks.html
+++ b/djangoproject/templates/members/corporate_members_join_thanks.html
@@ -2,11 +2,11 @@
 {% load i18n %}
 
 {% block content %}
-  <h1>{% trans "Corporate membership application submitted." %}</h1>
+  <h1>{% translate "Corporate membership application submitted." %}</h1>
   <p>
-    {% blocktrans %}
+    {% blocktranslate trimmed %}
       Thanks! Your application is being reviewed, and we'll follow up a
       response from the board after our next monthly meeting.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 {% endblock %}

--- a/djangoproject/templates/members/corporatemember_form.html
+++ b/djangoproject/templates/members/corporatemember_form.html
@@ -2,12 +2,12 @@
 {% load i18n %}
 
 {% block content %}
-  <h1>{% trans "Become a DSF corporate member" %}</h1>
+  <h1>{% translate "Become a DSF corporate member" %}</h1>
   <p>
-    {% blocktrans %}
+    {% blocktranslate trimmed %}
       Provide us with a few details and we'll start onboarding your
       organization!
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
   <form class="form-input corporate-membership-join-form" method="post" action="."
       enctype="multipart/form-data">
@@ -23,6 +23,6 @@
     {% if field.help_text %}<p class="footnote">{{ field.help_text|safe }}</p>{% endif %}
     </div>
     {% endfor %}
-  <input class="cta" type="submit" value="Send →">
+  <input class="cta" type="submit" value="{% translate "Send" %} →">
   </form>
 {% endblock %}

--- a/djangoproject/templates/members/corporatemember_list.html
+++ b/djangoproject/templates/members/corporatemember_list.html
@@ -16,8 +16,11 @@
   </p>
 
 {% if members.diamond %}
-<h3>{% translate "Diamond Corporate Members" %} (${{ corporate_membership_amounts.diamond|intcomma }}+)</h3>
-<p>{% blocktranslate trimmed %}Our diamond <a href="/foundation/corporate-membership/">corporate
+<h3>{% blocktranslate trimmed with diamond=corporate_membership_amounts.diamond %}
+  Diamond Corporate Members (${{ diamond|intcomma }}+)
+{% endblocktranslate %}</h3>
+<p>{% blocktranslate trimmed %}
+  Our diamond <a href="/foundation/corporate-membership/">corporate
   members</a> include mega corporations and foundations.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.diamond %}
@@ -27,9 +30,12 @@
 {% endif %}
 
 {% if members.platinum %}
-<h3>{% translate "Platinum Corporate Members" %} (${{ corporate_membership_amounts.platinum|intcomma }}+)</h3>
-<p>{% blocktranslate trimmed %}Our platinum <a href="/foundation/corporate-membership/">corporate
-   members</a> include organizations of ~500 people.{% endblocktranslate %}</p>
+<h3>{% blocktranslate trimmed with platinum=corporate_membership_amounts.platinum %}
+  Platinum Corporate Members (${{ platinum|intcomma }}+)
+{% endblocktranslate %}</h3>
+<p>{% blocktranslate trimmed %}
+  Our platinum <a href="/foundation/corporate-membership/">corporate
+  members</a> include organizations of ~500 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.platinum %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -38,9 +44,12 @@
 {% endif %}
 
 {% if members.gold %}
-<h3>{% translate "Gold Corporate Members" %} (${{ corporate_membership_amounts.gold|intcomma }}+)</h3>
-<p>{% blocktranslate trimmed %}Our gold <a href="/foundation/corporate-membership/">corporate
-members</a> include organizations of ~200 people.{% endblocktranslate %}</p>
+<h3>{% blocktranslate trimmed with gold=corporate_membership_amounts.gold %}
+  Gold Corporate Members (${{ gold|intcomma }}+)
+{% endblocktranslate %}</h3>
+<p>{% blocktranslate trimmed %}
+  Our gold <a href="/foundation/corporate-membership/">corporate
+  members</a> include organizations of ~200 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.gold %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -49,9 +58,12 @@ members</a> include organizations of ~200 people.{% endblocktranslate %}</p>
 {% endif %}
 
 {% if members.silver %}
-<h3>{% translate "Silver Corporate Members" %} (${{ corporate_membership_amounts.silver|intcomma }}+)</h3>
-<p>{% blocktranslate trimmed %}Our silver <a href="/foundation/corporate-membership/">corporate
-members</a> include organizations of ~50 people.{% endblocktranslate %}</p>
+<h3>{% blocktranslate trimmed with silver=corporate_membership_amounts.silver %}
+  Silver Corporate Members (${{ silver|intcomma }}+)
+{% endblocktranslate %}</h3>
+<p>{% blocktranslate trimmed %}
+  Our silver <a href="/foundation/corporate-membership/">corporate
+  members</a> include organizations of ~50 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.silver %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -60,9 +72,12 @@ members</a> include organizations of ~50 people.{% endblocktranslate %}</p>
 {% endif %}
 
 {% if members.bronze %}
-<h3>{% translate "Bronze Corporate Members" %} (${{ corporate_membership_amounts.bronze|intcomma }}+)</h3>
-<p>{% blocktranslate trimmed %}Our bronze <a href="/foundation/corporate-membership/">corporate
-members</a> include organizations of ~10 people.{% endblocktranslate %}</p>
+<h3>{% blocktranslate trimmed with bronze=corporate_membership_amounts.bronze %}
+  Bronze Corporate Members (${{ bronze|intcomma }}+)
+{% endblocktranslate %}</h3>
+<p>{% blocktranslate trimmed %}
+  Our bronze <a href="/foundation/corporate-membership/">corporate
+  members</a> include organizations of ~10 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.bronze %}
 {% include "members/includes/_member_with_logo.html" %}

--- a/djangoproject/templates/members/corporatemember_list.html
+++ b/djangoproject/templates/members/corporatemember_list.html
@@ -5,20 +5,20 @@
 {% block og_description %}The following organizations are corporate members of the Django Software Foundation.{% endblock %}
 
 {% block content %}
-  <h1>{% trans "Corporate members" %}</h1>
+  <h1>{% translate "Corporate members" %}</h1>
   <p>
-    {% blocktrans %}
+    {% blocktranslate trimmed %}
       The following organizations are corporate members of the Django Software
       Foundation. If you are interested in becoming a corporate member of the
       DSF, you can find out more on our <a href="/foundation/corporate-membership/">
       corporate membership page</a>.
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
 {% if members.diamond %}
-<h3>Diamond Corporate Members (${{ corporate_membership_amounts.diamond|intcomma }}+)</h3>
-<p>Our diamond <a href="/foundation/corporate-membership/">corporate
-  members</a> include mega corporations and foundations.</p>
+<h3>{% translate "Diamond Corporate Members" %} (${{ corporate_membership_amounts.diamond|intcomma }}+)</h3>
+<p>{% blocktranslate trimmed %}Our diamond <a href="/foundation/corporate-membership/">corporate
+  members</a> include mega corporations and foundations.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.diamond %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -27,9 +27,9 @@
 {% endif %}
 
 {% if members.platinum %}
-<h3>Platinum Corporate Members (${{ corporate_membership_amounts.platinum|intcomma }}+)</h3>
-<p>Our platinum <a href="/foundation/corporate-membership/">corporate
-   members</a> include organizations of ~500 people.</p>
+<h3>{% translate "Platinum Corporate Members" %} (${{ corporate_membership_amounts.platinum|intcomma }}+)</h3>
+<p>{% blocktranslate trimmed %}Our platinum <a href="/foundation/corporate-membership/">corporate
+   members</a> include organizations of ~500 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.platinum %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -38,9 +38,9 @@
 {% endif %}
 
 {% if members.gold %}
-<h3>Gold Corporate Members (${{ corporate_membership_amounts.gold|intcomma }}+)</h3>
-<p>Our gold <a href="/foundation/corporate-membership/">corporate
-members</a> include organizations of ~200 people.</p>
+<h3>{% translate "Gold Corporate Members" %} (${{ corporate_membership_amounts.gold|intcomma }}+)</h3>
+<p>{% blocktranslate trimmed %}Our gold <a href="/foundation/corporate-membership/">corporate
+members</a> include organizations of ~200 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.gold %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -49,9 +49,9 @@ members</a> include organizations of ~200 people.</p>
 {% endif %}
 
 {% if members.silver %}
-<h3>Silver Corporate Members (${{ corporate_membership_amounts.silver|intcomma }}+)</h3>
-<p>Our silver <a href="/foundation/corporate-membership/">corporate
-members</a> include organizations of ~50 people.</p>
+<h3>{% translate "Silver Corporate Members" %} (${{ corporate_membership_amounts.silver|intcomma }}+)</h3>
+<p>{% blocktranslate trimmed %}Our silver <a href="/foundation/corporate-membership/">corporate
+members</a> include organizations of ~50 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.silver %}
 {% include "members/includes/_member_with_logo.html" %}
@@ -60,9 +60,9 @@ members</a> include organizations of ~50 people.</p>
 {% endif %}
 
 {% if members.bronze %}
-<h3>Bronze Corporate Members (${{ corporate_membership_amounts.bronze|intcomma }}+)</h3>
-<p>Our bronze <a href="/foundation/corporate-membership/">corporate
-members</a> include organizations of ~10 people.</p>
+<h3>{% translate "Bronze Corporate Members" %} (${{ corporate_membership_amounts.bronze|intcomma }}+)</h3>
+<p>{% blocktranslate trimmed %}Our bronze <a href="/foundation/corporate-membership/">corporate
+members</a> include organizations of ~10 people.{% endblocktranslate %}</p>
 <ul class="corporate-members">
 {% for obj in members.bronze %}
 {% include "members/includes/_member_with_logo.html" %}

--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -2,14 +2,14 @@
 {% load i18n %}
 
 {% block content %}
-  <h1>{% trans "Individual members" %}</h1>
+  <h1>{% translate "Individual members" %}</h1>
   <p>
-    {% blocktrans %}
+    {% blocktranslate trimmed %}
       The following are Individual Members of the Django Software Foundation. Individual Members
       are appointed by the DSF in recognition of their service to the Django community. If you
       know someone who you think should be considered for Individual Membership, please
-    {% endblocktrans %}
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSd5lbWxAO-sylEEjHVKBNIpmHlhdJRf0_LCo8glnLUWd-Q2Sw/viewform?usp=sf_link">{% trans "fill out this form" %}</a>.
+    {% endblocktranslate %}
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSd5lbWxAO-sylEEjHVKBNIpmHlhdJRf0_LCo8glnLUWd-Q2Sw/viewform?usp=sf_link">{% translate "fill out this form" %}</a>.
   </p>
   <ul>
     {% for member in members %}
@@ -18,8 +18,8 @@
   </ul>
 
   {% if former_members %}
-    <h2>{% trans "Former members" %}</h2>
-    <p>{% trans "The following are former Individual Members of the DSF." %}</p>
+    <h2>{% translate "Former members" %}</h2>
+    <p>{% translate "The following are former Individual Members of the DSF." %}</p>
 
     <ul>
       {% for member in former_members %}

--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -1,12 +1,13 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
 {% block og_title %}Log in{% endblock %}
 {% block og_description %}Log in to your account{% endblock %}
 
 {% block content %}
 
-<h2>Teams</h2>
-<p>Teams indicate who is actively contributing in certain areas.</p>
+<h2>{% translate "Teams" %}</h2>
+<p>{% translate "Teams indicate who is actively contributing in certain areas." %}</p>
 
 {% for team in teams %}
 <div class="section">

--- a/djangoproject/templates/registration/activate.html
+++ b/djangoproject/templates/registration/activate.html
@@ -1,12 +1,14 @@
 {% extends "registration/base.html" %}
+{% load humanize i18n %}
 
-{% block title %}Account activation failed{% endblock %}
+{% block title %}{% translate "Account activation failed" %}{% endblock %}
 
 {% block content %}
-  <h1>Account activation failed.</h1>
-  {% load humanize %}
-  <p>Sorry, it didn't work. Either your activation link was incorrect, or
-  the activation key for your account has expired; activation keys are
-  only valid for {{ expiration_days|apnumber }} days after
-  registration.</p>
+  <h1>{% translate "Account activation failed." %}</h1>
+  
+  <p>{% blocktranslate trimmed with expiry=expiration_days|apnumber %}
+    Sorry, it didn't work. Either your activation link was incorrect, or
+    the activation key for your account has expired; activation keys are
+    only valid for {{ expiry }} days after
+    registration.{% endblocktranslate %}</p>
 {% endblock %}

--- a/djangoproject/templates/registration/activation_complete.html
+++ b/djangoproject/templates/registration/activation_complete.html
@@ -1,8 +1,10 @@
 {% extends "registration/base.html" %}
+{% load i18n %}
 
-{% block title %}Account activated{% endblock %}
+{% block title %}{% translate "Account activated" %}{% endblock %}
 
 {% block content %}
-  <h1>Account activated.</h1>
-  <p>Thanks for signing up! Now you can <a href="{% url 'login' %}">log in</a>.</p>
+  <h1>{% translate "Account activated." %}</h1>
+  {% url 'login' as login_url %}
+  <p>{% blocktranslate %}Thanks for signing up! Now you can <a href="{{ login_url }}">log in</a>.{% endblocktranslate %}</p>
 {% endblock %}

--- a/djangoproject/templates/registration/base.html
+++ b/djangoproject/templates/registration/base.html
@@ -1,3 +1,4 @@
 {% extends "base_2col.html" %}
+{% load i18n %}
 {% block sectionid %}community{% endblock %}
-{% block header %}<h1>Accounts</h1>{% endblock %}
+{% block header %}<h1>{% translate "Accounts" %}</h1>{% endblock %}

--- a/djangoproject/templates/registration/logged_out.html
+++ b/djangoproject/templates/registration/logged_out.html
@@ -1,8 +1,9 @@
 {% extends "registration/base.html" %}
-
-{% block title %}Logged out{% endblock %}
+{% load i18n %}
+{% block title %}{% translate "Logged out" %}{% endblock %}
 
 {% block content %}
-<h1>You've been logged out.</h1>
-<p>Thanks for stopping by; when you come back, don't forget to <a href="{% url 'login' %}">log in</a> again.</p>
+<h1>{% translate "You've been logged out." %}</h1>
+{% url 'login' as login_url %}
+<p>{% blocktranslate %}Thanks for stopping by; when you come back, don't forget to <a href="{{ login_url }}">log in</a> again.{% endblocktranslate %}</p>
 {% endblock %}

--- a/djangoproject/templates/registration/login.html
+++ b/djangoproject/templates/registration/login.html
@@ -1,14 +1,15 @@
 {% extends "registration/base.html" %}
+{% load i18n %}
 
-{% block title %}Log in{% endblock %}
+{% block title %}{% translate "Log in" %}{% endblock %}
 {% block og_title %}Log in{% endblock %}
 {% block og_description %}Log in to your account{% endblock %}
 
 {% block content %}
-    <h1>Log in</h1>
+    <h1>{% translate "Log in" %}</h1>
 
     {% if form.errors %}
-        <p class="error">Please correct the errors below:</p>
+        <p class="error">{% translate "Please correct the errors below:" %}</p>
         {{ form.non_field_errors }}
     {% endif %}
 
@@ -31,18 +32,19 @@
             {{ form.password }}
         </div>
         <p>
-            <input type="submit" value="Log in" class="cta"/>
+            <input type="submit" value="{% translate "Log in" %}" class="cta"/>
         </p>
     </form>
 {% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">Help</h1>
+    <h1 class="visuallyhidden">{% translate "Help" %}</h1>
     <div role="complementary">
-        <p>If you don't have an account, you can
-            <a href="{% url 'registration_register' %}">sign up</a> for one.</p>
-
-        <p>If you forgot your password, you can
-            <a href="{% url 'auth_password_reset' %}">reset it</a>.</p>
+        {% url 'registration_register' as registration_url %}
+        <p>{% blocktranslate trimmed %}If you don't have an account, you can
+            <a href="{{ registration_url }}">sign up</a> for one.{% endblocktranslate %}</p>
+        {% url 'auth_password_reset' as reset_url %}
+        <p>{% blocktranslate trimmed %}If you forgot your password, you can
+            <a href="{{ reset_url }}">reset it</a>.{% endblocktranslate %}</p>
     </div>
 {% endblock %}

--- a/djangoproject/templates/registration/password_reset_email.html
+++ b/djangoproject/templates/registration/password_reset_email.html
@@ -1,15 +1,15 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}You're receiving this e-mail because you requested a password reset
-for your user account at {{ site_name }}{% endblocktrans %}.
+{% blocktranslate %}You're receiving this e-mail because you requested a password reset
+for your user account at {{ site_name }}{% endblocktranslate %}.
 
-{% trans "Please go to the following page and choose a new password:" %}
+{% translate "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
 {% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
-{% trans "Your username, in case you've forgotten:" %} {{ user.username }}
+{% translate "Your username, in case you've forgotten:" %} {{ user.username }}
 
-{% trans "Thanks for using our site!" %}
+{% translate "Thanks for using our site!" %}
 
-{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+{% blocktranslate %}The {{ site_name }} team{% endblocktranslate %}
 
 {% endautoescape %}

--- a/djangoproject/templates/registration/registration_complete.html
+++ b/djangoproject/templates/registration/registration_complete.html
@@ -1,9 +1,9 @@
 {% extends "registration/base.html" %}
+{% load i18n %}
 
-{% block title %}Registration complete{% endblock %}
+{% block title %}{% translate "Registration complete" %}{% endblock %}
 
 {% block content %}
-    <h1>Check your email</h1>
-    <p>An activation link has been sent to the email address you supplied, along with instructions
-        for activating your account.</p>
+    <h1>{% translate "Check your email" %}</h1>
+    <p>{% translate "An activation link has been sent to the email address you supplied, along with instructions for activating your account." %}</p>
 {% endblock %}

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -1,68 +1,69 @@
 {% extends "registration/base.html" %}
+{% load i18n %}
 
-{% block title %}Sign up{% endblock %}
+{% block title %}{% translate "Sign up" %}{% endblock %}
 
 {% block content %}
-  <h1>Create an account</h1>
+  <h1>Create an account" %}</h1>
 
   <p>Or, <a href="https://code.djangoproject.com/github/login">login with GitHub</a>.</p>
 
   {% if form.errors %}
-    <p class="errors">Please correct the errors below: {{ form.non_field_errors }}</p>
+    <p class="errors">Please correct the errors below:" %} {{ form.non_field_errors }}</p>
   {% endif %}
 
 
   <form method="post" action="" class="form-input">
     {% csrf_token %}
     <div>
-      <label for="id_username">Username:</label>
+      <label for="id_username">{% translate "Username:" %}</label>
       {% if form.username.errors %}
         <p class="errors">{{ form.username.errors.as_text }}</p>
       {% endif %}
       {{ form.username }}
     </div>
     <div>
-      <label for="id_email">Email address:</label>
+      <label for="id_email">{% translate "Email address:" %}</label>
       {% if form.email.errors %}
         <p class="errors">{{ form.email.errors.as_text }}</p>
       {% endif %}
       {{ form.email }}
     </div>
     <div>
-      <label for="id_password1">Password:</label>
+      <label for="id_password1">{% translate "Password:" %}</label>
       {% if form.password1.errors %}
         <p class="errors">{{ form.password1.errors.as_text }}</p>
       {% endif %}
       {{ form.password1 }}
     </div>
     <div>
-      <label for="id_password2">Password (type again to catch typos):</label>
+      <label for="id_password2">{% translate "Password (type again to catch typos):" %}</label>
       {% if form.password2.errors %}
         <p class="errors">{{ form.password2.errors.as_text }}</p>
       {% endif %}
       {{ form.password2 }}
     </div>
     <p class="submit">
-        <input type="submit" class="cta" value="Register">
+        <input type="submit" class="cta" value="{% translate "Register" %}">
     </p>
   </form>
 
 {% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">Help</h1>
+    <h1 class="visuallyhidden">{% translate "Help" %}</h1>
     <div role="complementary">
-        <p>Fill out the form to the right (all fields are required), and your
+        <p>{% blocktranslate trimmed %}Fill out the form to the right (all fields are required), and your
             account will be created; you'll be sent an email with instructions on how
-            to finish your registration.</p>
+            to finish your registration.{% endblocktranslate %}</p>
 
-        <p>We'll only use your email to send you signup instructions. We hate spam
-            as much as you do.</p>
+        <p>{% blocktranslate trimmed %}We'll only use your email to send you signup instructions. We hate spam
+            as much as you do.{% endblocktranslate %}</p>
 
-        <p>This account will let you log into the ticket tracker, claim tickets,
-            and be exempt from spam filtering.</p>
+        <p>{% blocktranslate trimmed %}This account will let you log into the ticket tracker, claim tickets,
+            and be exempt from spam filtering.{% endblocktranslate %}</p>
 
-        <p>Your username can only consist of alphanumeric characters and
-            underscores and may be up to 30 characters long.</p>
+        <p>{% blocktranslate trimmed %}Your username can only consist of alphanumeric characters and
+            underscores and may be up to 30 characters long.{% endblocktranslate %}</p>
     </div>
 {% endblock %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% load fundraising_extras release_notes static %}
+{% load fundraising_extras i18n release_notes static %}
 
 {% block sectionid %}download{% endblock %}
-{% block title %}Download Django{% endblock %}
+{% block title %}{% translate "Download Django" %}{% endblock %}
 {% block layout_class %}sidebar-right{% endblock %}
 
 {% block og_title %}Download Django{% endblock %}
@@ -13,294 +13,315 @@
 {% block og_image_height %}480{% endblock %}
 
 {% block header %}
-  <h1>Download</h1>
+  <h1>{% translate "Download" %}</h1>
 {% endblock %}
 
 {% block content %}
-  <h1>How to get Django</h1>
-  <p>Django is available open-source under the
+  <h1>{% translate "How to get Django" %}</h1>
+  <p>
+  {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' as install_url_dev %}
+  {% blocktranslate trimmed %}
+    Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
     We recommend using the latest version of Python 3. The last version to
-    support Python 2.7 is Django 1.11 LTS. See <a href="
-    {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' %}#what-python-version-can-i-use-with-django">
+    support Python 2.7 is Django 1.11 LTS. See <a href="{{ install_url_dev }}#what-python-version-can-i-use-with-django">
     the FAQ</a> for the Python versions supported by each version of Django.
-    Here’s how to get it:</p>
+    Here’s how to get it:{% endblocktranslate %}
+  </p>
 
-  <h2>Option {% cycle '1' '2' '3' as options %}: Get the latest official version</h2>
-  <p>The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}. Read the
-    {% release_notes current.version show_version=True %}, then install it with
-    <a href="https://pip.pypa.io/en/latest/">pip</a>:</p>
+  {% release_notes current.version show_version=True as release_notes %}
+  <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
+  
+  {% if current.is_lts %}
+    <p>{% blocktranslate trimmed with version=current.version %}
+      The latest official version is {{ version }} (LTS). Read the
+      {{ release_notes }}, then install it with{% endblocktranslate %}
+      
+  {% else %}
+    <p>{% blocktranslate trimmed with version=current.version %}
+      The latest official version is {{ version }}. Read the
+      {{ release_notes }}, then install it with{% endblocktranslate %}
+  {% endif %}
+  <a href="https://pip.pypa.io/en/latest/">pip</a>:</p>
   <pre class="literal-block"><code>pip install Django=={{ current.version }}</code></pre>
 
   {% if preview %}
+      {% release_notes preview.version show_version=True as release_notes_preview %}
       {% with preview.version|slice:":3" as major_version %}
-      <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
-      <p>As part of the
-        <a href="https://code.djangoproject.com/wiki/Version{{ major_version }}Roadmap">
-        Django {{ major_version }} development process</a>, Django
+      <h2>{% translate "Option" %} {% cycle options %}: {% blocktranslate trimmed with status=preview.get_status_display major=major_version %}
+        Get the {{ status }} for {{ major }}{% endblocktranslate %}</h2>
+      <p>{% blocktranslate trimmed with status=preview.get_status_display major=major_version %}
+        As part of the
+        <a href="https://code.djangoproject.com/wiki/Version{{ major }}Roadmap">
+        Django {{ major }} development process</a>, Django
         {{ preview.version }} is available. This release is only for users who
         want to try the new version and help identify remaining bugs before the
-        {{ major_version }} release. Please read the
-        {% release_notes preview.version show_version=True %} before using this package.
-      <p>Install the {{ preview.get_status_display }} with <a href="https://pip.pypa.io/">pip</a>:</p>
+        {{ major }} release. Please read the
+        {{ release_notes_preview }} before using this package.
+      <p>Install the {{ status }} with{% endblocktranslate %} <a href="https://pip.pypa.io/">pip</a>:</p>
       <pre class="literal-block"><code>pip install --pre django</code></pre>
       {% endwith %}
   {% endif %}
 
-  <h2>Option {% cycle options %}: Get the latest development version</h2>
-  <p>The latest and greatest Django version is the one that’s in our Git repository (our revision-control system). This is only for experienced users who want to try incoming changes and help identify bugs before an official release. Get it using this shell command, which requires <a href="https://git-scm.com/">Git</a>:</p>
+  <h2>{% translate "Option" %} {% cycle options %}: {% translate "Get the latest development version" %}</h2>
+  <p>{% translate 'The latest and greatest Django version is the one that’s in our Git repository (our revision-control system). This is only for experienced users who want to try incoming changes and help identify bugs before an official release. Get it using this shell command, which requires <a href="https://git-scm.com/">Git</a>:' %}</p>
   <p class="literal-block"><code>git clone https://github.com/django/django.git</code></p>
-  <p>You can also download <a href="https://github.com/django/django/archive/main.tar.gz">
+  <p>{% blocktranslate trimmed %}You can also download <a href="https://github.com/django/django/archive/main.tar.gz">
     a gzipped tarball</a> of the development version. This archive is updated
-    every time we commit code.</p>
+    every time we commit code.{% endblocktranslate %}</p>
 
-  <h2>After you get it</h2>
-  <p>See the <a href="{% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' %}">installation guide</a> for further instructions. Make sure you read the documentation that corresponds to the version of Django you’ve just installed.</p>
-  <p>And be sure to sign up for the <a href="https://groups.google.com/group/django-users">django-users mailing list</a>, where other Django users and the Django developers themselves all hang out to help each other.</p>
+  <h2>{% translate "After you get it" %}</h2>
+  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as install_url_stable %}
+  <p>{% blocktranslate trimmed %}
+    See the <a href="{{ install_url_stable }}">installation guide</a> for further instructions. Make sure you read the documentation that corresponds to the version of Django you’ve just installed.
+  {% endblocktranslate %}</p>
+  <p>{% blocktranslate trimmed %}
+    And be sure to sign up for the <a href="https://groups.google.com/group/django-users">django-users mailing list</a>, where other Django users and the Django developers themselves all hang out to help each other.
+  {% endblocktranslate %}</p>
 
-  <h2 id="supported-versions">Supported Versions</h2>
-  <p><strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
-    These releases will contain new features, improvements to existing features, and such.</p>
-  <p><strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
+  <h2 id="supported-versions">{% translate "Supported Versions" %}</h2>
+  <p>{% blocktranslate trimmed %}<strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
+    These releases will contain new features, improvements to existing features, and such.{% endblocktranslate %}</p>
+  <p>{% blocktranslate trimmed %}<strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
     fix bugs and/or security issues. These releases will be 100% compatible with
     the associated feature release, unless this is impossible for security
     reasons or to prevent data loss. So the answer to "should I upgrade to the
-    latest patch release?” will always be "yes."</p>
-  <p>Certain feature releases will be designated as <strong>long-term support
+    latest patch release?” will always be "yes."{% endblocktranslate %}</p>
+  <p>{% blocktranslate trimmed %}Certain feature releases will be designated as <strong>long-term support
     (LTS) releases</strong>. These releases will get security and data loss
-    fixes applied for a guaranteed period of time, typically three years.</p>
-  <p>See the <a href="https://docs.djangoproject.com/en/dev/internals/release-process/#supported-versions">
-    supported versions policy</a> for detailed guidelines about what fixes will be backported.</p>
+    fixes applied for a guaranteed period of time, typically three years.{% endblocktranslate %}</p>
+  <p>{% blocktranslate trimmed %}See the <a href="https://docs.djangoproject.com/en/dev/internals/release-process/#supported-versions">
+    supported versions policy</a> for detailed guidelines about what fixes will be backported.{% endblocktranslate %}</p>
 
-  <img src="{% static "img/release-roadmap.png" %}" class='img-release' style="max-width:100%;" alt="Django release roadmap">
+  <img src="{% static "img/release-roadmap.png" %}" class='img-release' style="max-width:100%;" alt="{% translate "Django release roadmap" %}">
   <hr style="margin-bottom: 20px;">
 
   <table class='django-supported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Latest Release</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Latest Release" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>4.1</td>
       <td>{% get_latest_micro_release '4.1' %}</td>
-      <td>April 2023</td>
-      <td>December 2023</td>
+      <td>{% translate "April 2023" %}</td>
+      <td>{% translate "December 2023" %}</td>
     </tr>
     <tr>
       <td>4.0</td>
       <td>{% get_latest_micro_release '4.0' %}</td>
-      <td>August 3, 2022</td>
-      <td>April 2023</td>
+      <td>{% translate "August 3, 2022" %}</td>
+      <td>{% translate "April 2023" %}</td>
     </tr>
     <tr>
       <td>3.2 LTS</td>
       <td>{% get_latest_micro_release '3.2' %}</td>
-      <td>December 7, 2021</td>
-      <td>April 2024</td>
+      <td>{% translate "December 7, 2021" %}</td>
+      <td>{% translate "April 2024" %}</td>
     </tr>
   </table>
 
-  <h2 id="future-versions">Future Roadmap</h2>
+  <h2 id="future-versions">{% translate "Future Roadmap" %}</h2>
 
   <table class='django-supported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Release Date</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Release Date" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>5.2 LTS</td>
-      <td>April 2025</td>
-      <td>December 2025</td>
-      <td>April 2028</td>
+      <td>April 2025" %}</td>
+      <td>December 2025" %}</td>
+      <td>April 2028" %}</td>
     </tr>
     <tr>
       <td>5.1</td>
-      <td>August 2024</td>
-      <td>April 2025</td>
-      <td>December 2025</td>
+      <td>August 2024" %}</td>
+      <td>April 2025" %}</td>
+      <td>December 2025" %}</td>
     </tr>
     <tr>
       <td>5.0</td>
-      <td>December 2023</td>
-      <td>August 2024</td>
-      <td>April 2025</td>
+      <td>December 2023" %}</td>
+      <td>August 2024" %}</td>
+      <td>April 2025" %}</td>
     </tr>
     <tr>
       <td>4.2 LTS</td>
-      <td>April 2023</td>
-      <td>December 2023</td>
-      <td>April 2026</td>
+      <td>April 2023" %}</td>
+      <td>December 2023" %}</td>
+      <td>April 2026" %}</td>
     </tr>
   </table>
 
-  <h2 id="unsupported-versions">Unsupported previous releases</h2>
-  <p>These release series no longer receive security updates or bug fixes.</p>
+  <h2 id="unsupported-versions">Unsupported previous releases" %}</h2>
+  <p>These release series no longer receive security updates or bug fixes." %}</p>
 
   <table class='django-unsupported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Latest Release</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>Release Series" %}</th>
+      <th>Latest Release" %}</th>
+      <th>End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>3.1</td>
       <td>{% get_latest_micro_release '3.1' %}</td>
-      <td>April 6, 2021</td>
-      <td>December 7, 2021</td>
+      <td>April 6, 2021" %}</td>
+      <td>December 7, 2021" %}</td>
     </tr>
     <tr>
       <td>3.0</td>
       <td>{% get_latest_micro_release '3.0' %}</td>
-      <td>August 3, 2020</td>
-      <td>April 6, 2021</td>
+      <td>August 3, 2020" %}</td>
+      <td>April 6, 2021" %}</td>
     </tr>
     <tr>
       <td>2.2 LTS</td>
       <td>{% get_latest_micro_release '2.2' %}</td>
-      <td>December 2, 2019</td>
-      <td>April 11, 2022</td>
+      <td>December 2, 2019" %}</td>
+      <td>April 11, 2022" %}</td>
     </tr>
     <tr>
       <td>2.1</td>
       <td>{% get_latest_micro_release '2.1' %}</td>
-      <td>April 1, 2019</td>
-      <td>December 2, 2019</td>
+      <td>April 1, 2019" %}</td>
+      <td>December 2, 2019" %}</td>
     </tr>
     <tr>
       <td>2.0</td>
       <td>{% get_latest_micro_release '2.0' %}</td>
-      <td>August 1, 2018</td>
-      <td>April 1, 2019</td>
+      <td>August 1, 2018" %}</td>
+      <td>April 1, 2019" %}</td>
     </tr>
     <tr>
       <td>1.11 LTS <sup><a href="#ft3">3</a></sup></td>
       <td>{% get_latest_micro_release '1.11' %}</td>
-      <td>December 2, 2017</td>
-      <td>April 1, 2020</td>
+      <td>December 2, 2017" %}</td>
+      <td>April 1, 2020" %}</td>
     </tr>
     <tr>
       <td>1.10</td>
       <td>{% get_latest_micro_release '1.10' %}</td>
-      <td>April 4, 2017</td>
-      <td>December 2, 2017</td>
+      <td>April 4, 2017" %}</td>
+      <td>December 2, 2017" %}</td>
     </tr>
     <tr>
       <td>1.9</td>
       <td>{% get_latest_micro_release '1.9' %}</td>
-      <td>August 1, 2016</td>
-      <td>April 4, 2017</td>
+      <td>August 1, 2016" %}</td>
+      <td>April 4, 2017" %}</td>
     </tr>
     <tr>
       <td>1.8 LTS</td>
       <td>{% get_latest_micro_release '1.8' %}</td>
-      <td>December 1, 2015</td>
-      <td>April 1, 2018</td>
+      <td>December 1, 2015" %}</td>
+      <td>April 1, 2018" %}</td>
     </tr>
     <tr>
       <td>1.7</td>
       <td>{% get_latest_micro_release '1.7' %}</td>
-      <td>April 1, 2015</td>
-      <td>December 1, 2015</td>
+      <td>April 1, 2015" %}</td>
+      <td>December 1, 2015" %}</td>
     </tr>
     <tr>
       <td>1.6</td>
       <td>{% get_latest_micro_release '1.6' %}</td>
-      <td>September 2, 2014</td>
-      <td>April 1, 2015</td>
+      <td>September 2, 2014" %}</td>
+      <td>April 1, 2015" %}</td>
     </tr>
     <tr>
       <td>1.5</td>
       <td>{% get_latest_micro_release '1.5' %}</td>
-      <td>November 6, 2013</td>
-      <td>September 2, 2014</td>
+      <td>November 6, 2013" %}</td>
+      <td>September 2, 2014" %}</td>
     </tr>
     <tr>
       <td>1.4 LTS</td>
       <td>{% get_latest_micro_release '1.4' %}</td>
-      <td>February 26, 2013</td>
-      <td>October 1, 2015</td>
+      <td>February 26, 2013" %}</td>
+      <td>October 1, 2015" %}</td>
     </tr>
     <tr>
       <td>1.3</td>
       <td>{% get_latest_micro_release '1.3' %}</td>
-      <td>March 23, 2012</td>
-      <td>February 26, 2013</td>
+      <td>March 23, 2012" %}</td>
+      <td>February 26, 2013" %}</td>
     </tr>
   </table>
 
   <p style="max-width: 720px;">
-    <sup id="ft1">[1] Security fixes, data loss bugs, crashing bugs, major functionality
-    bugs in newly-introduced features, and regressions from older versions of Django.</sup><br>
-    <sup id="ft2">[2] Security fixes and data loss bugs.</sup><br>
-    <sup id="ft3">[3] Last version to support Python 2.7.</sup>
+    <sup id="ft1">[1] {% blocktranslate trimmed %}Security fixes, data loss bugs, crashing bugs, major functionality
+    bugs in newly-introduced features, and regressions from older versions of Django.{% endblocktranslate %}</sup><br>
+    <sup id="ft2">[2] {% translate "Security fixes and data loss bugs." %}</sup><br>
+    <sup id="ft3">[3] {% translate "Last version to support Python 2.7." %}</sup>
   </p>
 
 {% endblock %}
 
 {% block content-related %}
 
-<h1 class="visuallyhidden">Additional information</h1>
+<h1 class="visuallyhidden">{% translate "Additional information" %}</h1>
 <div role="complementary">
 
     {% donation_snippet %}
 
-    <h2>For the impatient:</h2>
+    <h2>{% translate "For the impatient:" %}</h2>
     <ul>
-      <li>Latest release:
+      <li>{% translate "Latest release:" %}
         <a href="{% url 'download-redirect' current.version 'tarball' %}">
           Django-{{ current.version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' current.version 'checksum' %}">
+        {% translate "Checksums:" %} <a href="{% url 'download-redirect' current.version 'checksum' %}">
           Django-{{ current.version }}.checksum.txt</a><br>
-        Release notes: {% release_notes current.version %}
+        {% translate "Release notes:" %} {% release_notes current.version %}
       </li>
 
       {% if preview %}
-      <li>Preview release:
+      <li>{% translate "Preview release:" %}
         <a href="{% url 'download-redirect' preview.version 'tarball' %}">
           Django-{{ preview.version }}.tar.gz</a><br>
-          Checksums: <a href="{% url 'download-redirect' preview.version 'checksum' %}">
+          {% translate "Checksums:" %} <a href="{% url 'download-redirect' preview.version 'checksum' %}">
             Django-{{ preview.version }}.checksum.txt</a><br>
-          Release notes: {% release_notes preview.version %}
+          {% translate "Release notes:" %} {% release_notes preview.version %}
       </li>
       {% endif %}
     </ul>
 
-    <h2>Which version is better?</h2>
-    <p>We improve Django almost every day and are pretty good about keeping the code stable. Thus, using the latest development code is a safe and easy way to get access to new features as they’re added. If you choose to follow the development version, keep in mind that there will occasionally be backwards-incompatible changes. You’ll want to pay close attention to the commits by watching <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to <a href="https://groups.google.com/group/django-updates">django-updates</a>.</p>
+    <h2>{% translate "Which version is better?" %}</h2>
+    <p>{% translate 'We improve Django almost every day and are pretty good about keeping the code stable. Thus, using the latest development code is a safe and easy way to get access to new features as they’re added. If you choose to follow the development version, keep in mind that there will occasionally be backwards-incompatible changes. You’ll want to pay close attention to the commits by watching <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to <a href="https://groups.google.com/group/django-updates">django-updates</a>.' %}</p>
 
-    <p>If you’re just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading).</p>
-    <h2>Previous releases</h2>
+    <p>{% translate "If you’re just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading)." %}</p>
+    <h2>{% translate "Previous releases" %}</h2>
     <ul>
       <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
         <a href="{% url 'download-redirect' previous.version 'tarball' %}">
           Django-{{ previous.version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' previous.version 'checksum' %}">
+        {% translate "Checksums:" %} <a href="{% url 'download-redirect' previous.version 'checksum' %}">
           Django-{{ previous.version }}.checksum.txt</a><br>
-        Release notes: {% release_notes previous.version %}
+        {% translate "Release notes:" %} {% release_notes previous.version %}
       </li>
       {% if lts %}
         <li>Django {{ lts.version }} (LTS):
           <a href="{% url 'download-redirect' lts.version 'tarball' %}">
             Django-{{ lts.version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' lts.version 'checksum' %}">
+        {% translate "Checksums:" %} <a href="{% url 'download-redirect' lts.version 'checksum' %}">
           Django-{{ lts.version }}.checksum.txt</a><br>
-          Release notes: {% release_notes lts.version %}
+          {% translate "Release notes:" %} {% release_notes lts.version %}
         </li>
       {% endif %}
     </ul>
 
-    <h2>Unsupported previous releases (no longer receive security updates or bug fixes)</h2>
+    <h2>{% translate "Unsupported previous releases (no longer receive security updates or bug fixes)" %}</h2>
     <ul>
       {% for release in unsupported %}
       <li>Django {{ release.version }}:
         <a href="{% url 'download-redirect' release.version 'tarball' %}">
           Django-{{ release.version }}.tar.gz</a><br>
-        Checksums: <a href="{% url 'download-redirect' release.version 'checksum' %}">
+        {% translate "Checksums:" %} <a href="{% url 'download-redirect' release.version 'checksum' %}">
           Django-{{ release.version }}.checksum.txt</a></li>
       {% endfor %}
     </ul>

--- a/djangoproject/templates/tracdb/bouncing_tickets.html
+++ b/djangoproject/templates/tracdb/bouncing_tickets.html
@@ -1,21 +1,22 @@
 {% extends "base_community.html" %}
+{% load i18n %}
 
 {% block content-related %}{% endblock %}
 
-{% block title %}Bouncing Tickets{% endblock %}
+{% block title %}{% translate "Bouncing Tickets" %}{% endblock %}
 
 {% block content %}
 
-<h1>Bouncing Tickets</h1>
+<h1>{% translate "Bouncing Tickets" %}</h1>
 
-<h2 class="deck">Tickets that have been repeatedly reopened.</h2>
+<h2 class="deck">{% translate "Tickets that have been repeatedly reopened." %}</h2>
 
 <table width="90%" class="docutils">
   <thead>
     <tr>
-      <th>Ticket</th>
-      <th>Times reopened</th>
-      <th>Last reopened</th>
+      <th>{% translate "Ticket" %}</th>
+      <th>{% translate "Times reopened" %}</th>
+      <th>{% translate "Last reopened" %}</th>
     </tr>
   </thead>
   <tbody>

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -99,7 +99,6 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
             resp = self.client.get('/en/', HTTP_HOST=self.www_host)
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn('Content-Language', resp)
-        self.assertIn('Vary', resp)
 
     def test_www_host_with_port(self):
         "www (with a port) should still use LocaleMiddleware"
@@ -107,7 +106,6 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
             resp = self.client.get('/en/', HTTP_HOST='%s:8000' % self.www_host)
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn('Content-Language', resp)
-        self.assertIn('Vary', resp)
 
 
 class TestChangeLanguage(TestCase):

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -83,11 +83,12 @@ urlpatterns = i18n_patterns(
 
     path('sitemap.xml', cache_page(60 * 60 * 6)(sitemap_views.sitemap), {'sitemaps': sitemaps}),
     path('weblog/', include('blog.urls')),
-    path('download/', include('releases.urls')),
+    path('download/', include('releases.urls.i18n_paths')),
     path('svntogit/', include('svntogit.urls')),
 )
 
 urlpatterns += [
+    path('download/', include('releases.urls.download')),
     path('', include('legacy.urls'))  # Exclude from i18n patterns
 ]
 

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.contenttypes import views as contenttypes_views
@@ -16,6 +17,7 @@ from aggregator.feeds import (
 from blog.feeds import WeblogEntryFeed
 from blog.sitemaps import WeblogSitemap
 from foundation.views import CoreDevelopers
+from djangoproject import views as project_views
 
 admin.autodiscover()
 
@@ -25,8 +27,9 @@ sitemaps = {
 }
 
 
-urlpatterns = [
+urlpatterns = i18n_patterns(
     path('', TemplateView.as_view(template_name='homepage.html'), name="homepage"),
+    path('change-language/<str:lang_code>/', project_views.change_language, name="change_language"),
     path('start/overview/', TemplateView.as_view(template_name='overview.html'), name="overview"),
     path('start/', TemplateView.as_view(template_name='start.html'), name="start"),
     # to work around a permanent redirect stored in the db that existed before the redesign:
@@ -83,7 +86,7 @@ urlpatterns = [
     path('download/', include('releases.urls')),
     path('svntogit/', include('svntogit.urls')),
     path('', include('legacy.urls')),
-]
+)
 
 if settings.DEBUG:
     urlpatterns += [

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -16,8 +16,8 @@ from aggregator.feeds import (
 )
 from blog.feeds import WeblogEntryFeed
 from blog.sitemaps import WeblogSitemap
-from foundation.views import CoreDevelopers
 from djangoproject import views as project_views
+from foundation.views import CoreDevelopers
 
 admin.autodiscover()
 

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -85,8 +85,11 @@ urlpatterns = i18n_patterns(
     path('weblog/', include('blog.urls')),
     path('download/', include('releases.urls')),
     path('svntogit/', include('svntogit.urls')),
-    path('', include('legacy.urls')),
 )
+
+urlpatterns += [
+    path('', include('legacy.urls'))  # Exclude from i18n patterns
+]
 
 if settings.DEBUG:
     urlpatterns += [

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -8,6 +8,7 @@ from django.contrib.sitemaps import views as sitemap_views
 from django.urls import include, path, re_path
 from django.views.decorators.cache import cache_page
 from django.views.generic import RedirectView, TemplateView
+from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
 
 from accounts import views as account_views
@@ -29,6 +30,7 @@ sitemaps = {
 
 urlpatterns = i18n_patterns(
     path('', TemplateView.as_view(template_name='homepage.html'), name="homepage"),
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     path('change-language/<str:lang_code>/', project_views.change_language, name="change_language"),
     path('start/overview/', TemplateView.as_view(template_name='overview.html'), name="overview"),
     path('start/', TemplateView.as_view(template_name='start.html'), name="start"),

--- a/djangoproject/views.py
+++ b/djangoproject/views.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from django.urls import translate_url
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.translation import check_for_language
+
+
+def change_language(request, lang_code):
+    """
+    Allow changing of language via GET request so that the docs
+    language selector can be reused.
+    Most of this code is taken from django's own `set_language` and the next
+    url gets checked if it's an allowed host.
+    """
+    next_url = request.META.get('HTTP_REFERER')
+    if not url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_url = '/'
+
+    response = HttpResponseRedirect(next_url)
+
+    if lang_code and check_for_language(lang_code):
+        if next_url:
+            next_trans = translate_url(next_url, lang_code)
+            if next_trans != next_url:
+                response = HttpResponseRedirect(next_trans)
+
+        response.set_cookie(
+            settings.LANGUAGE_COOKIE_NAME, lang_code,
+            max_age=settings.LANGUAGE_COOKIE_AGE,
+            path=settings.LANGUAGE_COOKIE_PATH,
+            domain=settings.LANGUAGE_COOKIE_DOMAIN,
+            secure=settings.LANGUAGE_COOKIE_SECURE,
+            httponly=settings.LANGUAGE_COOKIE_HTTPONLY,
+            samesite=settings.LANGUAGE_COOKIE_SAMESITE,
+        )
+
+    return response

--- a/djangoproject/views.py
+++ b/djangoproject/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import translate_url
 from django.utils.http import url_has_allowed_host_and_scheme
-from django.utils.translation import check_for_language
+from django.utils.translation import activate, check_for_language
 
 
 def change_language(request, lang_code):
@@ -28,6 +28,7 @@ def change_language(request, lang_code):
             if next_trans != next_url:
                 response = HttpResponseRedirect(next_trans)
 
+        activate(lang_code)
         response.set_cookie(
             settings.LANGUAGE_COOKIE_NAME, lang_code,
             max_age=settings.LANGUAGE_COOKIE_AGE,

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -161,7 +161,7 @@ class RedirectsTests(TestCase):
 
     def test_team_url(self):
         # This URL is linked from the docs.
-        self.assertEqual('/foundation/teams/', reverse('members:teams', urlconf=www_urls))
+        self.assertEqual('/en/foundation/teams/', reverse('members:teams', urlconf=www_urls))
 
     def test_internals_team(self):
         response = self.client.get(

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -3,6 +3,7 @@ from captcha.fields import ReCaptchaField
 from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 
 from .models import (
     INTERVAL_CHOICES, LEADERSHIP_LEVEL_AMOUNT, DjangoHero, Donation,
@@ -13,7 +14,7 @@ class DjangoHeroForm(forms.ModelForm):
     hero_type = forms.ChoiceField(
         required=False,
         widget=forms.RadioSelect,
-        label='I am donating as an',
+        label=_("I am donating as an"),
         choices=DjangoHero.HERO_TYPE_CHOICES,
         initial=DjangoHero.HERO_TYPE_CHOICES[0][0],
     )
@@ -22,7 +23,7 @@ class DjangoHeroForm(forms.ModelForm):
         widget=forms.TextInput(
             attrs={
                 'class': 'required',
-                'placeholder': 'Your name or the name of your organization',
+                'placeholder': _("Your name or the name of your organization"),
             },
         )
     )
@@ -30,7 +31,7 @@ class DjangoHeroForm(forms.ModelForm):
         required=False,
         widget=forms.TextInput(
             attrs={
-                'placeholder': 'Where are you located? (optional; will not be displayed)',
+                'placeholder': _("Where are you located? (optional; will not be displayed)"),
             },
         )
     )
@@ -38,27 +39,27 @@ class DjangoHeroForm(forms.ModelForm):
         required=False,
         widget=forms.TextInput(
             attrs={
-                'placeholder': 'Which URL should we link your name to?',
+                'placeholder': _("Which URL should we link your name to?"),
             },
         )
     )
     logo = forms.FileField(
         required=False,
-        help_text=(
+        help_text=_(
             "If you've donated at least US $%d, you can submit your logo and "
             "we will display it, too." % LEADERSHIP_LEVEL_AMOUNT
         ),
     )
     is_visible = forms.BooleanField(
         required=False,
-        label=(
+        label=_(
             "Yes, display my name, URL, and logo on this site. "
             "It'll be displayed shortly after we verify it."
         ),
     )
     is_subscribed = forms.BooleanField(
         required=False,
-        label=(
+        label=_(
             'Yes, the Django Software Foundation can inform me about '
             'future fundraising campaigns by email.'
         ),
@@ -122,7 +123,7 @@ class DonateForm(forms.Form):
         (1000, 'US $1,000'),
         (1250, 'US $1,250'),
         (2500, 'US $2,500'),
-        ('custom', 'Other amount'),
+        ('custom', _('Other amount')),
     )
 
     amount = forms.ChoiceField(choices=AMOUNT_CHOICES)

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -5,8 +5,8 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import crypto, timezone
-from django_hosts.resolvers import reverse
 from django.utils.translation import gettext_lazy as _
+from django_hosts.resolvers import reverse
 from sorl.thumbnail import ImageField, get_thumbnail
 
 GOAL_AMOUNT = Decimal("200000.00")

--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -6,6 +6,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import crypto, timezone
 from django_hosts.resolvers import reverse
+from django.utils.translation import gettext_lazy as _
 from sorl.thumbnail import ImageField, get_thumbnail
 
 GOAL_AMOUNT = Decimal("200000.00")
@@ -14,10 +15,10 @@ DISPLAY_DONOR_DAYS = 365
 DEFAULT_DONATION_AMOUNT = 50
 LEADERSHIP_LEVEL_AMOUNT = Decimal("1000.00")
 INTERVAL_CHOICES = (
-    ('monthly', 'Monthly donation'),
-    ('quarterly', 'Quarterly donation'),
-    ('yearly', 'Yearly donation'),
-    ('onetime', 'One-time donation'),
+    ('monthly', _('Monthly donation')),
+    ('quarterly', _('Quarterly donation')),
+    ('yearly', _('Yearly donation')),
+    ('onetime', _('One-time donation')),
 )
 
 
@@ -65,15 +66,15 @@ class DjangoHero(FundraisingModel):
     hero_type = models.CharField(max_length=30, choices=HERO_TYPE_CHOICES, blank=True)
     is_visible = models.BooleanField(
         default=False,
-        verbose_name="Agreed to displaying on the fundraising page?",
+        verbose_name=_("Agreed to displaying on the fundraising page?"),
     )
     is_subscribed = models.BooleanField(
         default=False,
-        verbose_name="Agreed to being contacted by DSF?",
+        verbose_name=_("Agreed to being contacted by DSF?"),
     )
     approved = models.BooleanField(
         null=True,
-        verbose_name="Name, URL, and Logo approved?",
+        verbose_name=_("Name, URL, and Logo approved?"),
     )
 
     objects = DjangoHeroManager()

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -11,10 +11,10 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from django.utils.translation import gettext_lazy as _
 
 from .forms import DjangoHeroForm, DonationForm, PaymentForm
 from .models import DjangoHero, Donation, Payment, Testimonial

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.utils.translation import gettext_lazy as _
 
 from .forms import DjangoHeroForm, DonationForm, PaymentForm
 from .models import DjangoHero, Donation, Payment, Testimonial
@@ -133,7 +134,7 @@ def manage_donations(request, hero):
         if hero_form.is_valid() and modify_donations_formset.is_valid():
             hero_form.save()
             modify_donations_formset.save()
-            messages.success(request, "Your information has been updated.")
+            messages.success(request, _("Your information has been updated."))
     else:
         hero_form = DjangoHeroForm(instance=hero)
         modify_donations_formset = ModifyDonationsFormset(
@@ -178,7 +179,7 @@ def cancel_donation(request, hero):
     donation.stripe_subscription_id = ''
     donation.save()
 
-    messages.success(request, "Your donation has been canceled.")
+    messages.success(request, _("Your donation has been canceled."))
     return redirect('fundraising:manage-donations', hero=hero.pk)
 
 
@@ -248,7 +249,7 @@ class WebhookHandler:
 
         mail_text = render_to_string(
             'fundraising/email/payment_failed.txt', {'donation': donation})
-        send_mail('Payment failed', mail_text,
+        send_mail(_('Payment failed'), mail_text,
                   settings.DEFAULT_FROM_EMAIL, [donation.donor.email])
 
         return HttpResponse(status=204)
@@ -312,7 +313,7 @@ class WebhookHandler:
             {'donation': donation}
         )
         send_mail(
-            'Thank you for your donation to the Django Software Foundation',
+            _('Thank you for your donation to the Django Software Foundation'),
             message,
             settings.FUNDRAISING_DEFAULT_FROM_EMAIL,
             [donation.receipt_email]

--- a/members/forms.py
+++ b/members/forms.py
@@ -1,14 +1,15 @@
 from django import forms
 from django.conf import settings
 from django.core.mail import send_mail
+from django.utils.translation import gettext_lazy as _
 
 from .models import CorporateMember
 
 
 class CorporateMemberSignUpForm(forms.ModelForm):
     amount = forms.IntegerField(
-        label='Donation amount',
-        help_text='Enter an integer in US$ without the dollar sign.',
+        label=_('Donation amount'),
+        help_text=_('Enter an integer in US$ without the dollar sign.'),
     )
 
     def __init__(self, *args, **kwargs):
@@ -32,39 +33,39 @@ class CorporateMemberSignUpForm(forms.ModelForm):
             elif isinstance(field.widget, (forms.FileInput, forms.Select)):
                 self.label_fields.append(name)
 
-        self.fields['billing_name'].widget.attrs['placeholder'] = (
+        self.fields['billing_name'].widget.attrs['placeholder'] = _(
             "Billing name (If different from above name)."
         )
-        self.fields['billing_name'].help_text = (
+        self.fields['billing_name'].help_text = _(
             "For example, this might be your full registered company name."
         )
-        self.fields['display_name'].widget.attrs['placeholder'] = (
+        self.fields['display_name'].widget.attrs['placeholder'] = _(
             "Your organization's name as you'd like it to appear on our website."
         )
-        self.fields['address'].widget.attrs['placeholder'] = (
+        self.fields['address'].widget.attrs['placeholder'] = _(
             'Mailing address'
         )
-        self.fields['address'].help_text = (
+        self.fields['address'].help_text = _(
             'We can send the invoice by email, but we need a contact address.'
         )
-        self.fields['description'].widget.attrs['placeholder'] = (
+        self.fields['description'].widget.attrs['placeholder'] = _(
             "A short paragraph that describes your organization and its "
             "activities, written as if the DSF were describing your company "
             "to a third party."
         )
-        self.fields['description'].help_text = (
+        self.fields['description'].help_text = _(
             """We'll use this text on the <a href="/foundation/corporate-members/">
             corporate membership page</a>; you can use the existing descriptions
             as a guide for flavor we're looking for."""
         )
-        self.fields['django_usage'].widget.attrs['placeholder'] = (
+        self.fields['django_usage'].widget.attrs['placeholder'] = _(
             'How does your organization use Django?'
         )
-        self.fields['django_usage'].help_text = (
+        self.fields['django_usage'].help_text = _(
             "This won't be displayed publicly but helps the DSF Board "
             "to evaluate your application."
         )
-        self.fields['amount'].help_text = (
+        self.fields['amount'].help_text = _(
             """Enter an amount above and the appropriate membership level will
             be automatically selected. Or select a membership level below and
             the minimum donation will be entered for you. See

--- a/members/models.py
+++ b/members/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.views.generic.dates import timezone_today
+from django.utils.translation import gettext_lazy as _
 from django_hosts import reverse
 from sorl.thumbnail import ImageField, get_thumbnail
 
@@ -23,11 +24,11 @@ CORPORATE_MEMBERSHIP_AMOUNTS = {
 }
 
 MEMBERSHIP_LEVELS = (
-    (BRONZE_MEMBERSHIP, 'Bronze'),
-    (SILVER_MEMBERSHIP, 'Silver'),
-    (GOLD_MEMBERSHIP, 'Gold'),
-    (PLATINUM_MEMBERSHIP, 'Platinum'),
-    (DIAMOND_MEMBERSHIP, 'Diamond'),
+    (BRONZE_MEMBERSHIP, _('Bronze')),
+    (SILVER_MEMBERSHIP, _('Silver')),
+    (GOLD_MEMBERSHIP, _('Gold')),
+    (PLATINUM_MEMBERSHIP, _('Platinum')),
+    (DIAMOND_MEMBERSHIP, _('Diamond')),
 )
 
 MEMBERSHIP_TO_KEY = dict((k, v.lower()) for k, v in MEMBERSHIP_LEVELS)
@@ -54,7 +55,7 @@ class IndividualMember(models.Model):
 class Team(models.Model):
     name = models.CharField(max_length=250)
     slug = models.SlugField()
-    description = models.TextField(help_text='HTML, without surrounding <p> tags.')
+    description = models.TextField(help_text=_('HTML, without surrounding <p> tags.'))
     members = models.ManyToManyField(IndividualMember)
 
     def __str__(self):
@@ -82,19 +83,19 @@ class CorporateMember(models.Model):
     billing_name = models.CharField(
         max_length=250,
         blank=True,
-        help_text='If different from display name.',
+        help_text=_('If different from display name.'),
     )
     logo = ImageField(upload_to='corporate-members', null=True, blank=True)
     description = models.TextField(blank=True)
     url = models.URLField(verbose_name='URL')
     contact_name = models.CharField(max_length=250)
     contact_email = models.EmailField()
-    billing_email = models.EmailField(blank=True, help_text='If different from contact email.',)
+    billing_email = models.EmailField(blank=True, help_text=_('If different from contact email.'))
     membership_level = models.IntegerField(choices=MEMBERSHIP_LEVELS)
     address = models.TextField(blank=True)
-    django_usage = models.TextField(blank=True, help_text='Not displayed publicly.')
-    notes = models.TextField(blank=True, help_text='Not displayed publicly.')
-    inactive = models.BooleanField(default=False, help_text='No longer renewing.')
+    django_usage = models.TextField(blank=True, help_text=_('Not displayed publicly.'))
+    notes = models.TextField(blank=True, help_text=_('Not displayed publicly.'))
+    inactive = models.BooleanField(default=False, help_text=_('No longer renewing.'))
 
     objects = CorporateMemberManager()
 
@@ -140,7 +141,7 @@ def create_thumbnail_on_save(sender, **kwargs):
 
 class Invoice(models.Model):
     sent_date = models.DateField(blank=True, null=True)
-    amount = models.IntegerField(help_text='In integer dollars')
+    amount = models.IntegerField(help_text=_('In integer dollars'))
     paid_date = models.DateField(blank=True, null=True)
     expiration_date = models.DateField(blank=True, null=True)
     member = models.ForeignKey(CorporateMember, on_delete=models.CASCADE)

--- a/members/models.py
+++ b/members/models.py
@@ -4,8 +4,8 @@ from django.core import signing
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.views.generic.dates import timezone_today
 from django.utils.translation import gettext_lazy as _
+from django.views.generic.dates import timezone_today
 from django_hosts import reverse
 from sorl.thumbnail import ImageField, get_thumbnail
 

--- a/members/test_admin.py
+++ b/members/test_admin.py
@@ -43,7 +43,7 @@ class CorporateMemberAdminTests(TestCase):
         self.assertIn('green', modeladmin.membership_expires(self.member))
 
     def test_renewal_link(self):
-        expected_str = '<a href="http://www.djangoproject.localhost:8000/foundation/corporate-membership/renew/'
+        expected_str = '<a href="http://www.djangoproject.localhost:8000/en/foundation/corporate-membership/renew/'
         modeladmin = CorporateMemberAdmin(CorporateMember, admin.site)
         self.assertTrue(modeladmin.renewal_link(self.member).startswith(expected_str))
 

--- a/members/test_management.py
+++ b/members/test_management.py
@@ -42,7 +42,7 @@ class CorporateMemberTests(TestCase):
             '%s. Would you like to renew your support?' % localize(self.thirty_days_from_now),
             msg.body
         )
-        self.assertIn('http://www.djangoproject.localhost:8000/foundation/corporate-membership/renew/', msg.body)
+        self.assertIn('http://www.djangoproject.localhost:8000/en/foundation/corporate-membership/renew/', msg.body)
         self.assertEqual(msg.from_email, settings.FUNDRAISING_DEFAULT_FROM_EMAIL)
         self.assertEqual(
             msg.to,

--- a/releases/admin.py
+++ b/releases/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
 from .models import Release
 
@@ -14,7 +15,7 @@ class ReleaseAdmin(admin.ModelAdmin):
     def show_status(self, obj):
         return obj.get_status_display()
     show_status.admin_order_field = 'status'
-    show_status.short_description = 'status'
+    show_status.short_description = _('status')
 
 
 admin.site.register(Release, ReleaseAdmin)

--- a/releases/models.py
+++ b/releases/models.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
 from django.utils.version import get_complete_version, get_main_version
 
 
@@ -149,18 +150,24 @@ class Release(models.Model):
 
     version = models.CharField(max_length=16, primary_key=True)
     date = models.DateField(
-        "Release date",
+        _("Release date"),
         null=True, blank=True,
         default=datetime.date.today,
-        help_text="Leave blank if the release date isn't know yet, typically "
-                  "if you're creating the final release just after the alpha "
-                  "because you want to build docs for the upcoming version.")
+        help_text=_(
+            "Leave blank if the release date isn't know yet, typically "
+            "if you're creating the final release just after the alpha "
+            "because you want to build docs for the upcoming version."
+        )
+    )
     eol_date = models.DateField(
-        "End of life date",
+        _("End of life date"),
         null=True, blank=True,
-        help_text="Leave blank if the end of life date isn't known yet, "
-                  "typically because it depends on the release date of a "
-                  "later version.")
+        help_text=_(
+            "Leave blank if the end of life date isn't known yet, "
+            "typically because it depends on the release date of a "
+            "later version."
+        )
+    )
 
     major = models.PositiveSmallIntegerField(editable=False)
     minor = models.PositiveSmallIntegerField(editable=False)
@@ -168,7 +175,7 @@ class Release(models.Model):
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, editable=False)
     iteration = models.PositiveSmallIntegerField(editable=False)
 
-    is_lts = models.BooleanField("Long term support release", default=False)
+    is_lts = models.BooleanField(_("Long term support release"), default=False)
 
     objects = ReleaseManager()
 
@@ -219,9 +226,9 @@ class Release(models.Model):
             if self.version_tuple[:3] >= (1, 0, 4):
                 pattern = '%(media)spgp/Django-%(version)s.checksum.txt'
             else:
-                raise ValueError('No checksum for this version')
+                raise ValueError(_('No checksum for this version'))
         else:
-            raise ValueError('Unknown file')
+            raise ValueError(_('Unknown file'))
 
         return pattern % {
             'media': settings.MEDIA_URL,
@@ -234,7 +241,7 @@ class Release(models.Model):
 
 def create_releases_up_to_1_5():
     if Release.objects.exists():
-        raise Exception("Releases already exist, aborting.")
+        raise Exception(_("Releases already exist, aborting."))
     versions = [                        # extracted from the redirects table
         '0.90',
         '0.91', '0.91.1', '0.91.2', '0.91.3',

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -1,13 +1,14 @@
 import datetime
 
 from django.contrib.redirects.models import Redirect
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils.safestring import SafeString
 
 from .models import Release, create_releases_up_to_1_5
 from .templatetags.release_notes import get_latest_micro_release, release_notes
 
 
+@override_settings(USE_I18N=False)
 class LegacyURLsTests(TestCase):
 
     fixtures = ['redirects-downloads']          # provided by the legacy app

--- a/releases/urls/download.py
+++ b/releases/urls/download.py
@@ -1,8 +1,7 @@
-from django.urls import path, re_path
+from django.urls import re_path
 
-from .views import index, redirect
+from ..views import redirect
 
 urlpatterns = [
-    path('', index, name='download'),
     re_path('^([0-9a-z_.-]+)/(tarball|checksum|egg)/$', redirect, name='download-redirect'),
 ]

--- a/releases/urls/i18n_paths.py
+++ b/releases/urls/i18n_paths.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from ..views import index
+
+urlpatterns = [
+    path('', index, name='download'),
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = djangodocs,.tox
+exclude = djangodocs,.tox,.venv
 ignore = F405,W504
 max-line-length = 160
 

--- a/svntogit/tests.py
+++ b/svntogit/tests.py
@@ -4,15 +4,15 @@ from django.test import TestCase
 class SvnToGitTests(TestCase):
 
     def test_redirect(self):
-        response = self.client.get('/svntogit/1/', follow=False)
+        response = self.client.get('/en/svntogit/1/', follow=False)
         target = 'https://github.com/django/django/commit/d6ded0e91b'
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response['Location'], target)
 
     def test_redirect_empty_changeset(self):
-        response = self.client.get('/svntogit/7/')
+        response = self.client.get('/en/svntogit/7/')
         self.assertEqual(response.status_code, 404)
 
     def test_redirect_non_existing_changeset(self):
-        response = self.client.get('/svntogit/20000/')
+        response = self.client.get('/en/svntogit/20000/')
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
This sets up i18n URL patterns with the language selector from the docs, beginning to address #883.

This also adds translation tags to the fundraising templates to being to address #377 

As for the languages in settings, I've taken those which are currently in the locale directory.

Happy for any feedback on the current state of changes & also as to whether I should keep adding translation tags to the rest of the templates or do that as separate, smaller, PRs.
