### PR TITLE
Fixed HTML of community page.

### DIFF
--- a/djangoproject/templates/aggregator/index.html
+++ b/djangoproject/templates/aggregator/index.html
@@ -70,8 +70,8 @@
               <a href="{% url 'community-add-feed' feedtype.slug %}">Add your feed</a>
             {% endif %}
           </p>
-        </li>
-      </div>
+        </div>
+      </li>
     {% endfor %}
   </ul>
 


### PR DESCRIPTION
This should fix the main issue with recently deployed community page:

![image](https://github.com/django/djangoproject.com/assets/2865885/6b1bfc3e-c072-44b0-b5be-11e07e38e5e8)
