### PR TITLE
Fixed #1559 -- Refactor BaseContactForm to use built-in AkismetContactForm

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -1,19 +1,14 @@
 import logging
 
-import django
 from django import forms
-from django.conf import settings
-from django.contrib.sites.models import Site
-from django.utils.encoding import force_bytes
-from django_contact_form.forms import ContactForm
+from django_contact_form.forms import AkismetContactForm
 from django_recaptcha.fields import ReCaptchaField
 from django_recaptcha.widgets import ReCaptchaV3
-from pykismet3 import Akismet, AkismetServerError
 
 logger = logging.getLogger(__name__)
 
 
-class BaseContactForm(ContactForm):
+class BaseContactForm(AkismetContactForm):
     message_subject = forms.CharField(
         max_length=100,
         widget=forms.TextInput(
@@ -42,40 +37,9 @@ class BaseContactForm(ContactForm):
     def message(self):
         return "From: {name} <{email}>\n\n{body}".format(**self.cleaned_data)
 
-    def clean_body(self):
-        """
-        Check spam against Akismet.
-
-        Backported from django-contact-form pre-1.0; 1.0 dropped built-in
-        Akismet support.
-        """
-        if "body" in self.cleaned_data and getattr(settings, "AKISMET_API_KEY", None):
-            try:
-                akismet_api = Akismet(
-                    api_key=settings.AKISMET_API_KEY,
-                    blog_url="http://%s/" % Site.objects.get_current().domain,
-                    user_agent="Django {}.{}.{}".format(*django.VERSION),
-                )
-
-                akismet_data = {
-                    "user_ip": self.request.META.get("REMOTE_ADDR", ""),
-                    "user_agent": self.request.headers.get("user-agent", ""),
-                    "referrer": self.request.headers.get("referer", ""),
-                    "comment_content": force_bytes(self.cleaned_data["body"]),
-                    "comment_author": self.cleaned_data.get("name", ""),
-                    "comment_author_email": self.cleaned_data.get("email", ""),
-                    "comment_type": "contact-form",
-                }
-                if getattr(settings, "AKISMET_TESTING", None):
-                    # Adding test argument to the request in order to
-                    # tell akismet that they should ignore the request
-                    # so that test runs affect the heuristics
-                    akismet_data["test"] = 1
-                if akismet_api.check(akismet_data):
-                    raise forms.ValidationError("Akismet thinks this message is spam")
-            except AkismetServerError:
-                logger.error("Akismet server error")
-        return self.cleaned_data["body"]
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
 
 
 class FoundationContactForm(BaseContactForm):


### PR DESCRIPTION
This PR refactors the 'BaseContactForm' in 'contact/forms.py' to utilize the built-in 'AkismetContactForm' from the current version of django-contact-form. This change simplifies our codebase and leverages the maintained functionality provided by the library.

Key changes:
1. Updated 'BaseContactForm' to inherit from 'AkismetContactForm' instead of 'ContactForm'.
2. Removed the custom 'clean_body()' method as Akismet spam checking is now handled by the parent class.
3. Added an '__init__' method to properly handle the request object needed for Akismet functionality.
4. Removed unused imports related to the old implementation.
5. Maintained all existing custom fields and methods (subject, message, etc.).

Please review and let me know if any further changes or testing are needed.