### PR TITLE
Allow using formatted text for ongoing business in DSF meeting minutes

### DIFF
--- a/djangoproject/templates/foundation/meeting_detail.html
+++ b/djangoproject/templates/foundation/meeting_detail.html
@@ -75,7 +75,7 @@
     {% for business in ongoing_business %}
       <h3>{{ business.title }}</h2>
 
-      {{ business.body|safe }}
+      {{ business.body_html|safe }}
     {% endfor %}
   {% endif %}
 


### PR DESCRIPTION
`body_html` contains the markup, `body` is only the plain-text source. This matches how `new_business` renders a few lines below.