### PR TITLE
Fix SameSite cookie issue for dark mode

### DIFF
--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -78,11 +78,13 @@
 		}
 	}
 
-	function setCookie(cname, cvalue, domain, exdays) {
+	function setCookie(cname, cvalue, domain) {
 		const d = new Date();
-		d.setTime(d.getTime() + (exdays*24*60*60*1000));
+		d.setTime(d.getTime() + (365*24*60*60*1000)); // 1 year
 		let expires = "expires="+ d.toUTCString();
-		document.cookie = `${cname}=${cvalue}; Domain=${domain}; ${expires};path=/`;
+        // change the SameSite attribute if it's on development or production
+        sameSiteAttribute = domain == 'localhost' ? 'SameSite=Lax;' : `Domain=${domain}; SameSite=None; Secure;`
+		document.cookie = `${cname}=${cvalue}; ${sameSiteAttribute} ${expires}; path=/;`;
 	}
 
 	function getCookie(cname) {


### PR DESCRIPTION
Prior to this change, we can't change the dark mode multiple times due to the new property [SameSite](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) missing. 

This change add the property `SameSite` and the attribute `Secure` with it's for production purpose. 
It also corrects the expiration of the cookie.