### PR TITLE
Update custom.html DOM text reinterpreted as HTML

### DIFF
--- a/djangoproject/static/js/lib/webfontloader/lib/webfontloader/demo/public/custom.html
+++ b/djangoproject/static/js/lib/webfontloader/lib/webfontloader/demo/public/custom.html
@@ -52,7 +52,7 @@
       var output = document.getElementById('events');
       if (output) {
         var e = document.createElement('li');
-        e.innerHTML = message;
+        e.innerText = message;
         output.appendChild(e);
       }
       if (window.console && window.console.log) {


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.