### PR TITLE
Fix #1276: Add copy to clipboard icon for commands

### DIFF
--- a/djangoproject/scss/_console-tabs.scss
+++ b/djangoproject/scss/_console-tabs.scss
@@ -44,4 +44,17 @@
     >.c-tab-win:checked~.c-content-win {
         display: block;
     }
+    >.c-content-win, >.c-content-unix .highlight-console{
+        .highlight{
+            display: flex;
+            justify-content: space-between;
+
+            .btn-clipboard{
+                float: right;
+                position: sticky;
+                cursor: pointer;
+                margin: 15px;
+            }
+        }
+    }
 }

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -98,7 +98,7 @@ define(function() {
         mods.push('mod/messages');
     }
 
-    if (hasClass('code-block-caption') || hasClass('snippet')) {
+    if (hasClass('code-block-caption') || hasClass('snippet') || hasClass('c-content-unix') || hasClass('c-content-win')){
         mods.push('mod/clippify');
     }
 

--- a/djangoproject/static/js/mod/clippify.js
+++ b/djangoproject/static/js/mod/clippify.js
@@ -8,6 +8,16 @@ define(['jquery', 'clipboard'], function($, Clipboard) {
         btn.data('clipboard-text', $.trim(code.text()));
         header.append(btn);
     });
+    $('.c-content-win, .c-content-unix').each(function() {
+        var header = $(this);
+        var code = $('.highlight', header);
+        // Check if the icon has already been added
+        var btn = $('<span class="btn-clipboard" title="Copy this code">');
+        btn.append('<i class="icon icon-clipboard">');
+        btn.data('clipboard-text', $.trim(code.clone().find('.gp, .go').remove().end().text()));
+        code.append(btn);
+    });
+    
     // For Django 2.0 docs and older.
     $('.snippet').each(function() {
         var code = $('.highlight', this);


### PR DESCRIPTION
- Fixes #1276 
- This fix utilizes the existing copy to clipboard icon.


## Screenshots for reference

Before:
![image](https://github.com/django/djangoproject.com/assets/44068293/dcdb0388-df4b-4707-94b4-7691b8897899)

After:
- Light Theme (Windows):
![image](https://github.com/django/djangoproject.com/assets/44068293/f4ef216f-eedb-4f12-a0d5-d7e446dac825)

- Light Theme (Linux/Mac) 
![image](https://github.com/django/djangoproject.com/assets/44068293/4536de9d-cd68-42f7-b5e5-d3a6301f291b)

- Dark Theme (Linux/Mac)
![image](https://github.com/django/djangoproject.com/assets/44068293/b2663fcb-4fc7-4fbc-b649-6de97a32da46)

- Dark Theme (Windows)
![image](https://github.com/django/djangoproject.com/assets/44068293/f544871c-6096-4501-be1e-606446c86096)


- Copied Message
 ![image](https://github.com/django/djangoproject.com/assets/44068293/b67e00bd-936e-4b94-b8bd-446533b746dc)
