### PR TITLE
Removed usage of Python's deprecated distutils.version package.

### DIFF
--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -1,7 +1,6 @@
-from distutils.version import StrictVersion
-
 from django import template
 from django.utils.safestring import mark_safe
+from django.utils.version import get_version_tuple
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
@@ -46,7 +45,7 @@ def get_all_doc_versions(context, url=None):
                 versions.append(release.version)
 
     # Save the versions into the context
-    versions = sorted(StrictVersion(x) for x in versions if x != "dev")
+    versions = sorted(get_version_tuple(x) for x in versions if x != "dev")
     return [str(x) for x in versions] + ["dev"]
 
 

--- a/releases/models.py
+++ b/releases/models.py
@@ -1,11 +1,12 @@
 import datetime
-from distutils.version import LooseVersion
 
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.version import get_complete_version, get_main_version
+
+from .utils import get_loose_version_tuple
 
 
 # A version of django.utils.version.get_version() which maps "rc" to "rc"
@@ -198,7 +199,7 @@ class Release(models.Model):
     def version_tuple(self):
         """Return a tuple in the format of django.VERSION."""
         version = self.version.replace("-", "").replace("_", "")
-        version = LooseVersion(version).version
+        version = list(get_loose_version_tuple(version))
         if len(version) == 2:
             version.append(0)
         if not isinstance(version[2], int):

--- a/releases/templatetags/release_notes.py
+++ b/releases/templatetags/release_notes.py
@@ -1,18 +1,17 @@
-from distutils.version import LooseVersion
-
 from django import template
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 from django_hosts.resolvers import reverse
 
 from ..models import Release
+from ..utils import get_loose_version_tuple
 
 register = template.Library()
 
 
 @register.simple_tag()
 def release_notes(version, show_version=False):
-    version_x_dot_y = ".".join(str(x) for x in LooseVersion(version).version[:2])
+    version_x_dot_y = ".".join(str(x) for x in get_loose_version_tuple(version)[:2])
     is_pre_release = any(c in version for c in ("a", "b", "c"))
     # links for prereleases don't have their own release notes
     display_version = version_x_dot_y if is_pre_release else version

--- a/releases/utils.py
+++ b/releases/utils.py
@@ -1,0 +1,19 @@
+from django.utils.regex_helper import _lazy_re_compile
+
+version_component_re = _lazy_re_compile(r"(\d+|[a-z]+|\.)")
+
+
+def get_loose_version_tuple(version):
+    """
+    Return a tuple of version numbers (e.g. (1, 2, 3, 'b', 2)) from the version
+    string (e.g. '1.2.3b2').
+    """
+    version_numbers = []
+    for item in version_component_re.split(version):
+        if item and item != ".":
+            try:
+                component = int(item)
+            except ValueError:
+                component = item
+            version_numbers.append(component)
+    return tuple(version_numbers)


### PR DESCRIPTION
The distutils package was formally deprecated in Python 3.10 and removed in Python 3.12.