### PR TITLE
Fix #1409 -- Add Keyboard Accessibility To Hamburger Menu

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -526,7 +526,7 @@ blockquote {
     .menu-button {
         @include font-size(20);
         background: $green-dark;
-        border-radius: 23px;
+        border: 0;
         color: var(--menu);
         cursor: pointer;
         display: block;

--- a/djangoproject/static/js/mod/mobile-menu.js
+++ b/djangoproject/static/js/mod/mobile-menu.js
@@ -12,7 +12,7 @@ define([
         init: function(){
             var self = this;
             self.menu.addClass('nav-menu-on');
-            self.button = $('<div class="menu-button"><i class="icon icon-reorder"></i><span>Menu</span></div>');
+            self.button = $('<button class="menu-button"><i class="icon icon-reorder"></i><span>Menu</span></button>');
             self.button.insertBefore(self.menuBtn);
             self.button.on( 'click', function(){
                 self.menu.toggleClass('active');


### PR DESCRIPTION
Fix for #1409 

This changes the menu button from a `div` to a `button` element so the keyboard is able to tab to it. The border is set to 0 to override the default button border style.


Before - It wasn't able to tab to the menu button
![Screenshot from 2023-10-20 06-33-11](https://github.com/django/djangoproject.com/assets/82607723/7701320b-cc61-4fdd-8fbb-5f3e8f34408d)

After - It is able to tab to the menu button with the red border around it
![Screenshot from 2023-10-20 08-11-08](https://github.com/django/djangoproject.com/assets/82607723/dfa3a0bf-3bc1-4c6a-9c34-5dacd5790276)


### Other notes
- [ ] ~When you tab to the menu it should be obvious you're on it (look how the dark mode button works), probably using css :focus selector~ It already shows a red outline when you tab to it.
- [ ] ~When you hit space it should activate, again like the dark mode toggle~ It already does open/close the menu when you hit SPACE or ENTER.
- [ ] When the menu is open, the first time we press the tab key, it should bring the focus to the first menu item on the list. Right now it jumps to the light/dark theme button.
- [ ] Should the menu button be in a nav element?
- [ ] Should there be aria-expanded and aria-label attributes on the menu button?
- [ ] When the menu is closed and you hit tab, should the focus go first to the light/dark theme button, and then to the menu button?