### PR TITLE
fix: Install g++ to fix libsass build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
 COPY ./requirements ./requirements
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
+        g++ \
         gcc \
         libc6-dev \
         libpq-dev \


### PR DESCRIPTION
This fixes #1407 and with g++ libsass can be installed.