### PR TITLE
Increased flake8 line-length config slightly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,10 @@
 [flake8]
 exclude = djangodocs,.tox,*/migrations/*
 ignore = F405,W504,W503
-max-line-length = 88
+# black enforces an 88 char line length but in some edge cases it's unable to
+# do so, and in that case it creates an unresolvable E501 error. The solution
+# is to set a slightly higher limit for flake8.
+max-line-length = 90
 per-file-ignores =
     docs/tests.py: E501
 


### PR DESCRIPTION
This should fix the breakage introduced by the `black` update in #1372