### PR TITLE
Updated Pillow and sorl-thumbnail.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,11 +12,11 @@ docutils==0.17.1
 feedparser==6.0.8
 Jinja2==3.1.2
 libsass==0.21.0
-Pillow==9.3.0
+Pillow==10.2.0
 psycopg2==2.9.3
 Pygments==2.12.0
 pykismet3==0.1.1
 requests==2.31.0
-sorl-thumbnail==12.8.0
+sorl-thumbnail==12.10.0
 Sphinx==4.5.0
 stripe==2.56.0


### PR DESCRIPTION
This replaces #1414 (dependabot failed because `sorl-thumbnail` also had to be updated)