### PR TITLE
 #1470 - remove Django powered sites

### DIFF
--- a/djangoproject/templates/base_community.html
+++ b/djangoproject/templates/base_community.html
@@ -44,8 +44,6 @@
     <dl class="list-links">
       <dt><a href="https://www.djangopackages.com/" rel="nofollow">Django Packages</a></dt>
       <dd>Find third-party packages to supercharge your project</dd>
-      <dt><a href="https://www.djangosites.org/" rel="nofollow">Django-powered Sites</a></dt>
-      <dd>Add your site to the list</dd>
       <dt><a href="/community/badges/">Django Badges</a></dt>
       <dd>Show your support (or wish longingly)</dd>
       <dt><a href="/community/logos/">Django Logos</a></dt>


### PR DESCRIPTION
I've addressed the issue #1470 and removed Django powered sites which caused django website to shutdown.