### PR TITLE
Added a RSS feed for the DSF board's meeting minutes

### DIFF
--- a/djangoproject/templates/foundation/meeting_archive.html
+++ b/djangoproject/templates/foundation/meeting_archive.html
@@ -3,6 +3,10 @@
 {% block og_title %}Meeting minutes archive{% endblock %}
 {% block og_description %}View meeting minutes{% endblock %}
 
+{% block head_extra %}
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url 'foundation-minutes-feed' %}" />
+{% endblock %}
+
 {% block content %}
 <h1>Meeting minutes archive</h1>
 

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -13,6 +13,7 @@ from accounts import views as account_views
 from aggregator.feeds import CommunityAggregatorFeed, CommunityAggregatorFirehoseFeed
 from blog.feeds import WeblogEntryFeed
 from blog.sitemaps import WeblogSitemap
+from foundation.feeds import FoundationMinutesFeed
 from foundation.views import CoreDevelopers
 
 admin.autodiscover()
@@ -115,6 +116,11 @@ urlpatterns = [
         name="aggregator-firehose-feed",
     ),
     path("rss/community/<slug>/", CommunityAggregatorFeed(), name="aggregator-feed"),
+    path(
+        "rss/foundation/minutes/",
+        FoundationMinutesFeed(),
+        name="foundation-minutes-feed",
+    ),
     # django-push
     path("subscriber/", include("django_push.subscriber.urls")),
     # Trac schtuff

--- a/foundation/feeds.py
+++ b/foundation/feeds.py
@@ -20,5 +20,5 @@ class FoundationMinutesFeed(Feed):
     def item_author_name(self, item):
         return "DSF Board"
 
-    def item_description(self, item):
-        return item.treasurer_report_html
+    def item_title(self, item):
+        return str(item)

--- a/foundation/feeds.py
+++ b/foundation/feeds.py
@@ -1,0 +1,24 @@
+from datetime import datetime, time
+
+from django.contrib.syndication.views import Feed
+from django.utils.timezone import make_aware
+
+from .models import Meeting
+
+
+class FoundationMinutesFeed(Feed):
+    title = "The DSF meeting minutes"
+    link = "https://www.djangoproject.com/foundation/minutes/"
+    description = "The meeting minutes of the Django Software Foundation's board."
+
+    def items(self):
+        return Meeting.objects.all()[:10]
+
+    def item_pubdate(self, item):
+        return make_aware(datetime.combine(item.date, time.min))
+
+    def item_author_name(self, item):
+        return "DSF Board"
+
+    def item_description(self, item):
+        return item.treasurer_report_html

--- a/foundation/feeds.py
+++ b/foundation/feeds.py
@@ -12,7 +12,7 @@ class FoundationMinutesFeed(Feed):
     description = "The meeting minutes of the Django Software Foundation's board."
 
     def items(self):
-        return Meeting.objects.all()[:10]
+        return Meeting.objects.order_by("-date")[:10]
 
     def item_pubdate(self, item):
         return make_aware(datetime.combine(item.date, time.min))

--- a/foundation/tests.py
+++ b/foundation/tests.py
@@ -20,12 +20,12 @@ class MeetingTestCase(TestCase):
         )
         Meeting.objects.create(
             date=date.today(),
-            title="Minutes",
-            slug="minutes",
+            title="DSF Board monthly meeting",
+            slug="dsf-board-monthly-meeting",
             leader=member,
             treasurer_report="Hello World",
         )
 
         response = self.client.get(reverse("foundation-minutes-feed"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Hello World", response.content)
+        self.assertIn(b"DSF Board monthly meeting", response.content)

--- a/foundation/tests.py
+++ b/foundation/tests.py
@@ -1,0 +1,31 @@
+from datetime import date
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import BoardMember, Meeting, Office, Term
+
+
+class MeetingTestCase(TestCase):
+    def test_meeting_minutes_feed(self):
+        """
+        Make sure that the meeting minutes RSS feed works
+        """
+        user = User.objects.create_superuser("admin", "admin@example.com", "password")
+        member = BoardMember.objects.create(
+            account=user,
+            office=Office.objects.create(name="treasurer"),
+            term=Term.objects.create(year=2023),
+        )
+        Meeting.objects.create(
+            date=date.today(),
+            title="Minutes",
+            slug="minutes",
+            leader=member,
+            treasurer_report="Hello World",
+        )
+
+        response = self.client.get(reverse("foundation-minutes-feed"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Hello World", response.content)


### PR DESCRIPTION
I found out via Mastodon that I've been accepted as an individual member of the DSF. That's great news. I didn't even know that the DSF meeting minutes were available online though (sorry for that!)

I propose adding a RSS feed to give those meeting notes some additional visibility. RSS is great and everyone should still be using it ;-)

(I also included a `tox.ini` fix to make running tests locally work with tox 4)