### PR TITLE
Fix #1253 : Side-Scrollbar on the website breaks the focus while reading

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -21,6 +21,10 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
+    &::-webkit-scrollbar {
+        display: none;// for hiding the scrollbar on chromium
+    }
+
     .layout-secondary,
     [role="complementary"] {
         @include sans-serif; // reverse font style on sidebar and secondary areas


### PR DESCRIPTION
Hello mantainers , this is a fix to the issue #1253. I have added the `-webkit-scrollbar` pseudo selectors to hide the side scrollbar in webkit based browsers.