### PR TITLE
add og:title to the docs

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -2,7 +2,7 @@
 {% load i18n fundraising_extras docs %}
 
 {% block title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
-
+{% block og_title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
 {% block doc_url %}{% url 'document-index' lang=lang version=version host 'docs' %}{% endblock %}
 
 {% block link_rel_tags %}

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -2,7 +2,8 @@
 {% load i18n fundraising_extras docs %}
 
 {% block title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
-{% block og_title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
+{% block og_title %}{{ doc.title|striptags|escape|safe }} | {% trans "Django documentation" %}{% endblock %}
+
 {% block doc_url %}{% url 'document-index' lang=lang version=version host 'docs' %}{% endblock %}
 
 {% block link_rel_tags %}

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -2,7 +2,7 @@
 {% load i18n fundraising_extras docs %}
 
 {% block title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
-{% block og_title %}{{ doc.title|striptags|escape|safe }} | {% trans "Django documentation" %}{% endblock %}
+{% block og_title %}{{ doc.title|striptags|escape }} | {% trans "Django documentation" %}{% endblock %}
 
 {% block doc_url %}{% url 'document-index' lang=lang version=version host 'docs' %}{% endblock %}
 

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -2,7 +2,7 @@
 {% load i18n fundraising_extras docs %}
 
 {% block title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
-{% block og_title %}{{ doc.title|striptags|escape }} | {% trans "Django documentation" %}{% endblock %}
+{% block og_title %}{{ doc.title|striptags }} | {% trans "Django documentation" %}{% endblock %}
 
 {% block doc_url %}{% url 'document-index' lang=lang version=version host 'docs' %}{% endblock %}
 


### PR DESCRIPTION
This uses the same og:title as the page title.

The hooks are [already in the base template](https://github.com/django/djangoproject.com/blob/main/djangoproject/templates/base.html#L23) so this is very straightforward.

![image](https://github.com/django/djangoproject.com/assets/66555/e1850c2a-3877-413a-bc72-1314592a440f)
