### PR TITLE
Upgraded django-contact-form to 2.1.

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -3,11 +3,11 @@ import logging
 import django
 from captcha.fields import ReCaptchaField
 from captcha.widgets import ReCaptchaV3
-from contact_form.forms import ContactForm
 from django import forms
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.utils.encoding import force_bytes
+from django_contact_form.forms import ContactForm
 from pykismet3 import Akismet, AkismetServerError
 
 logger = logging.getLogger(__name__)

--- a/contact/views.py
+++ b/contact/views.py
@@ -1,5 +1,5 @@
-from contact_form.views import ContactFormView
 from django.urls import reverse
+from django_contact_form.views import ContactFormView
 
 from .forms import FoundationContactForm
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
 Babel==2.10.1
-django-contact-form==1.9
+django-contact-form==2.1
 django-countries==7.5.1
 django-hosts==5.1
 django-money==2.1.1


### PR DESCRIPTION
Django 4.2 is supported officially from 2.1 (also supports 3.2 🙂)
Ref: https://github.com/django/djangoproject.com/issues/1437

Migration guide: https://django-contact-form.readthedocs.io/en/latest/upgrade.html#changes-between-django-contact-form-1-x-and-2-x

Impact rename of contact_form to django_contact_form