### PR TITLE
#1474 Fixed links to subsections in the Local Django Communities page

### DIFF
--- a/djangoproject/templates/aggregator/local-django-community.html
+++ b/djangoproject/templates/aggregator/local-django-community.html
@@ -8,21 +8,21 @@
 
   <h2>Local Django Communities</h2>
 
-  {% if grouped_django_communities %}<h3>Table of contents<a class="plink" href="#table-of-contents"> ¶</a></h3>{% endif %}
+  {% if grouped_django_communities %}<h3 id="table-of-contents">Table of contents<a class="plink" href="#table-of-contents"> ¶</a></h3>{% endif %}
   <ul>
     {% for local_django_community in grouped_django_communities %}
-      <li><a href="#{{ local_django_community.grouper.title }}-meetups">{{ local_django_community.grouper.title }}</a></li>
+      <li><a href="#{{ local_django_community.grouper.title | lower }}-meetups">{{ local_django_community.grouper.title }}</a></li>
     {% endfor %}
   </ul>
 
 
   {% for local_django_community in grouped_django_communities %}
-    <div class="section">
+    <div id="{{ local_django_community.grouper.title | lower }}-meetups" class="section">
       <h2>{{ local_django_community.grouper.title }} <a class="plink" href="#{{ local_django_community.grouper.title | lower }}-meetups">¶</a></h2>
       <ul>
         {% for django_community in local_django_community.list %}
           <li>
-            <h3 id="{{ django_community.slug }}-team">{{ django_community.name }} <a class="plink" href="#{{ django_community.slug }}-meetup">¶</a></h3>
+            <h3 id="{{ django_community.slug }}-meetup">{{ django_community.name }} <a class="plink" href="#{{ django_community.slug }}-meetup">¶</a></h3>
             <p class="meta">{{ django_community.city }}, {{ django_community.country }} &nbsp;
               {% if django_community.is_active %}
                 Active


### PR DESCRIPTION
### Summary
The "Local Django Communities" [page](https://www.djangoproject.com/community/local/) contains some missing ids in the HTML  which makes the sections unreachable. I have added the relevant ids in HTML tags which fixes all the links.
Fixes #1474 