### PR TITLE
Used Django's builtin redis cache backend

### DIFF
--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -20,11 +20,8 @@ CACHES = {
         "OPTIONS": {"tcp_nodelay": True, "ketama": True},
     },
     "docs-pages": {
-        "BACKEND": "redis_cache.RedisCache",
-        "LOCATION": SECRETS.get("redis_host", "localhost:6379"),
-        "OPTIONS": {
-            "DB": 2,
-        },
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": SECRETS.get("redis_host", "redis://localhost:6379/2"),
     },
 }
 

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -14,14 +14,13 @@ THUMBNAIL_DEBUG = DEBUG
 
 CACHES = {
     "default": {
-        "BACKEND": "django_pylibmc.memcached.PyLibMCCache",
-        "LOCATION": SECRETS.get("memcached_host", "127.0.0.1:11211"),
-        "BINARY": True,
-        "OPTIONS": {"tcp_nodelay": True, "ketama": True},
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": SECRETS.get("cache_default_url", "redis://localhost:6379"),
     },
+    # We use a separate cache for docs so we can purge it when docs are rebuilt
     "docs-pages": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": SECRETS.get("redis_host", "redis://localhost:6379/2"),
+        "LOCATION": SECRETS.get("cache_docs_url", "redis://localhost:6379/2"),
     },
 }
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,3 @@
 -r common.txt
-django-pylibmc==0.6.1
-pylibmc==1.6.3
 redis==5.0.8
 sentry-sdk==2.11.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,5 @@
 -r common.txt
 django-pylibmc==0.6.1
-django-redis-cache==3.0.1
 pylibmc==1.6.3
 redis==5.0.8
 sentry-sdk==2.11.0


### PR DESCRIPTION
Fix for #1023 

Two big questions that I don't have the answer to (yet?):

- [ ] Should we re-populate the cache (somehow transferring the data from memcached to redis) as we deploy the `default` cache? How big of an impact would it have to clear the site's cache all at once?
- [ ] Will the `docs-pages` cache change seamlessly work as we change the backend (I think yes, but I haven't tested)
- [ ] Should we consider using `hiredis` to improve performance? I believe all that would be needed is to use `redis[hiredis]` in the requirements.