### PR TITLE
Fixed N+1 query problem in docs switcher.

### DIFF
--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -38,7 +38,7 @@ def get_all_doc_versions(context, url=None):
     versions = []
 
     # Look for each version of the docs.
-    for release in DocumentRelease.objects.filter(lang=lang):
+    for release in DocumentRelease.objects.select_related('release').filter(lang=lang):
         version_root = get_doc_root(release.lang, release.version)
         if version_root.exists():
             doc_path = get_doc_path(version_root, url)

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -15,6 +15,7 @@ from releases.models import Release
 
 from .models import Document, DocumentRelease
 from .sitemaps import DocsSitemap
+from .templatetags.docs import get_all_doc_versions
 from .utils import get_doc_path
 
 
@@ -194,6 +195,11 @@ class SearchFormTestCase(TestCase):
 
 
 class TemplateTagTests(TestCase):
+    fixtures = ['doc_test_fixtures']
+
+    def test_get_all_doc_versions(self):
+        with self.assertNumQueries(1):
+            get_all_doc_versions({})
 
     def test_pygments_template_tag(self):
         template = Template('''


### PR DESCRIPTION
The related release object is fetched via the `version` property. Adding select_related() fetches this as a single query.

Closes #1252