### PR TITLE
Remove AmazonSmile link

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -34,9 +34,6 @@
   <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a> -
     Buy official t-shirts, accessories, and more to support Django.</li>
   <li><a href="https://github.com/sponsors/django" target="_blank">Sponsor Django via GitHub Sponsors</a>.</li>
-  <li><a href="/foundation/donate/#amazon-smile">Amazon Smile</a> - When you
-    shop at Amazon, you can nominate for 0.5% of the purchase price of your
-    eligible purchases to be donated to the DSF.</li>
   <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving
     Program</a> - If your employer participates, you can make donations to the
     DSF via payroll deduction.</li>

--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -58,7 +58,6 @@
           <ul>
             <li><a href="{% url "fundraising:index" %}">Sponsor Django</a></li>
             <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a></li>
-            <li><a href="/foundation/donate/#amazon-smile">Amazon Smile</a></li>
             <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving Program</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Closes #1300

Reason: https://www.aboutamazon.com/news/company-news/amazon-closing-amazonsmile-to-focus-its-philanthropic-giving-to-programs-with-greater-impact