### PR TITLE
Simplify header text on community pages (#1563)

### DIFF
--- a/aggregator/context_processors.py
+++ b/aggregator/context_processors.py
@@ -12,5 +12,5 @@ def community_stats(request):
     Context processor to calculate Django's age for the community pages.
     """
     # Django 3.2 introduces depth kwarg. Set timesince(..., depth=1) then.
-    stats = {"age": timesince(DJANGO_DOB)}
+    stats = {"age": timesince(DJANGO_DOB, depth=1)}
     return {"community_stats": stats}


### PR DESCRIPTION
## Simplify Header Text on Community Pages

### Issue Reference

This pull request addresses [#1563](https://github.com/WajahatKanju/djangoproject.com/issues/1563).

### Description

The current header on the community pages reads:

Building the Django Community for 18 years, 11 months. Come join us!

This text is a bit too detailed, and a comment in the code suggests that it was intended to be shorter.

### Changes Made

- Simplified the header text on community pages by updating the age display to show only the number of years Django has been active. This was achieved by modifying the `timesince` function call in `aggregator/context_processors.py`.

**FROM:**
```python
stats = {"age": timesince(DJANGO_DOB)}
```
**TO**
```python
stats = {"age": timesince(DJANGO_DOB, depth=1)}
```