### PR TITLE
Refs #1255 -- alert error message text visibility in dark mode

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2300,7 +2300,7 @@ h2 + .list-link-soup {
 
 #outdated-warning {
     background-color: var(--error-light);
-    color: var(--error-dark);
+    color: $black-light-5;
 }
 
 #docs-content {


### PR DESCRIPTION
Closes #1255 

After the fix : 
<img width="1677" alt="Capture d’écran 2022-11-08 à 22 40 24" src="https://user-images.githubusercontent.com/17890338/200682544-152a4cfb-d0a0-4f6e-8d96-4f4621e2c312.png">
<img width="1680" alt="Capture d’écran 2022-11-08 à 22 40 12" src="https://user-images.githubusercontent.com/17890338/200682564-4a4af241-160e-4c64-9733-0b55d6cd0155.png">
