### PR TITLE
Make it possible to force build from update_docs_and_index

### DIFF
--- a/docs/management/commands/update_docs_and_index.py
+++ b/docs/management/commands/update_docs_and_index.py
@@ -7,5 +7,16 @@ class Command(BaseCommand):
     Update the docs then reindex them in the search vector field.
     """
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            default=False,
+            help=(
+                "Force docs update even if docs in git didn't change or the "
+                "version is no longer supported."
+            ),
+        )
+
     def handle(self, **options):
         call_command("update_docs", update_index=True, **options)


### PR DESCRIPTION
If you run `./manage.py update_docs_and_index --force` the `--force` flag gets mapped to the built-in `--force-color` attribute from `BaseCommand`, and then does not get passed through to the `update_docs` command that gets called.

This allows passing `--force` and passing it through to `update_docs`.