### PR TITLE
Set high value for recaptcha test on donations page.

### DIFF
--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -90,3 +90,5 @@ if "sentry_dsn" in SECRETS and not DEBUG:
 if "recaptcha_public_key" in SECRETS:
     RECAPTCHA_PUBLIC_KEY = SECRETS.get("recaptcha_public_key")
     RECAPTCHA_PRIVATE_KEY = SECRETS.get("recaptcha_private_key")
+
+RECAPTCHA_REQUIRED_SCORE = 0.85


### PR DESCRIPTION
By setting a high required score we should 🤞 reject card testers. 


(If someone could ✅ this I can deploy it. 🙏)