### PR TITLE
Fix feed aggregator n+1 issue [#1261]

### DIFF
--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -20,7 +20,9 @@ class FeedType(models.Model):
         return "%s" % (self.name,)
 
     def items(self):
-        return FeedItem.objects.select_related('feed', 'feed__feed_type').filter(feed__feed_type=self)
+        return FeedItem.objects.select_related(
+            'feed', 'feed__feed_type'
+        ).filter(feed__feed_type=self)
 
 
 APPROVED_FEED = "A"

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -20,9 +20,9 @@ class FeedType(models.Model):
         return "%s" % (self.name,)
 
     def items(self):
-        return FeedItem.objects.select_related(
-            'feed', 'feed__feed_type'
-        ).filter(feed__feed_type=self)
+        return FeedItem.objects.select_related("feed", "feed__feed_type").filter(
+            feed__feed_type=self
+        )
 
 
 APPROVED_FEED = "A"

--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -20,7 +20,7 @@ class FeedType(models.Model):
         return "%s" % (self.name,)
 
     def items(self):
-        return FeedItem.objects.filter(feed__feed_type=self)
+        return FeedItem.objects.select_related('feed', 'feed__feed_type').filter(feed__feed_type=self)
 
 
 APPROVED_FEED = "A"

--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -89,8 +89,8 @@ class AggregatorTests(TestCase):
             )
 
     def test_community_index_number_of_queries(self):
-        """ Intended to prevent an n+1 issue on the community index view """
-        url = reverse('community-index')
+        """Intended to prevent an n+1 issue on the community index view"""
+        url = reverse("community-index")
         with self.assertNumQueries(4):
             self.client.get(url)
 

--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -88,6 +88,12 @@ class AggregatorTests(TestCase):
                 guid=feed.title,
             )
 
+    def test_community_index_number_of_queries(self):
+        """ Intended to prevent an n+1 issue on the community index view """
+        url = reverse('community-index')
+        with self.assertNumQueries(4):
+            self.client.get(url)
+
     def test_feed_list_only_approved_and_active(self):
         url = reverse(
             "community-feed-list", kwargs={"feed_type_slug": self.feed_type.slug}


### PR DESCRIPTION
Simplifying from the changes in #1274 to address the regression in #1261.

This keeps things simple, using `select_related` on the feed items query and testing to ensure the queries executed from the community index.

Closes #1261