### PR TITLE
Update tox.ini to use allowlist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =py38-{tests,flake8,black,isort}
 skipsdist = true
 
 [testenv]
-whitelist_externals = make
+allowlist_externals = make
 passenv = DJANGO_SETTINGS_MODULE
 deps =
     tests: -r{toxinidir}/requirements/tests.txt


### PR DESCRIPTION
Prior to this change, we were using the whitelist_externals setting.

This change updates the tox.ini to use allowlist_externals instead of whitelist_externals, as whitelist_externals is now deprecated[0].

[0]: https://tox.readthedocs.io/en/latest/config.html