### PR TITLE
Fixed Issue Menu button is not a button #1234

### DIFF
--- a/djangoproject/static/js/mod/mobile-menu.js
+++ b/djangoproject/static/js/mod/mobile-menu.js
@@ -12,7 +12,7 @@ define([
         init: function(){
             var self = this;
             self.menu.addClass('nav-menu-on');
-            self.button = $('<div class="menu-button"><i class="icon icon-reorder"></i><span>Menu</span></div>');
+            self.button = $('<div class="menu-button"><button class="icon icon-reorder" style="background-color: transparent; color: white; border: none;"></button><span>Menu</span></div>');
             self.button.insertBefore(self.menuBtn);
             self.button.on( 'click', function(){
                 self.menu.toggleClass('active');


### PR DESCRIPTION
The issue has been fixed the menu button is now focusable on pressing `tab` from the keyboard.
The menu button is focusable from the keyboard by pressing the Tab button. 
![Screenshot (1)](https://github.com/django/djangoproject.com/assets/75746412/9a975465-ef9a-4b9d-8bb8-9514041136bc)
We can open the options from the keyboard by pressing Enter button
![Screenshot (2)](https://github.com/django/djangoproject.com/assets/75746412/d55ed508-0a55-47fd-94f5-e4794967a4d7)
