### PR TITLE
Fixed libsass link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ Styles
 ------
 
 CSS is written in `Scss <http://sass-lang.com/>`_ and compiled via
-`Libsass <http://libsass.org/>`_.
+`Libsass <https://sass-lang.com/libsass/>`_.
 
 Run the following to compile the Scss files to CSS::
 


### PR DESCRIPTION
At some point in this year (based on the snapshots in web.archive.org) the http://libsass.org domain stopped rediredirecting to https://sass-lang.com/libsass and became some type of gambling related website.