### PR TITLE
Bump pre-commit and docutils

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ django-read-only==1.16.0
 django-recaptcha==4.0.0
 django-registration-redux==2.13
 Django==4.2.13
-docutils==0.17.1
+docutils==0.20.1
 feedparser==6.0.8
 Jinja2==3.1.4
 libsass==0.21.0
@@ -18,5 +18,5 @@ Pygments==2.17.2
 pykismet3==0.1.1
 requests==2.32.0
 sorl-thumbnail==12.10.0
-Sphinx==4.5.0
+Sphinx==7.1.2
 stripe==2.56.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
 -r common.txt
-pre-commit~=2.20.0
+pre-commit~=3.5.0
 watchdog==2.1.6


### PR DESCRIPTION
Bumping them to their last version that supports Python 3.8

Sphinx is a pretty central dependency for us (since it's the tool that builds our documentation), so I'd like to do a few more manual checks before merging:

- [ ] Make sure the documentation builds locally
- [ ] Does the `Sphinx` version need to be synced with django/django?