### PR TITLE
Updated download page for 4.2 release.

### DIFF
--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -83,16 +83,16 @@
       <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
-      <td>4.1</td>
-      <td>{% get_latest_micro_release '4.1' %}</td>
-      <td>April 2023</td>
+      <td>4.2 LTS</td>
+      <td>{% get_latest_micro_release '4.2' %}</td>
       <td>December 2023</td>
+      <td>April 2026</td>
     </tr>
     <tr>
-      <td>4.0</td>
-      <td>{% get_latest_micro_release '4.0' %}</td>
-      <td>August 3, 2022</td>
-      <td>April 2023</td>
+      <td>4.1</td>
+      <td>{% get_latest_micro_release '4.1' %}</td>
+      <td>April 1, 2023</td>
+      <td>December 2023</td>
     </tr>
     <tr>
       <td>3.2 LTS</td>
@@ -112,6 +112,12 @@
       <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
+      <td>6.0</td>
+      <td>December 2025</td>
+      <td>August 2026</td>
+      <td>April 2027</td>
+    </tr>
+    <tr>
       <td>5.2 LTS</td>
       <td>April 2025</td>
       <td>December 2025</td>
@@ -129,12 +135,6 @@
       <td>August 2024</td>
       <td>April 2025</td>
     </tr>
-    <tr>
-      <td>4.2 LTS</td>
-      <td>April 2023</td>
-      <td>December 2023</td>
-      <td>April 2026</td>
-    </tr>
   </table>
 
   <h2 id="unsupported-versions">Unsupported previous releases</h2>
@@ -146,6 +146,12 @@
       <th>Latest Release</th>
       <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
       <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+    </tr>
+    <tr>
+      <td>4.0</td>
+      <td>{% get_latest_micro_release '4.0' %}</td>
+      <td>August 3, 2022</td>
+      <td>April 1, 2023</td>
     </tr>
     <tr>
       <td>3.1</td>


### PR DESCRIPTION
:rotating_light:  Don't merge before April 3, 2023 (4.2 release).
