### PR TITLE
Updated to Pygments==2.17.2.

### DIFF
--- a/docs/tests.py
+++ b/docs/tests.py
@@ -231,6 +231,7 @@ def band_listing(request):
                     <span class="k">def</span><span class="nf">band_listing</span>
                     <span class="p">(</span><span class="n">request</span>
                     <span class="p">):</span>
+                    <span class="w">    </span>
                     <span class="sd">&quot;&quot;&quot;A view of all bands.&quot;&quot;&quot;</span>
                     <span class="n">bands</span> <span class="o">=</span>
                     <span class="n">models</span><span class="o">.</span>

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,7 @@ Jinja2==3.1.2
 libsass==0.21.0
 Pillow==9.3.0
 psycopg2==2.9.3
-Pygments==2.12.0
+Pygments==2.17.2
 pykismet3==0.1.1
 requests==2.31.0
 sorl-thumbnail==12.8.0


### PR DESCRIPTION
Pygments 2.14 changed the way that the `HtmlFormatter()` renders whitespace which caused one of our tests to start failing.

I've updated the expected HTML output in the test and bumped `Pygments` to the latest available version. This replaces #1391 