### PR TITLE
Fixed CSS width for heroes without logos.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3432,11 +3432,6 @@ form .footnote {
 			margin-bottom: 5px;
 		}
 
-		.no-logo-hero {
-			min-height: 60px;
-			margin-right: 24px;
-		}
-
 		div {
 			float: left;
 			text-align: center;
@@ -3446,6 +3441,12 @@ form .footnote {
 				max-width: 90%;
 				max-height: 170px;
 			}
+		}
+
+		.no-logo-hero {
+			min-height: 60px;
+			margin-right: 24px;
+			width: auto;
 		}
 	}
 


### PR DESCRIPTION
Regression in 8920d32faf9457d805832f145ad93d79c004591d.

Before:

![image](https://github.com/django/djangoproject.com/assets/2865885/b43a4b5f-2251-4f30-8f64-25599504394a)

After:

![image](https://github.com/django/djangoproject.com/assets/2865885/feeab533-b040-479c-b5bc-30ae918c2384)
