### PR TITLE
Fix logic for selecting search key string

### DIFF
--- a/djangoproject/static/js/mod/search-key.js
+++ b/djangoproject/static/js/mod/search-key.js
@@ -12,7 +12,7 @@ define([
             $(document).ready(function () {
                 const search_form_input = self.search_form.find('input');
                 const raw_placeholder = search_form_input.attr('placeholder');
-                const shortcut = navigator.userAgent.indexOf("Mac") === -1 ? "⌘ + K" :  "Ctrl + K";
+                const shortcut = navigator.userAgent.indexOf("Mac") === -1 ? "Ctrl + K" : "⌘ + K";
                 search_form_input.attr('placeholder', `${raw_placeholder} (${shortcut})`);
 
                 $(window).keydown(function(e) {


### PR DESCRIPTION
Current logic incorrectly shows "⌘ + K" in Chrome on Windows (user agent 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36'). It does not contain "Mac".

The logic was introduced in #1236 and appears to be swapped - showing Windows/Linux shortcut on mac and vice-versa.