### PR TITLE
Tweaked maximum donation amount

### DIFF
--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -181,7 +181,7 @@ class PaymentForm(forms.Form):
     amount = forms.IntegerField(
         required=True,
         min_value=1,  # Minimum payment from Stripe API
-        max_value=1_000_000,  # Reject clearly unrealistic amounts.
+        max_value=999_999,  # Reject clearly unrealistic amounts.
     )
     interval = forms.ChoiceField(
         required=True,

--- a/fundraising/tests/test_forms.py
+++ b/fundraising/tests/test_forms.py
@@ -27,7 +27,7 @@ class TestPaymentForm(TestCase):
         """
         form = PaymentForm(
             data={
-                "amount": 1_000_001,
+                "amount": 1_000_000,
                 "interval": "onetime",
                 "captcha": "TESTING",
             }


### PR DESCRIPTION
The stripe API rejects anything > $999,999.99 and we're sporadically getting error reports on Sentry from people trying out 1 million.