### PR TITLE
Fix table style for foundation flatpage

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2608,6 +2608,19 @@ dl.data {
     }
 }
 
+.table-wrapper {
+    // This class is used to avoid the table exceeds the size of the content
+    // and add a scrollbar to see the rest of the content in mobile
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    overflow: auto;
+    white-space: normal;
+}
+
+table.foundation td {
+    border-bottom: 1px solid var(--hairline-color);
+    padding: 0 5px;
+}
 
 table.docutils td,
 table.docutils th {


### PR DESCRIPTION
Prior to this change, the foundation page have 2 tables with previous boards which are not responsive and hard to distinguish rows in mobile.

This change add two CSS classes which fixes this issue.

## Screenshots 📷 
### BEFORE
<img width="430" alt="Capture d’écran 2024-01-16 à 01 52 27" src="https://github.com/django/djangoproject.com/assets/17890338/ce729ee3-fbb5-4dc0-9e73-bf75b1f29cdb">
<img width="430" alt="Capture d’écran 2024-01-16 à 01 52 45" src="https://github.com/django/djangoproject.com/assets/17890338/11fa3fcb-c8e7-4be9-af5e-4ace3c5391bb">

### AFTER
**Dark Mode**
<img width="431" alt="Capture d’écran 2024-01-16 à 01 41 21" src="https://github.com/django/djangoproject.com/assets/17890338/4a0c0883-0df1-460f-a4b9-6e5a6615a17b">
<img width="430" alt="Capture d’écran 2024-01-16 à 01 41 28" src="https://github.com/django/djangoproject.com/assets/17890338/e2316555-15a8-47a6-a39a-71f03720ba18">
<img width="430" alt="Capture d’écran 2024-01-16 à 01 41 42" src="https://github.com/django/djangoproject.com/assets/17890338/3b1b86b9-8adc-4623-a71c-00fc97c4387b">

**Light Mode**
<img width="430" alt="Capture d’écran 2024-01-16 à 01 44 52" src="https://github.com/django/djangoproject.com/assets/17890338/734884af-d36e-4c5f-b704-3f9d0686252e">
<img width="430" alt="Capture d’écran 2024-01-16 à 01 46 03" src="https://github.com/django/djangoproject.com/assets/17890338/1c98ad2c-e194-470e-876a-3241335a9b28">
