### PR TITLE
Add a link to setting up a virtual python env

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ djangoproject.com source code
 
 To run locally, do the usual:
 
-#. Create a Python 3.8+ virtualenv and activate it
+#. Create a `Python 3.8+ virtualenv and activate it`<https://docs.python.org/3/library/venv.html>_
 
 #. Install dependencies::
 


### PR DESCRIPTION
This a small update in the hopes of making the getting started docs more accessible. Python Env's are hard for me so I hope adding this link will make people's lives easlier.