### PR TITLE
Changes header navigation to a <nav> element, style by ID

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -575,8 +575,6 @@ blockquote {
 		}
 	}
 
-	[role="navigation"] {
-		background: $green-dark;
 	#header-navigation {
 		background: $green-dark;
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -577,6 +577,8 @@ blockquote {
 
 	[role="navigation"] {
 		background: $green-dark;
+	#header-navigation {
+		background: $green-dark;
 
 		width: 100%;
 

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -5,7 +5,7 @@
     <div class="mobile-toggle">
       {% include "includes/toggle_theme.html" %}
     </div>
-    <nav id="top-navigation">
+    <nav id="header-navigation">
       <ul>
         <li{% if 'start' in request.path %} class="active"{% endif %}>
           <a href="{% url 'overview' %}">Overview</a>

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -5,7 +5,7 @@
     <div class="mobile-toggle">
       {% include "includes/toggle_theme.html" %}
     </div>
-    <div role="navigation">
+    <nav id="top-navigation">
       <ul>
         <li{% if 'start' in request.path %} class="active"{% endif %}>
           <a href="{% url 'overview' %}">Overview</a>
@@ -38,6 +38,6 @@
           {% include "includes/toggle_theme.html" %}
         </li>
       </ul>
-    </div>
+    </nav>
   </div>
 </div>


### PR DESCRIPTION
Use a `<nav>` element for the top mavigation bar, instead of `role="navitation"`.

These are semantically equivalent, but its better to style by class or ID than by role/element type, as other content on the page may be marked up as `<nav>` in future (e.g. the docs side bar).