### PR TITLE
Simplify header text on community pages (#1563)

### DIFF
--- a/aggregator/context_processors.py
+++ b/aggregator/context_processors.py
@@ -12,5 +12,5 @@ def community_stats(request):
     Context processor to calculate Django's age for the community pages.
     """
     # Django 3.2 introduces depth kwarg. Set timesince(..., depth=1) then.
-    stats = {"age": timesince(DJANGO_DOB)}
+    stats = {"age": timesince(DJANGO_DOB, depth=1)}
     return {"community_stats": stats}

--- a/aggregator/tests.py
+++ b/aggregator/tests.py
@@ -8,6 +8,7 @@ from django.core import mail
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
+from django.utils.timesince import timesince
 
 from docs.models import DocumentRelease
 from releases.models import Release
@@ -142,6 +143,12 @@ class AggregatorTests(TestCase):
             ["Approved long URL Item", "Approved Item"],
             transform=attrgetter("title"),
         )
+
+    def test_header_text_simplification_shows_only_years(self):
+        django_dob = datetime.datetime(2005, 7, 21)
+        age = timesince(django_dob, depth=1)
+        self.assertIn("years", age)
+        self.assertNotIn("months", age)
 
 
 class TestForms(SimpleTestCase):


### PR DESCRIPTION
## Simplify Header Text on Community Pages

### Issue Reference

This pull request addresses/fixes [#1563](https://github.com/django/djangoproject.com/issues/1563).

### Description

The current header on the community pages reads:

Building the Django Community for 18 years, 11 months. Come join us!

This text is a bit too detailed, and a comment in the code suggests that it was intended to be shorter.

### Changes Made

- Simplified the header text on community pages by updating the age display to show only the number of years Django has been active. This was achieved by modifying the `timesince` function call in `aggregator/context_processors.py`.

**FROM:**
```python
stats = {"age": timesince(DJANGO_DOB)}
```
**TO**
```python
stats = {"age": timesince(DJANGO_DOB, depth=1)}
```

### Added Test

- Added a unit test to verify that the header text is simplified to show only the number of years and does not include months. The test checks that the output contains "years" and does not contain "months."

**Test Method:**
```python
def test_header_text_simplification_shows_only_years(self):
    django_dob = datetime.datetime(2005, 7, 21)
    age = timesince(django_dob, depth=1)
    self.assertIn("years", age)
    self.assertNotIn("months", age)
```