### PR TITLE
Add permalinks to the headers in teams page

### DIFF
--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -10,7 +10,7 @@
 
 {% for team in teams %}
 <div class="section">
-<h3 id="{{ team.slug }}-team">{{ team.name }}</h3>
+  <h3 id="{{ team.slug }}-team">{{ team.name }}<a class="plink" href="#{{ team.slug }}-team">¶</a></h3>
 <p>{{ team.description|safe }}</p>
 <ul>
 {% for member in team.members.all %}

--- a/members/test_views.py
+++ b/members/test_views.py
@@ -158,6 +158,9 @@ class TeamListViewTests(TestCase):
         self.assertSequenceEqual(
             response.context["teams"], [self.ops_team, self.security_team]
         )
-        self.assertContains(response, '<h3 id="ops-team">Ops team</h3>')
+        self.assertContains(
+            response,
+            '<h3 id="ops-team">Ops team<a class="plink" href="#ops-team">¶</a></h3>',
+        )
         self.assertContains(response, "<p>Ops stuff.</p>")
         self.assertContains(response, "<ul><li>DjangoDeveloper</li></ul>", html=True)


### PR DESCRIPTION
Prior to this change, we couldn't link sub-headers in the teams page.

This change adds permalink urls to each h3 header in the page. So that we can link each team section separately.

I used the `plink` class from https://github.com/django/djangoproject.com/blob/main/djangoproject/templates/conduct/faq.html#L18.