### PR TITLE
Upgraded to django-recaptcha 4.0.0 (third time's the charm 🍀 )

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -1,13 +1,13 @@
 import logging
 
 import django
-from captcha.fields import ReCaptchaField
-from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.utils.encoding import force_bytes
 from django_contact_form.forms import ContactForm
+from django_recaptcha.fields import ReCaptchaField
+from django_recaptcha.widgets import ReCaptchaV3
 from pykismet3 import Akismet, AkismetServerError
 
 logger = logging.getLogger(__name__)

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -70,7 +70,7 @@ INSTALLED_APPS = [
     "svntogit",
     "tracdb",
     "fundraising",
-    "captcha",
+    "django_recaptcha",
     "registration",
     "django_hosts",
     "sorl.thumbnail",

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -63,4 +63,4 @@ if DEBUG:
             "djangoproject.middleware.CORSMiddleware",
         )
 
-SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
+SILENCED_SYSTEM_CHECKS = ["django_recaptcha.recaptcha_test_key_error"]

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -14,7 +14,7 @@ DATABASES = {
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
-    "captcha.recaptcha_test_key_error"  # Default test keys for development.
+    "django_recaptcha.recaptcha_test_key_error"  # Default test keys for development.
 ]
 
 ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -86,7 +86,7 @@ if "sentry_dsn" in SECRETS and not DEBUG:
     )
 
 # RECAPTCHA KEYS
-# Defaults will trigger 'captcha.recaptcha_test_key_error' system check
+# Defaults will trigger 'django_recaptcha.recaptcha_test_key_error' system check
 if "recaptcha_public_key" in SECRETS:
     RECAPTCHA_PUBLIC_KEY = SECRETS.get("recaptcha_public_key")
     RECAPTCHA_PRIVATE_KEY = SECRETS.get("recaptcha_private_key")

--- a/djangoproject/static/js/mod/stripe-donation.js
+++ b/djangoproject/static/js/mod/stripe-donation.js
@@ -3,13 +3,10 @@ define([
     'stripe'
 ], function($) {
     var $donationForm = $('.stripe-donation');
-    var $submitButton = $donationForm.find('.cta');
 
-    $donationForm.on('submit', function (e) {
-        e.preventDefault();
+    function postToStripe(recaptchaToken) {
         var interval = $donationForm.find('[name=interval]').val();
         var amount = $donationForm.find('[name=amount]').val();
-        var recaptchaToken = document.getElementById('id_captcha').value;
         var csrfToken = $donationForm.find('[name=csrfmiddlewaretoken]').val();
         var data = {
             'interval': interval,
@@ -38,6 +35,16 @@ define([
                 }
             }
         })
+    };
+
+    $donationForm.on('submit', function (e) {
+        e.preventDefault();
+        // validate token on form submit
+        let public_key = document.getElementById("id_captcha").getAttribute('data-sitekey');
+        grecaptcha.execute(public_key, {action: 'form'}).then(function(token) {
+            console.log("reCAPTCHA validated. Posting to stripe...");
+            postToStripe(token);
+        });
     });
 
 });

--- a/djangoproject/static/js/mod/stripe-donation.js
+++ b/djangoproject/static/js/mod/stripe-donation.js
@@ -37,6 +37,12 @@ define([
         })
     };
 
+    // django-recaptcha==4.0.0 adds a `submit` event listener to the form that ends up calling
+    // form.sumit(), therefore bypassing our own event listener.
+    // As a workaround, we remove their event listener and replace it with our own
+    if (window.recaptchaFormSubmit !== undefined) {
+        $donationForm[0].removeEventListener("submit", window.recaptchaFormSubmit);
+    }
     $donationForm.on('submit', function (e) {
         e.preventDefault();
         // validate token on form submit

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -1,8 +1,8 @@
 import stripe
-from captcha.fields import ReCaptchaField
-from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.utils.safestring import mark_safe
+from django_recaptcha.fields import ReCaptchaField
+from django_recaptcha.widgets import ReCaptchaV3
 
 from .models import INTERVAL_CHOICES, LEADERSHIP_LEVEL_AMOUNT, DjangoHero, Donation
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ django-hosts==5.1
 django-money==3.1
 django-push==1.1
 django-read-only==1.12.0
-django-recaptcha==3.0.0
+django-recaptcha==4.0.0
 django-registration-redux==2.13
 Django==3.2.23
 docutils==0.17.1


### PR DESCRIPTION
I took the work from #1450 (which was reverted later because of https://github.com/django-recaptcha/django-recaptcha/issues/348).

For ease of review, I added an extra commit which I believe fixes the issue we encountered (the two commits can then be squashed before merging)

Here's how I tested it locally:

1) Commented out `postToStripe(token)` in our own `stripe-donation.js`
2) Loaded the page at `/fundraising/` on my local version
3) Clicked the "donate monthly" button
4) Without my fix, the form is submitted and the page reloads. With my fix, the page doesn't reload and the console shows "reCAPTCHA validated. Posting to stripe...")