### PR TITLE
Upgraded django-recaptcha to 4.0.0. (🎶  one more time 🎶 )

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -1,13 +1,13 @@
 import logging
 
 import django
-from captcha.fields import ReCaptchaField
-from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.utils.encoding import force_bytes
 from django_contact_form.forms import ContactForm
+from django_recaptcha.fields import ReCaptchaField
+from django_recaptcha.widgets import ReCaptchaV3
 from pykismet3 import Akismet, AkismetServerError
 
 logger = logging.getLogger(__name__)

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -70,7 +70,7 @@ INSTALLED_APPS = [
     "svntogit",
     "tracdb",
     "fundraising",
-    "captcha",
+    "django_recaptcha",
     "registration",
     "django_hosts",
     "sorl.thumbnail",

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -63,4 +63,4 @@ if DEBUG:
             "djangoproject.middleware.CORSMiddleware",
         )
 
-SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
+SILENCED_SYSTEM_CHECKS = ["django_recaptcha.recaptcha_test_key_error"]

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -14,7 +14,7 @@ DATABASES = {
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
-    "captcha.recaptcha_test_key_error"  # Default test keys for development.
+    "django_recaptcha.recaptcha_test_key_error"  # Default test keys for development.
 ]
 
 ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -86,7 +86,7 @@ if "sentry_dsn" in SECRETS and not DEBUG:
     )
 
 # RECAPTCHA KEYS
-# Defaults will trigger 'captcha.recaptcha_test_key_error' system check
+# Defaults will trigger 'django_recaptcha.recaptcha_test_key_error' system check
 if "recaptcha_public_key" in SECRETS:
     RECAPTCHA_PUBLIC_KEY = SECRETS.get("recaptcha_public_key")
     RECAPTCHA_PRIVATE_KEY = SECRETS.get("recaptcha_private_key")

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -1,8 +1,8 @@
 import stripe
-from captcha.fields import ReCaptchaField
-from captcha.widgets import ReCaptchaV3
 from django import forms
 from django.utils.safestring import mark_safe
+from django_recaptcha.fields import ReCaptchaField
+from django_recaptcha.widgets import ReCaptchaV3
 
 from .models import INTERVAL_CHOICES, LEADERSHIP_LEVEL_AMOUNT, DjangoHero, Donation
 
@@ -134,7 +134,7 @@ class DonateForm(forms.Form):
 
     amount = forms.ChoiceField(choices=AMOUNT_CHOICES)
     interval = forms.ChoiceField(choices=INTERVAL_CHOICES)
-    captcha = ReCaptchaField(widget=ReCaptchaV3)
+    captcha = ReCaptchaField(widget=ReCaptchaV3(action="form"))
 
 
 class DonationForm(forms.ModelForm):
@@ -176,7 +176,8 @@ class PaymentForm(forms.Form):
     `amount` can be any integer, so a ChoiceField is not appropriate.
     """
 
-    captcha = ReCaptchaField(widget=ReCaptchaV3)
+    # NOTE: `action` needs to match the one used in stripe-donation.js
+    captcha = ReCaptchaField(widget=ReCaptchaV3(action="form"))
     amount = forms.IntegerField(
         required=True,
         min_value=1,  # Minimum payment from Stripe API

--- a/fundraising/tests/test_forms.py
+++ b/fundraising/tests/test_forms.py
@@ -1,10 +1,15 @@
+from unittest.mock import patch
+
 from django.test import TestCase
+from django_recaptcha.client import RecaptchaResponse
 
 from ..forms import PaymentForm
 
 
 class TestPaymentForm(TestCase):
-    def test_basics(self):
+    @patch("django_recaptcha.fields.client.submit")
+    def test_basics(self, client_submit):
+        client_submit.return_value = RecaptchaResponse(is_valid=True, action="form")
         form = PaymentForm(
             data={
                 "amount": 100,
@@ -12,9 +17,11 @@ class TestPaymentForm(TestCase):
                 "captcha": "TESTING",
             }
         )
-        self.assertTrue(form.is_valid())
+        self.assertTrue(form.is_valid(), form.errors)
 
-    def test_max_value_validation(self):
+    @patch("django_recaptcha.fields.client.submit")
+    def test_max_value_validation(self, client_submit):
+        client_submit.return_value = RecaptchaResponse(is_valid=True, action="form")
         """
         Reject unrealistic values greater than $1,000,000.
         """

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django_hosts.resolvers import reverse as django_hosts_reverse
+from django_recaptcha.client import RecaptchaResponse
 
 from ..models import DjangoHero, Donation
 
@@ -59,8 +60,10 @@ class TestCampaign(TestCase):
         self.assertFalse(content["success"])
 
     @patch("stripe.checkout.Session.create")
-    def test_submitting_donation_form_valid(self, session_create):
+    @patch("django_recaptcha.fields.client.submit")
+    def test_submitting_donation_form_valid(self, client_submit, session_create):
         session_create.return_value = {"id": "TEST_ID"}
+        client_submit.return_value = RecaptchaResponse(is_valid=True, action="form")
         response = self.client.post(
             reverse("fundraising:donation-session"),
             {

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ django-hosts==5.1
 django-money==3.1
 django-push==1.1
 django-read-only==1.12.0
-django-recaptcha==3.0.0
+django-recaptcha==4.0.0
 django-registration-redux==2.13
 Django==3.2.23
 docutils==0.17.1


### PR DESCRIPTION
OK folks, I think this one might stick.

I tested it locally by getting my own recaptcha keys and I can then see that the captcha is validated (I get an error from stripe which seems to indicate that things will work once in production: `No such product: 'dummy_monthly_id'`).

There were three things I had to change compared to the original commit 16787c80e2acdbfb32b5b9711e95715ed9cca222:

- Work around django-recaptcha automatically submitting the form (https://github.com/django-recaptcha/django-recaptcha/issues/348) by disabling their `onsubmit` event and doing the call to `grecaptcha.execute(...)` manually.
- Make sure to set the returned token value to the `captcha` form field (this part was missing in my previous attempt 901bdd96e0c3e9a96bcf34b15fbfda854d682e17
- Make sure that both the widget declared on the form and the js use the same `action`, otherwise the captcha validation fails (this was also missing in my previous attempt).


I've got a good feeling about this one 🤞🏻 

**EDIT** I had to fix some tests that were breaking because the recaptcha test keys don't work with a custom `action` as documented in https://github.com/django-recaptcha/django-recaptcha/?tab=readme-ov-file#local-development-and-functional-testing