### PR TITLE
Updated docs-related model fixtures for 4.2 release.

### DIFF
--- a/docs/fixtures/doc_releases.json
+++ b/docs/fixtures/doc_releases.json
@@ -10,19 +10,19 @@
 },
 {
   "model": "docs.documentrelease",
-  "pk": 35,
+  "pk": 37,
   "fields": {
     "lang": "fr",
-    "release": "4.1",
+    "release": "4.2",
     "is_default": false
   }
 },
 {
   "model": "docs.documentrelease",
-  "pk": 36,
+  "pk": 38,
   "fields": {
     "lang": "en",
-    "release": "4.1",
+    "release": "4.2",
     "is_default": true
   }
 }

--- a/releases/fixtures/doc_releases.json
+++ b/releases/fixtures/doc_releases.json
@@ -163,5 +163,19 @@
     "iteration": 0,
     "is_lts": false
   }
+},
+{
+  "model": "releases.release",
+  "pk": "4.2",
+  "fields": {
+    "date": "2023-04-03",
+    "eol_date": null,
+    "major": 4,
+    "minor": 2,
+    "micro": 0,
+    "status": "f",
+    "iteration": 0,
+    "is_lts": true
+  }
 }
 ]


### PR DESCRIPTION
:rotating_light:  Don't merge before April 3, 2023 (4.2 release).