### PR TITLE
Corrected og title and description for teams page.

### DIFF
--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -1,7 +1,12 @@
 {% extends "base_foundation.html" %}
 
-{% block og_title %}Log in{% endblock %}
-{% block og_description %}Log in to your account{% endblock %}
+{% block og_title %}Meet the Teams | Django Software Foundation{% endblock %}
+{% block og_description %}{% spaceless %}
+  Get to know the teams behind the Django Software Foundation,
+  including the Steering Council and various committees. Learn about
+  their roles and responsibilities in advancing the development and
+  adoption of the Django web framework.
+{% endspaceless %}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
Prior to this change, og title and desc was set incorrectly as it was
the login page.

This change updates those fields with related content.

Before:
<img width="535" alt="Screenshot 2023-05-03 at 11 25 40" src="https://user-images.githubusercontent.com/1615150/235891728-f53f0dd2-cd9d-4c82-801b-4df02b2e18d5.png">
