### PR TITLE
Added django-read-only. 

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -88,7 +88,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.sitemaps",
     "django_push.subscriber",
-    "django_read_only"
+    "django_read_only",
 ]
 
 LANGUAGE_CODE = "en-us"

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.sitemaps",
     "django_push.subscriber",
+    "django_read_only"
 ]
 
 LANGUAGE_CODE = "en-us"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -18,3 +18,4 @@ requests==2.27.1
 sorl-thumbnail==12.8.0
 Sphinx==4.5.0
 stripe==2.56.0
+django-read-only==1.11.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,7 +3,7 @@ django-contact-form==1.9
 django-hosts==5.1
 django-money==2.1.1
 django-push==1.1
-django-read-only==1.11.0
+django-read-only==1.12.0
 django-recaptcha==3.0.0
 django-registration-redux==2.10
 Django==3.2.16

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,6 +3,7 @@ django-contact-form==1.9
 django-hosts==5.1
 django-money==2.1.1
 django-push==1.1
+django-read-only==1.11.0
 django-recaptcha==3.0.0
 django-registration-redux==2.10
 Django==3.2.16
@@ -18,4 +19,3 @@ requests==2.27.1
 sorl-thumbnail==12.8.0
 Sphinx==4.5.0
 stripe==2.56.0
-django-read-only==1.11.0


### PR DESCRIPTION
On using `DJANGO_READ_ONLY=1`, it's now possible to shell in read-only mode:
```
DJANGO_READ_ONLY=1 python manage.py shell
```

<img width="597" alt="Screenshot 2023-01-23 at 8 31 35 PM" src="https://user-images.githubusercontent.com/14011425/214072616-84b788db-a1ca-49cd-a213-4f5c1fc4b3e5.png">

Resolves #1059 
