### PR TITLE
Fixed #1282 -- Migration to new Transifex CLI

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,24 +1,18 @@
 [main]
-host = https://www.transifex.com
-type = PO
-lang_map = zh_CN:zh_Hans, zh_TW:zh_Hant
+host     = https://www.transifex.com
+lang_map = zh_CN: zh_Hans, zh_TW: zh_Hant
 
-# Get translations for the 'docs' app from the 'django-docs' project (resource: 'website-strings')
-[django-docs.website-strings]
+[o:django:p:django-docs:r:website-strings]
 file_filter = docs/locale/<lang>/LC_MESSAGES/django.po
 source_file = docs/locale/en/LC_MESSAGES/django.po
 source_lang = en
 
-# Get translations for the 'dashboard' app from the 'djangoproject.com' project (resource: 'dashboard-app')
-# 'dashboard' is a reserved word in Transifex, so we use 'dashboard-app' instead.
-[djangoproject-com.dashboard-app]
+[o:django:p:djangoproject-com:r:dashboard-app]
 file_filter = dashboard/locale/<lang>/LC_MESSAGES/django.po
 source_file = dashboard/locale/en/LC_MESSAGES/django.po
 source_lang = en
 
-# Send everything else to the 'main' resource in the 'djangoproject.com' project.
-# If/when needed, other apps may be split out into separate resources (a la 'dashboard' above).
-[djangoproject-com.main]
+[o:django:p:djangoproject-com:r:main]
 file_filter = locale/<lang>/LC_MESSAGES/django.po
 source_file = locale/en/LC_MESSAGES/django.po
 source_lang = en

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,6 @@ To run locally, do the usual:
     python3 -m pip install -r requirements/dev.txt
     npm install
 
-   *Note: for Python 3.10+ you have to append* ``--ignore-requires-python`` *to* ``pip``
-
    Alternatively, use the make task::
 
     make install
@@ -300,7 +298,9 @@ Translation
 -----------
 
 We're using Transifex to help manage the translation process. The
-``requirements/dev.txt`` file will install the Transifex client.
+Transifex client app is required. To install it, run::
+
+    curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 
 Before using the command-line Transifex client, create ``~/.transifexrc``
 according to the instructions at

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,3 @@
 -r common.txt
 pre-commit~=2.20.0
-transifex-client==0.14.4
 watchdog==2.1.6


### PR DESCRIPTION
Used `tx migrate` command, updated `Transifex` install instruction in README.

Fixed #1282 