### PR TITLE
Fixed #1453 -- Fixed code block indentantion on the Getting started page.

### DIFF
--- a/djangoproject/templates/start.html
+++ b/djangoproject/templates/start.html
@@ -69,26 +69,32 @@
       <div class="collapsing-content">
         <p>Deﬁne your data models entirely in Python. You get a rich, dynamic database-access API for free — but you can still write SQL if needed.</p>
         <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='topics/db/models' host 'docs' %}">Read more</a>
+        {# fmt:off #}
         {% pygment 'python' %}
-          from django.db import models
+from django.db import models
 
-          class Band(models.Model):
-          """A model of a rock band."""
-          name = models.CharField(max_length=200)
-          can_rock = models.BooleanField(default=True)
 
-          class Member(models.Model):
-          """A model of a rock band member."""
-          name = models.CharField("Member's name", max_length=200)
-          instrument = models.CharField(choices=(
-          ('g', "Guitar"),
-          ('b', "Bass"),
-          ('d', "Drums"),
-          ),
-          max_length=1
-          )
-          band = models.ForeignKey("Band")
-        {% endpygment %}
+class Band(models.Model):
+    """A model of a rock band."""
+
+    name = models.CharField(max_length=200)
+    can_rock = models.BooleanField(default=True)
+
+
+class Member(models.Model):
+    """A model of a rock band member."""
+
+    name = models.CharField("Member's name", max_length=200)
+    instrument = models.CharField(
+        choices=(
+            ("g", "Guitar"),
+            ("b", "Bass"),
+            ("d", "Drums"),
+        ),
+        max_length=1,
+    )
+    band = models.ForeignKey("Band"){% endpygment %}
+        {# fmt:on #}
       </div>
     </li>
     <li>
@@ -97,26 +103,27 @@
         <p>A clean, elegant URL scheme is an important detail in a high-quality web application. Django encourages beautiful URL design and doesn’t put any cruft in URLs, like .php or .asp.</p>
         <p>To design URLs for an application, you create a Python module called a URLconf. Like a table of contents for your app, it contains a simple mapping between URL patterns and your views.</p>
         <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='topics/http/urls' host 'docs' %}">Read more</a>
+        {# fmt:off #}
         {% pygment 'python' %}
-          from django.urls import path
+from django.urls import path
 
-          from . import views
+from . import views
 
-          urlpatterns = [
-          path('bands/', views.band_listing, name='band-list'),
-          path('bands/<int:band_id>/', views.band_detail, name='band-detail'),
-            path('bands/search/', views.band_search, name='band-search'),
-            ]
-        {% endpygment %}
+urlpatterns = [
+    path("bands/", views.band_listing, name="band-list"),
+    path("bands/<int:band_id>/", views.band_detail, name="band-detail"),
+    path("bands/search/", views.band_search, name="band-search"),
+]{% endpygment %}
         {% pygment 'python' %}
-          from django.shortcuts import render
-          from bands.models import Band
+from bands.models import Band
+from django.shortcuts import render
 
-          def band_listing(request):
-          """A view of all bands."""
-          bands = Band.objects.all()
-          return render(request, 'bands/band_listing.html', {'bands': bands})
-        {% endpygment %}
+
+def band_listing(request):
+    """A view of all bands."""
+    bands = Band.objects.all()
+    return render(request, "bands/band_listing.html", {"bands": bands}){% endpygment %}
+        {# fmt:on #}
       </div>
     </li>
     <li>
@@ -142,9 +149,7 @@
     {% endfor %}
     </ul>
   </body>
-</html>
-{% endverbatim %}
-        {% endpygment %}
+</html>{% endverbatim %}{% endpygment %}
       </div>
     </li>
     <li>
@@ -152,15 +157,17 @@
       <div class="collapsing-content">
         <p>Django provides a powerful form library that handles rendering forms as HTML, validating user-submitted data, and converting that data to native Python types. Django also provides a way to generate forms from your existing models and use those forms to create and update data.</p>
         <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='topics/forms' host 'docs' %}">Read more</a>
-        {% pygment 'python'%}
-          from django import forms
+        {# fmt:off #}
+        {% pygment 'python' %}
+from django import forms
 
-          class BandContactForm(forms.Form):
-          subject = forms.CharField(max_length=100)
-          message = forms.CharField()
-          sender = forms.EmailField()
-          cc_myself = forms.BooleanField(required=False)
-        {% endpygment %}
+
+class BandContactForm(forms.Form):
+    subject = forms.CharField(max_length=100)
+    message = forms.TextField()
+    sender = forms.EmailField()
+    cc_myself = forms.BooleanField(required=False){% endpygment %}
+        {# fmt:on #}
       </div>
     </li>
     <li>
@@ -168,15 +175,17 @@
       <div class="collapsing-content">
         <p>Django comes with a full-featured and secure authentication system. It handles user accounts, groups, permissions and cookie-based user sessions. This lets you easily build sites that allow users to create accounts and safely log in/out.</p>
         <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='topics/auth' host 'docs' %}">Read more</a>
+        {# fmt:off #}
         {% pygment 'python' %}
-          from django.contrib.auth.decorators import login_required
-          from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
 
-          @login_required
-          def my_protected_view(request):
-          """A view that can only be accessed by logged-in users"""
-          return render(request, 'protected.html', {'current_user': request.user})
-        {% endpygment %}
+
+@login_required
+def my_protected_view(request):
+    """A view that can only be accessed by logged-in users"""
+    return render(request, "protected.html", {"current_user": request.user}){% endpygment %}
+        {# fmt:on #}
       </div>
     </li>
     <li>
@@ -184,18 +193,21 @@
       <div class="collapsing-content">
         <p>One of the most powerful parts of Django is its automatic admin interface. It reads metadata in your models to provide a powerful and production-ready interface that content producers can immediately use to start managing content on your site. It’s easy to set up and provides many hooks for customization.</p>
         <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='ref/contrib/admin' host 'docs' %}">Read more</a>
+        {# fmt:off #}
         {% pygment 'python' %}
-          from django.contrib import admin
-          from bands.models import Band, Member
+from bands.models import Band, Member
+from django.contrib import admin
 
-          class MemberAdmin(admin.ModelAdmin):
-          """Customize the look of the auto-generated admin for the Member model"""
-          list_display = ('name', 'instrument')
-          list_filter = ('band',)
 
-          admin.site.register(Band)  # Use the default options
-          admin.site.register(Member, MemberAdmin)  # Use the customized options
-        {% endpygment %}
+class MemberAdmin(admin.ModelAdmin):
+    """Customize the look of the auto-generated admin for the Member model"""
+
+    list_display = ("name", "instrument")
+    list_filter = ("band",)
+
+    admin.site.register(Band)  # Use the default options
+    admin.site.register(Member, MemberAdmin)  # Use the customized options{% endpygment %}
+        {# fmt:on #}
       </div>
     </li>
     <li>
@@ -203,20 +215,20 @@
       <div class="collapsing-content">
         <p>Django offers full support for translating text into different languages, plus locale-specific formatting of dates, times, numbers, and time zones. It lets developers and template authors specify which parts of their apps should be translated or formatted for local languages and cultures, and it uses these hooks to localize web applications for particular users according to their preferences.</p>
         <a class="link-readmore" href="{% url 'document-detail' lang='en' version='stable' url='topics/i18n' host 'docs' %}">Read more</a>
-
+        {# fmt:off #}
         {% pygment 'python' %}
-          from django.shortcuts import render
-          from django.utils.translation import gettext
+from django.shortcuts import render
+from django.utils.translation import gettext
 
-          def homepage(request):
-          """
-          Shows the homepage with a welcome message that is translated in the
-          user's language.
-          """
-          message = gettext('Welcome to our site!')
-          return render(request, 'homepage.html', {'message': message})
-        {% endpygment %}
 
+def homepage(request):
+    """
+    Shows the homepage with a welcome message that is translated in the
+    user's language.
+    """
+    message = gettext("Welcome to our site!")
+    return render(request, "homepage.html", {"message": message}){% endpygment %}
+        {# fmt:on #}
       {# No need to escape the HTML: pygment takes care of that #}
         {% pygment 'django' %}
 {% verbatim %}
@@ -244,9 +256,7 @@
     {% endfor %}
     </ul>
   </body>
-</html>
-{% endverbatim %}
-        {% endpygment %}
+</html>{% endverbatim %}{% endpygment %}
       </div>
     </li>
     <li>


### PR DESCRIPTION
# Description

This fixes code blocks on www.djangoproject.com/start page not displaying with correct Python indentation (and includes my best guess at correct PEP8 styling).

Fixes https://github.com/django/djangoproject.com/issues/1453

## Fix

The DjHTML code indenter was automatically changing the indentation for the code blocks which were colorised by `{% pygment 'python' %}`. This led to incorrectly formatted Python code which would neither pass a Python interpreter's indentation checks or conform to PEP8.

The DjHTML indenter can be temporarily turned off for certain lines by making use of `{# fmt:off #}` and `{# fmt:on #}`. This is the method I think works best in this specific use-case. See https://github.com/rtts/djhtml#fmtoff-and-fmton.

### \<pre/> vs fmt:off

The DjHTML indentation can also be stopped from being applied by using `<pre>` tags. However, the `<pre>` tags cause lots of extra vertical whitespace on the website so I feel just disabling the formatter is the better way to go.

If pre tags are included within the pygment block then they get treated as plain text instead of markup.
If pre tags wrap the pygment block then the newlines at the end of the open and close pygment lines lead to the increased vertical white space since whitespace is preserved 

## Screenshots

I have the current djangoproject.com/start/ page vs this PR's djangoproject/start/ page visualised side-by-side.
Old on the left, new on the right.

### Admin section

<img width="1728" alt="admin" src="https://github.com/django/djangoproject.com/assets/134723582/1389454e-0219-41dd-b7d3-cd7155ae83c4">

### Forms and Authentications sections
<img width="1728" alt="forms-and-authentication" src="https://github.com/django/djangoproject.com/assets/134723582/26beb210-c68b-4800-8e94-8b0e974fd78d">

### Internationalisation section

<img width="1728" alt="internationalisation" src="https://github.com/django/djangoproject.com/assets/134723582/53980046-34d0-41d4-bff3-52cc9c1a7589">

### Object Relational Mapper section
<img width="1728" alt="object-relational-mapper" src="https://github.com/django/djangoproject.com/assets/134723582/1c791df2-2166-4c5e-a5cf-d4ec2f9b570e">

### URLs and Views section

<img width="1728" alt="urls-and-views" src="https://github.com/django/djangoproject.com/assets/134723582/d786ce98-3083-4d6e-93e5-fd9cc9cb6270">


