### PR TITLE
Update individual membership page

### DIFF
--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -44,7 +44,7 @@
     </li>
     <li>
       {% blocktrans %}
-        Serving on a <a href="https://github.com/django/dsf-working-groups">DSF Working Group</a>
+        Serving on a <a href="https://github.com/django/dsf-working-groups">DSF Working Group</a>.
       {% endblocktrans %}
     </li>
   </ul>

--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -34,7 +34,7 @@
     </li>
     <li>
       {% blocktrans %}
-        Contributing to discussionsin community areas such as the <a href="https://forum.djangoproject.com/">Django Forum</a> or <a href="https://discord.com/invite/xcRH6mN4fa">Discord</a>.
+        Contributing to discussions in community areas such as the <a href="https://forum.djangoproject.com/">Django Forum</a> or <a href="https://discord.com/invite/xcRH6mN4fa">Discord</a>.
       {% endblocktrans %}
     </li>
     <li>

--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -5,26 +5,61 @@
   <h1>{% trans "Individual members" %}</h1>
   <p>
     {% blocktrans %}
-      Individual Members are appointed by the DSF in recognition of their service to the Django community.
-
-      Service to the Django community takes many forms. Here are some non-exhaustive examples of the categories of work that might qualify as service:
-
-      <ul>
-        <li>Code contributions on Django projects or major third-party packages in the Django ecosystem</li>
-        <li>Reviewing pull requests or triaging Django project tickets</li>
-        <li>Documentation, tutorials or blog posts related to Django</li>
-        <li>Discussions about Django in community areas such as the django-developers mailing list and Django Forum</li>
-        <li>Attending or organizing Django-related events or user groups</li>
-      </ul>
-
-      If you would like to apply for Individual Membership, please
+      Individual Members are appointed by the DSF in recognition of their contribution to the DSF's mission of advancing and promoting Django, protecting the framework's long-term viability, and advancing the state of the art in web development.
     {% endblocktrans %}
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSd5lbWxAO-sylEEjHVKBNIpmHlhdJRf0_LCo8glnLUWd-Q2Sw/viewform?usp=sf_link">{% trans "fill out this form" %}</a>.
   </p>
 
   <p>
     {% blocktrans %}
-      You can also nominate others if you know someone who should be considered. If you are unsure if you meet the criteria, but you would like to be a member, please apply. If you're not accepted, you will receive a response with information about how you can successfully apply in the future.
+      Contribution to the DSF's mission takes many forms. 
+      Here are some non-exhaustive examples of the categories of work that might qualify:
+    {% endblocktrans %}
+  </p>
+
+  <ul>
+    <li>
+      {% blocktrans %}
+        Contributing code, documentation, or tests to Django or to major third-party packages in the Django ecosystem.
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        Reviewing pull requests or triaging tickets on Django or a third-party app.
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        Creating learning resources (blogs, videos, etc.) for people to learn Django.
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        Contributing to discussionsin community areas such as the <a href="https://forum.djangoproject.com/">Django Forum</a> or <a href="https://discord.com/invite/xcRH6mN4fa">Discord</a>.
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        Being part of the organizing team for a Django community event.
+      {% endblocktrans %}
+    </li>
+    <li>
+      {% blocktrans %}
+        Serving on a <a href="https://github.com/django/dsf-working-groups">DSF Working Group</a>
+      {% endblocktrans %}
+    </li>
+  </ul>
+
+  <p>
+    {% blocktrans %}
+      For more information about membership, see <a href="faq/">the DSF membership FAQ</a>.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans %}
+      If you would like to apply for Individual Membership, please <a href="https://docs.google.com/forms/d/e/1FAIpQLSd5lbWxAO-sylEEjHVKBNIpmHlhdJRf0_LCo8glnLUWd-Q2Sw/viewform?usp=sf_link">fill out this form</a>.
+      If you are unsure if you meet the criteria, but you would like to be a member, please apply anyway!
+      You can also nominate others using the same form if you know someone who should be considered.
     {% endblocktrans %}
   </p>
 

--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -11,7 +11,7 @@
 
   <p>
     {% blocktrans %}
-      Contribution to the DSF's mission takes many forms. 
+      Contribution to the DSF's mission takes many forms.
       Here are some non-exhaustive examples of the categories of work that might qualify:
     {% endblocktrans %}
   </p>


### PR DESCRIPTION
This updates the membership page with the new membership rules/criteria (blog post forthcoming).

The FAQ is managed as a flatpage, so isn't part of this change.
