### PR TITLE
Fixed favicon URLs in search description.

### DIFF
--- a/docs/templates/docs/search_description.xml
+++ b/docs/templates/docs/search_description.xml
@@ -5,8 +5,8 @@
   <Description>{% blocktrans with version=release.human_version %}Search Django {{ version }} documentation{% endblocktrans %}</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <OutputEncoding>UTF-8</OutputEncoding>
-  <Image width="16" height="16" type="image/x-icon">https://{{ site.domain }}{% static "img/favicon.ico" %}</Image>
-  <Image width="32" height="32" type="image/x-icon">https://{{ site.domain }}{% static "img/favicon.ico" %}</Image>
+  <Image width="16" height="16" type="image/x-icon">{% static "img/favicon.ico" %}</Image>
+  <Image width="32" height="32" type="image/x-icon">{% static "img/favicon.ico" %}</Image>
   <Query role="example" searchTerms="testing" />
   <Developer>{% trans "Django team" %}</Developer>
   <SyndicationRight>open</SyndicationRight>


### PR DESCRIPTION
Fixes the url of the [OpenSearch](https://docs.djangoproject.com/en/5.0/search/description/) favicon (currently something like `https://www.djangoproject.comhttps://static.djangoproject.com/img/favicon.6dbf28c0650e.ico`), keeping only the url of the static file.