### PR TITLE
Update excanvas.js DOM text reinterpreted as HTML

### DIFF
--- a/djangoproject/static/js/lib/jquery-flot/excanvas.js
+++ b/djangoproject/static/js/lib/jquery-flot/excanvas.js
@@ -148,7 +148,7 @@ if (!document.createElement('canvas').getContext) {
         // Remove fallback content. There is no way to hide text nodes so we
         // just remove all childNodes. We could hide all elements and remove
         // text nodes but who really cares about the fallback content.
-        el.innerHTML = '';
+        el.textContent = '';
 
         // do not use inline function because that will leak memory
         el.attachEvent('onpropertychange', onPropertyChange);


### PR DESCRIPTION
By using textContent, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.