### PR TITLE
Fixes focus indicators

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -279,6 +279,7 @@ html[data-theme="dark"] {
     background: transparent;
     vertical-align: middle;
     padding: 0;
+    color: var(--menu);
 }
 
 .theme-toggle svg {

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -278,11 +278,7 @@ html[data-theme="dark"] {
     border: none;
     background: transparent;
     vertical-align: middle;
-    padding: 20px 10px;
-
-    @include respond-max(768px) {
-        padding: 0;
-    }
+    padding: 0;
 }
 
 .theme-toggle svg {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -590,12 +590,14 @@ blockquote {
             text-transform: uppercase;
             margin: 0 10px;
             border-top: 1px solid lighten($green-dark, 5%);
+            padding: 20px 0px;
 
             @include respond-min(768px) {
                 margin: 0;
                 border: 0;
                 float: left;
                 text-align: left;
+                padding: 20px 10px;
             }
 
             &.active a {
@@ -606,7 +608,6 @@ blockquote {
         a {
             color: var(--menu);
             display: block;
-            padding: 20px 0px;
             text-decoration: none;
 
             &:active,
@@ -615,7 +616,6 @@ blockquote {
             }
 
             @include respond-min(768px) {
-                padding: 20px 10px;
             }
         }
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -41,6 +41,10 @@ a {
         color: var(--text-l10);
     }
 
+    &:focus {
+        outline: 2px solid currentColor;
+    }
+
     &:active,
     &:focus,
     &:hover {
@@ -1229,9 +1233,13 @@ a.cta {
         font-style: normal;
     }
 
-    &:hover,
-    &:focus {
+    &:hover{
         background: lighten($green-medium, 4%);
+    }
+
+    &:focus {
+        outline-offset: 2px;
+        outline-color: var(--primary);
     }
 
     &:active {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -618,9 +618,6 @@ blockquote {
             &:hover {
                 color: var(--secondary-accent);
             }
-
-            @include respond-min(768px) {
-            }
         }
 
         span {
@@ -1237,7 +1234,7 @@ a.cta {
         font-style: normal;
     }
 
-    &:hover{
+    &:hover {
         background: lighten($green-medium, 4%);
     }
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -52,6 +52,10 @@ a {
     }
 }
 
+button:focus {
+    outline: 2px solid currentColor;
+}
+
 ::selection {
     // Text Selection Colors
     background-color: var(--selection);


### PR DESCRIPTION
Refs #1381 

Improves the focus indicators. Based on WCAG 2.2 standards, it is a better idea to have solid outlines instead of a dotted outline for focus indicators. Also, color change for focus indication isn't great because it doesn't often work for color blinded people.

So things done in this PR:
- Make all anchor tags have a solid 2px outline of the currentColor (Sadly the currentColor itself doesn't meet WCAG color contrast requirement, so the focus indicator doesn't either, but hopefully that's a separate discussion)
- Apply the same above design to all buttons as well
- Adds an offsetted focus outline for the CTAs
- Moves padding in navigation elements from the `<a>` element to the `<li>` element.

These address the below concerns by @thibaudcolas in #1381 
> Focus style almost invisible on "Get started with Django" CTA

> Custom "dotted outline" focus styles: not visible enough and broken in main navigation

Attaching some screenshots of the changes:
![image](https://github.com/django/djangoproject.com/assets/9530293/91880579-8217-474b-9644-3b3bb9eda009)
![image](https://github.com/django/djangoproject.com/assets/9530293/21b7cec3-dbc6-44f8-93b5-a8943ddb0f33)
