### PR TITLE
this fixes #1339 how logo displays

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -3,6 +3,7 @@ html[data-theme="light"],
 :root {
 	--body-fg: #{$text};
 	--body-bg: #{$white};
+	--logo-bg: #ffffff;
 
 	--menu: #{$white};
 
@@ -59,6 +60,7 @@ html[data-theme="light"],
 	html:not([data-theme="light"]) {
 		--body-fg: #C1CAD2;
 		--body-bg: #{$black};
+		--logo-bg: #272c27;
 
 		--text-l10: #{$green-light};
 		--text-l20: #{$green-very-light};
@@ -145,6 +147,7 @@ html[data-theme="light"],
 html[data-theme="dark"] {
 	--body-fg: #C1CAD2;
 	--body-bg: #{$black};
+	--logo-bg: #272c27;
 
 	--text-l10: #{$green-light};
 	--text-l20: #{$green-very-light};

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -3,7 +3,7 @@ html[data-theme="light"],
 :root {
 	--body-fg: #{$text};
 	--body-bg: #{$white};
-	--logo-bg: #ffffff;
+	--logo-bg: #{$white};
 
 	--menu: #{$white};
 
@@ -60,7 +60,7 @@ html[data-theme="light"],
 	html:not([data-theme="light"]) {
 		--body-fg: #C1CAD2;
 		--body-bg: #{$black};
-		--logo-bg: #272c27;
+		--logo-bg: #{$logo-bg-dark};
 
 		--text-l10: #{$green-light};
 		--text-l20: #{$green-very-light};
@@ -147,7 +147,7 @@ html[data-theme="light"],
 html[data-theme="dark"] {
 	--body-fg: #C1CAD2;
 	--body-bg: #{$black};
-	--logo-bg: #272c27;
+	--logo-bg: #{$logo-bg-dark};
 
 	--text-l10: #{$green-light};
 	--text-l20: #{$green-very-light};

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3140,7 +3140,10 @@ form .footnote {
             text-align: center;
         }
         .hero {
-            width: calc(100% / 3);
+            width: 30%;
+            background-color: var(--logo-bg);
+			border-radius: 10px;
+			margin: 5px;
             position: relative;
             height: auto;
             div {

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -39,6 +39,7 @@ $red-dark-l10: lighten($red-dark, 10);
 $black: #0e1117;
 $black-light-5: lighten($black, 5);
 $font-path: "../fonts/fira-mono";
+$logo-bg-dark: #272c27;
 
 
 // @font-face declarations


### PR DESCRIPTION
Logos in dark theme were not clear and alignment was not perfect. Fixed both of them.

**before:**
![Screen Shot 2023-04-14 at 11 28 03 PM](https://user-images.githubusercontent.com/98866798/232121653-9da9e885-af75-438d-940e-3f9cc2882fcb.png)
**After:**
![fixed_styles](https://user-images.githubusercontent.com/98866798/231110726-29201c13-cb4f-4c22-abc7-6ab512538675.png)
**After in light mode:**
![Screen Shot 2023-04-15 at 9 43 21 AM](https://user-images.githubusercontent.com/98866798/232182701-dab4fa44-6c6b-44e9-8615-1f6258566559.png)
I have not done much in light mode because every thing looks good in light mode
