### PR TITLE
Add a link to Corporate membership in the site footer

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -58,6 +58,7 @@
           <h2>Support Us</h2>
           <ul>
             <li><a href="{% url "fundraising:index" %}">Sponsor Django</a></li>
+            <li><a href="/foundation/corporate-membership/">Corporate membership</a></li>
             <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a></li>
             <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving Program</a></li>
           </ul>


### PR DESCRIPTION
This [Corporate membership](https://www.djangoproject.com/foundation/corporate-membership/) page is hard to find currently even if you know it exists. From Catherine Holmes on the DSF Slack:

> The only way I know from the [Fundraising](https://www.djangoproject.com/fundraising/) page to get to the corporate members is to scroll down to the corporate members and click on "corporate members" 

I can’t find the link to this page even with Catherine’s instructions, so it feels like a footer link would definitely help.