### PR TITLE
#1437 - Upgrade to Django 4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       rev: "1.18.0"
       hooks:
           - id: django-upgrade
-            args: [--target-version, "3.2"]
+            args: [--target-version, "4.2"]
     - repo: https://github.com/psf/black
       rev: 24.4.2
       hooks:

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -28,7 +28,7 @@ class EntryTestCase(DateTimeMixin, TestCase):
             pub_date=self.now, is_active=True, headline="active", slug="b"
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Entry.objects.published(),
             ["active"],
             transform=lambda entry: entry.headline,
@@ -54,7 +54,7 @@ class EntryTestCase(DateTimeMixin, TestCase):
             pub_date=self.tomorrow, is_active=True, headline="future active", slug="d"
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Entry.objects.published(),
             ["past active"],
             transform=lambda entry: entry.headline,
@@ -85,10 +85,10 @@ class EventTestCase(DateTimeMixin, TestCase):
         Event.objects.create(date=self.yesterday, pub_date=self.now, headline="past")
         Event.objects.create(date=self.tomorrow, pub_date=self.now, headline="future")
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Event.objects.future(), ["future"], transform=lambda event: event.headline
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Event.objects.past(), ["past"], transform=lambda event: event.headline
         )
 
@@ -98,10 +98,10 @@ class EventTestCase(DateTimeMixin, TestCase):
         """
         Event.objects.create(date=self.now, pub_date=self.now, headline="today")
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Event.objects.future(), ["today"], transform=lambda event: event.headline
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Event.objects.past(), ["today"], transform=lambda event: event.headline
         )
 
@@ -121,10 +121,10 @@ class EventTestCase(DateTimeMixin, TestCase):
             date=self.tomorrow + D, pub_date=self.tomorrow + D, headline="d"
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Event.objects.future(), ["c", "d"], transform=lambda event: event.headline
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Event.objects.past(), ["b", "a"], transform=lambda event: event.headline
         )
 
@@ -141,7 +141,7 @@ class ViewsTestCase(DateTimeMixin, TestCase):
         )
         response = self.client.get(reverse("weblog:index"))
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(response.context["events"], [])
+        self.assertQuerySetEqual(response.context["events"], [])
 
 
 class SitemapTests(DateTimeMixin, TestCase):

--- a/contact/tests.py
+++ b/contact/tests.py
@@ -38,7 +38,7 @@ class ContactFormTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertFormError(
-            response, "form", "email", ["Enter a valid email address."]
+            response.context["form"], "email", ["Enter a valid email address."]
         )
 
     @override_settings(AKISMET_API_KEY="")  # Disable Akismet in tests
@@ -67,7 +67,9 @@ class ContactFormTests(TestCase):
                 "body": "Hello, World!",
             },
         )
-        self.assertFormError(response, "form", "name", ["This field is required."])
+        self.assertFormError(
+            response.context["form"], "name", ["This field is required."]
+        )
 
     @skipIf(not has_network_connection, "Requires a network connection")
     def test_akismet_detect_spam(self):

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -51,7 +51,11 @@ MIDDLEWARE = (
 
 SESSION_COOKIE_SECURE = True
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
 
 STATIC_ROOT = str(DATA_DIR.joinpath("static"))
 

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -62,7 +62,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
     def test_docs_host_excluded(self):
         "We get no Content-Language or Vary headers when docs host is excluded"
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", HTTP_HOST=self.docs_host)
+            resp = self.client.get("/", headers={"host": self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertNotIn("Content-Language", resp)
         self.assertNotIn("Vary", resp)
@@ -73,7 +73,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         (with a port) is excluded
         """
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", HTTP_HOST="%s:8000" % self.docs_host)
+            resp = self.client.get("/", headers={"host": "%s:8000" % self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertNotIn("Content-Language", resp)
         self.assertNotIn("Vary", resp)
@@ -86,7 +86,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         with self.settings(
             LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host], USE_X_FORWARDED_HOST=True
         ):
-            resp = self.client.get("/", HTTP_X_FORWARDED_HOST=self.docs_host)
+            resp = self.client.get("/", headers={"x-forwarded-host": self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertNotIn("Content-Language", resp)
         self.assertNotIn("Vary", resp)
@@ -94,7 +94,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
     def test_docs_host_not_excluded(self):
         "We still get Content-Language when docs host is not excluded"
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[]):
-            resp = self.client.get("/", HTTP_HOST=self.docs_host)
+            resp = self.client.get("/", headers={"host": self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertIn("Content-Language", resp)
         self.assertIn("Vary", resp)
@@ -102,7 +102,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
     def test_www_host(self):
         "www should still use LocaleMiddleware"
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", HTTP_HOST=self.www_host)
+            resp = self.client.get("/", headers={"host": self.www_host})
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn("Content-Language", resp)
         self.assertIn("Vary", resp)
@@ -110,7 +110,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
     def test_www_host_with_port(self):
         "www (with a port) should still use LocaleMiddleware"
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", HTTP_HOST="%s:8000" % self.www_host)
+            resp = self.client.get("/", headers={"host": "%s:8000" % self.www_host})
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn("Content-Language", resp)
         self.assertIn("Vary", resp)

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -165,7 +165,7 @@ class RedirectsTests(TestCase):
     def test_internals_team(self):
         response = self.client.get(
             "/en/dev/internals/team/",
-            HTTP_HOST="docs.djangoproject.localhost:8000",
+            headers={"host": "docs.djangoproject.localhost:8000"},
         )
         self.assertRedirects(
             response,
@@ -190,7 +190,7 @@ class SearchFormTestCase(TestCase):
 
     def test_empty_get(self):
         response = self.client.get(
-            "/en/dev/search/", HTTP_HOST="docs.djangoproject.localhost:8000"
+            "/en/dev/search/", headers={"host": "docs.djangoproject.localhost:8000"}
         )
         self.assertEqual(response.status_code, 200)
 
@@ -303,7 +303,7 @@ class UpdateDocTests(TestCase):
                 }
             ]
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.release.documents.all(),
             ["This is the title"],
             transform=attrgetter("title"),
@@ -319,7 +319,7 @@ class UpdateDocTests(TestCase):
                 }
             ]
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.release.documents.all(),
             ["Title & title"],
             transform=attrgetter("title"),
@@ -333,7 +333,7 @@ class UpdateDocTests(TestCase):
                 {"current_page_name": "foo/3"},
             ]
         )
-        self.assertQuerysetEqual(self.release.documents.all(), [])
+        self.assertQuerySetEqual(self.release.documents.all(), [])
 
     def test_excluded_documents(self):
         """
@@ -375,7 +375,7 @@ class SitemapTests(TestCase):
 
     def test_sitemap_index(self):
         response = self.client.get(
-            "/sitemap.xml", HTTP_HOST="docs.djangoproject.localhost:8000"
+            "/sitemap.xml", headers={"host": "docs.djangoproject.localhost:8000"}
         )
         self.assertContains(response, "<sitemap>", count=2)
         self.assertContains(
@@ -394,7 +394,7 @@ class SitemapTests(TestCase):
 
     def test_sitemap_404(self):
         response = self.client.get(
-            "/sitemap-xx.xml", HTTP_HOST="docs.djangoproject.localhost:8000"
+            "/sitemap-xx.xml", headers={"host": "docs.djangoproject.localhost:8000"}
         )
         self.assertEqual(response.status_code, 404)
         self.assertEqual(

--- a/docs/views.py
+++ b/docs/views.py
@@ -317,7 +317,7 @@ def sitemap_index(request, sitemaps):
         sitemap_url = reverse(
             "document-sitemap", host="docs", kwargs={"section": section}
         )
-        sites.append(sitemap_url)
+        sites.append({"location": sitemap_url})
     return TemplateResponse(
         request,
         "sitemap_index.xml",

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,11 +3,11 @@ django-contact-form==2.1
 django-countries==7.5.1
 django-hosts==5.1
 django-money==3.1
-django-push==1.1
+django-push @ git+https://github.com/brutasse/django-push.git@22fda99641cfbd2f3075a723d92652a8e38220a5
 django-read-only==1.12.0
 django-recaptcha==4.0.0
 django-registration-redux==2.13
-Django==3.2.25
+Django==4.2.13
 docutils==0.17.1
 feedparser==6.0.8
 Jinja2==3.1.4

--- a/tracdb/tests.py
+++ b/tracdb/tests.py
@@ -36,14 +36,14 @@ class TicketTestCase(TracDBCreateDatabaseMixin, TestCase):
         """
         A wrapper around assertQuerysetEqual with some useful defaults
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             queryset, expected, transform=transform, ordered=ordered
         )
 
     def test_ticket_table_exist_in_testdb(self):
         self._create_ticket(summary="test", custom={"x": "y"})
         self.assertTicketsEqual(Ticket.objects.all(), ["test"])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             TicketCustom.objects.all(),
             [("x", "y")],
             transform=attrgetter("name", "value"),
@@ -54,7 +54,7 @@ class TicketTestCase(TracDBCreateDatabaseMixin, TestCase):
         self._create_ticket(summary="test1", custom={"x": "A", "y": "B"})
         self._create_ticket(summary="test2", custom={"z": "C"})
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Ticket.objects.with_custom().order_by("summary"),
             [
                 ("test1", {"x": "A", "y": "B"}),


### PR DESCRIPTION
We're still waiting for jazzband to approve `django-push`, but in the meantime we could pin to the github hash that added support for Django 4.2+.