### PR TITLE
Add Fediverse link in footer.html

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -48,7 +48,7 @@
           <ul>
             <li><a href="https://github.com/django">GitHub</a></li>
             <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
-            <li><a href="https://fosstodon.org/@django">Fediverse (Mastodon)</a></li>
+            <li><a href="https://fosstodon.org/@django" rel="me">Fediverse (Mastodon)</a></li>
             <li><a href="{% url 'weblog-feed' %}">News RSS</a></li>
             <li><a href="https://groups.google.com/forum/#!forum/django-users">Django Users Mailing List</a></li>
           </ul>

--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -48,6 +48,7 @@
           <ul>
             <li><a href="https://github.com/django">GitHub</a></li>
             <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
+            <li><a href="https://fosstodon.org/@django">Fediverse (Mastodon)</a></li>
             <li><a href="{% url 'weblog-feed' %}">News RSS</a></li>
             <li><a href="https://groups.google.com/forum/#!forum/django-users">Django Users Mailing List</a></li>
           </ul>


### PR DESCRIPTION
I think we're ready to add this? The follower count seems substantial, and the bot has been behaving well :crossed_fingers: 

A couple of updates here:

* The account on https://fosstodon.org/@django has been handed over to the Ops team.
* The "bot" element remains, and updates from the RSS will be automatically added.
* There's no one actively monitoring notifications, hence calling this a "bot" continues to be a fair label.

CC: @MarkusH 

I tried to find other places in the codebase by searching for "twitter.com". But this seems to be the only relevant place to link the profile. There's a "tweet this" link on the donation thank you page, but doing "Toot This" buttons seems too complicated (needs a step to choose an instance).

### Terminology :)

On choosing "Fediverse (Mastodon)" as a label: Saying "Fediverse" is probably the more generic term - "Mastodon" is after all just one of several clients. There are even members of Django community working on other clients (https://jointakahe.org/).