### PR TITLE
Fixed Stripe webhooks crash when object is empty.

### DIFF
--- a/fundraising/test_data/empty_payment.json
+++ b/fundraising/test_data/empty_payment.json
@@ -1,0 +1,14 @@
+{
+  "id": "evt_103MXP2kbIgHtIBFeIFqPxp7",
+  "object": "event",
+  "api_version": "2015-01-11",
+  "created": 1683928544,
+  "data": {
+    "object": ""
+  },
+  "livemode": true,
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": null,
+  "type": "invoice.payment_succeeded"
+}

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -223,6 +223,12 @@ class TestWebhooks(TestCase):
         self.assertTrue(response.status_code, 422)
 
     @patch("stripe.Event.retrieve")
+    def test_empty_object(self, event):
+        event.return_value = self.stripe_data("empty_payment")
+        response = self.post_event()
+        self.assertEqual(response.status_code, 422)
+
+    @patch("stripe.Event.retrieve")
     def test_zero_invoice_amount(self, event):
         """Zero payment amounts don't need to be created."""
         event.return_value = self.stripe_data("zero_invoice_amount")

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -212,6 +212,8 @@ class WebhookHandler:
             "checkout.session.completed": self.checkout_session_completed,
         }
         handler = handlers.get(self.event.type, lambda: HttpResponse(422))
+        if not self.event.data.object:
+            return HttpResponse(status=422)
         return handler()
 
     def payment_succeeded(self):


### PR DESCRIPTION
Sentry Issue: https://django.sentry.io/issues/4179342470/

Stack trace:
```
AttributeError: 'str' object has no attribute 'charge' ...
File "django/views/decorators/http.py", line 40, in inner
  return func(request, *args, **kwargs)
File "django/views/decorators/csrf.py", line 54, in wrapped_view
  return view_func(*args, **kwargs)
File "fundraising/views.py", line 200, in receive_webhook
  return WebhookHandler(event).handle()
File "fundraising/views.py", line 215, in handle
  return handler()
File "fundraising/views.py", line 220, in payment_succeeded
  if Payment.objects.filter(stripe_charge_id=invoice.charge).exists():
```