### PR TITLE
Fixed #1276 -- Added copy buttons to console and shell commands.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3624,6 +3624,11 @@ ul.corporate-members li {
 }
 
 .code-block-caption,
+.highlight-console,
+.c-content-win,
+.highlight-shell,
+.highlight-doscon,
+.literal-block,
 .snippet {
     .btn-clipboard {
         float: right;

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -98,7 +98,13 @@ define(function() {
         mods.push('mod/messages');
     }
 
-    if (hasClass('code-block-caption') || hasClass('snippet')) {
+    if (hasClass('code-block-caption') ||
+        hasClass('snippet') ||
+        hasClass('highlight-console') ||
+        hasClass('c-content-win') ||
+        hasClass('highlight-shell') ||
+        hasClass('highlight-doscon') ||
+        hasClass('literal-block')) {
         mods.push('mod/clippify');
     }
 

--- a/djangoproject/static/js/mod/clippify.js
+++ b/djangoproject/static/js/mod/clippify.js
@@ -1,13 +1,27 @@
 define(['jquery', 'clipboard'], function($, Clipboard) {
-    $('.code-block-caption').each(function() {
-        var header = $(this);
-        var wrapper = header.parent();
-        var code = $('.highlight', wrapper);
+    function addCopyButton(btnParent, code){
         var btn = $('<span class="btn-clipboard" title="Copy this code">');
         btn.append('<i class="icon icon-clipboard">');
-        btn.data('clipboard-text', $.trim(code.text()));
-        header.append(btn);
+        btn.data('clipboard-text', $.trim(code));
+        btnParent.prepend(btn);
+    };
+    $('.code-block-caption').each(function(){
+        var header = $(this);
+        var wrapper = header.parent();
+        var codeBlock = $('pre', wrapper);
+        addCopyButton(header, codeBlock.text())
     });
+    $('.highlight-console, .c-content-win, .highlight-shell, .highlight-doscon').each(function(){
+        var codeBlock = $('pre', this);
+        var clone = $(codeBlock).clone();
+        $('.gp, .go', clone).remove();
+        addCopyButton(codeBlock, clone.text());
+    });
+    $('#download .literal-block').each(function () {
+        var codeBlock = $(this);
+        addCopyButton(codeBlock, codeBlock.text());
+    });
+
     // For Django 2.0 docs and older.
     $('.snippet').each(function() {
         var code = $('.highlight', this);


### PR DESCRIPTION
Fixes #1276 

Although there is a PR pending, added one as well, hope it's okay.

Added copy buttons for console and shell commands. Also added copy buttons on the Download page.
Minimum code changes, no new styles added, button adding functionality is moved to a separate function, so it can be further reused with different code blocks.

![test](https://github.com/django/djangoproject.com/assets/23117124/500d8538-3eaa-4356-bcea-ffb9f7c79c4c)

Comments aren't copied (like in an example below), nor are the promts.
![12023-12-06_21-30](https://github.com/django/djangoproject.com/assets/23117124/f4017871-98f1-4561-9f71-4101da938bba)
