### PR TITLE
Fixed #1401 - Django utils Section link overflow

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2517,6 +2517,7 @@ dt {
         // for docs links. if we keep text-decoration, then underscores in function names become invisible.
         color: var(--error-dark);
         text-decoration: none;
+        overflow-wrap: break-word;
         border-bottom: 1px dotted var(--text-light);
 
         &:visited {


### PR DESCRIPTION
Added overflow-wrap in ```#docs-content a.reference``` to fix the overflow of links
### Before
![image](https://github.com/django/djangoproject.com/assets/104075614/bd738f57-82f0-4e29-a597-32904ce01a4e)
### After
![image](https://github.com/django/djangoproject.com/assets/104075614/88cde45a-625b-4f33-b188-6e7daf88f138)

