### PR TITLE
Fix feed aggregator n+1 issue & cache the model data [#1261]

### DIFF
--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -20,7 +20,7 @@ class FeedType(models.Model):
         return "%s" % (self.name,)
 
     def items(self):
-        return FeedItem.objects.filter(feed__feed_type=self)
+        return FeedItem.objects.select_related('feed', 'feed__feed_type').filter(feed__feed_type=self)
 
 
 APPROVED_FEED = 'A'

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -164,13 +164,13 @@ class FeedItem(models.Model):
 
 
 @receiver((post_delete, post_save), sender=FeedItem)
-def invalidate_feed_item_cache_from_items(sender, instance, created, **kwargs):
+def invalidate_feed_item_cache_from_items(sender, instance, **kwargs):
     """ Invalidate the feed item cached data when items or are changed or deleted """
     cache.delete(CACHED_FEEDITEMS_KEY.format(feed_type_id=instance.feed.feed_type_id))
 
 
 @receiver((post_delete, post_save), sender=FeedType)
-def invalidate_feed_item_cache_from_feedtype(sender, instance, created, **kwargs):
+def invalidate_feed_item_cache_from_feedtype(sender, instance, **kwargs):
     """ Invalidate the feed item cached data when items or are changed or deleted """
     cache.delete(CACHED_FEEDITEMS_KEY.format(feed_type_id=instance.id))
 

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -151,7 +151,7 @@ class FeedItem(models.Model):
                 return FeedItem.objects.none()
             return items
 
-        items = FeedItem.objects.select_related('feed', 'feed__feed_type').filter(
+        items = FeedItem.objects.filter(
             feed__feed_type_id=feed_type_id
         ).select_related('feed', 'feed__feed_type')
 

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.db import models
-from django.db.models.signals import post_save, post_delete
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django_push.subscriber import signals as push_signals
 from django_push.subscriber.models import Subscription

--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -89,6 +89,12 @@ class AggregatorTests(TestCase):
                 guid=feed.title,
             )
 
+    def test_community_index_number_of_queries(self):
+        """ Intended to prevent an n+1 issue on the community index view """
+        url = reverse('community-index')
+        with self.assertNumQueries(4):
+            self.client.get(url)
+
     def test_feed_list_only_approved_and_active(self):
         url = reverse('community-feed-list', kwargs={'feed_type_slug': self.feed_type.slug})
         response = self.client.get(url)

--- a/aggregator/utils.py
+++ b/aggregator/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from .models import FeedType, FeedItem
+from .models import FeedItem, FeedType
 
 
 def push_credentials(hub_url):

--- a/aggregator/utils.py
+++ b/aggregator/utils.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from aggregator.models import FeedType, FeedItem
+
 
 def push_credentials(hub_url):
     """
@@ -8,3 +10,12 @@ def push_credentials(hub_url):
     We always use superfeedr so this is easy.
     """
     return tuple(settings.SUPERFEEDR_CREDS)
+
+
+def get_feed_data(num_items=5) -> list:
+    """ Fetches feed data, from cache if available """
+    feeds = []
+    feed_types = FeedType.objects.values('id', 'name', 'slug', 'can_self_add')
+    for ft in feed_types:
+        feeds.append((ft, FeedItem.cached_by_feed_type_id(ft['id'])[0:num_items]))
+    return feeds

--- a/aggregator/utils.py
+++ b/aggregator/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from aggregator.models import FeedType, FeedItem
+from .models import FeedType, FeedItem
 
 
 def push_credentials(hub_url):

--- a/aggregator/views.py
+++ b/aggregator/views.py
@@ -5,16 +5,18 @@ from django.views.generic.list import ListView
 
 from .forms import FeedModelForm
 from .models import APPROVED_FEED, Feed, FeedItem, FeedType
+from .utils import get_feed_data
 
 
 def index(request):
     """
     Displays the latest feeds of each type.
+
+    Template requires;
+        FeedType name, slug & can_self_add
+        FeedItem date_modified, link, title, feed__public_url, feed__title
     """
-    feeds = []
-    for ft in FeedType.objects.all():
-        feeds.append((ft, ft.items()[0:5]))
-    ctx = {'feedtype_list': feeds}
+    ctx = {'feed_data': get_feed_data()}
     return render(request, 'aggregator/index.html', ctx)
 
 

--- a/djangoproject/templates/aggregator/index.html
+++ b/djangoproject/templates/aggregator/index.html
@@ -14,21 +14,21 @@
 
 <ul class="list-collapsing">
 
-{% for feedtype, latest_feeds in feedtype_list %}
+{% for feedtype, latest_items in feed_data %}
   <li id="{{ feedtype.slug }}">
     <h2 class="bullet-icon"><i class="icon icon-rss blue"></i> {{ feedtype.name }}</h2>
     <div class="collapsing-content">
       <dl class="list-links">
-        {% for item in latest_feeds %}
+        {% for item in latest_items %}
             <dt><a href="{{ item.link }}">{{ item.title }}</a></dt>
             <dd>{{ item.date_modified|date:"N jS, Y \a\t P" }} by <a href="{{ item.feed.public_url }}">{{ item.feed.title }}</a></dd>
         {% endfor %}
       </dl>
       <p class="meta">
-        {% if latest_feeds %}
+        {% if latest_items %}
           <a href="{% url 'community-feed-list' feedtype.slug %}">View more</a>
         {% endif %}
-        {% if latest_feeds and feedtype.can_self_add %}
+        {% if latest_items and feedtype.can_self_add %}
           or
         {% endif %}
         {% if feedtype.can_self_add %}


### PR DESCRIPTION
This addresses the regression in #1261 and adds caching for feed items.

Items are cached for 24 hours and invalidated on saving or deleting `FeedType` and `FeedItem`.

Prior to this the community page had 10 queries. The initial `select_related` brought it down to 7 and then the caching brings it down to 4.