### PR TITLE
Make it possible to use a different database user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,10 @@ Install and run locally from a virtual environment
       "superfeedr_creds": ["any@email.com", "some_string"],
       "db_host": "localhost",
       "db_password": "secret",
+      "db_user": "djangoproject",
       "trac_db_host": "localhost",
-      "trac_db_password": "secret"
+      "trac_db_password": "secret",
+      "trac_db_user": "code.djangoproject"
     }
 
 #. Add ``export DJANGOPROJECT_DATA_DIR=~/.djangoproject`` (without the backticks)

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -34,7 +34,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "djangoproject",
-        "USER": "djangoproject",
+        "USER": SECRETS.get("db_user", "djangoproject"),
         "HOST": SECRETS.get("db_host", ""),
         "PASSWORD": SECRETS.get("db_password", ""),
         "PORT": SECRETS.get("db_port", ""),
@@ -42,7 +42,7 @@ DATABASES = {
     "trac": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "code.djangoproject",
-        "USER": "code.djangoproject",
+        "USER": SECRETS.get("trac_db_user", "code.djangoproject"),
         "HOST": SECRETS.get("trac_db_host", ""),
         "PASSWORD": SECRETS.get("trac_db_password", ""),
         "PORT": SECRETS.get("trac_db_port", ""),


### PR DESCRIPTION
In development it's convenient to not have to create separate database users for every project. this allows it to be configurable without changing any of the defaults.