### PR TITLE
fix: smooth scroll to search input with dynamic banner offset

### DIFF
--- a/djangoproject/static/js/mod/search-key.js
+++ b/djangoproject/static/js/mod/search-key.js
@@ -17,8 +17,14 @@ define([
 
                 $(window).keydown(function(e) {
                     if ((e.metaKey || e.ctrlKey) && e.key === 'k' && $('input:focus, textarea:focus').length === 0) {
+                        const warning_banner_height = $('#dev-warning').outerHeight() || 0;
+                        const search_form_input_top = search_form_input.offset().top;
+                        const scroll_to_position = search_form_input_top - warning_banner_height;
                         search_form_input.focus().select();
-                        search_form_input[0].scrollIntoView({ behavior: "smooth", block: "start" });
+                        window.scrollTo({
+                            top: scroll_to_position,
+                            behavior: 'smooth'
+                        });
                         return false;
                     }
                 });


### PR DESCRIPTION
### Overview
This pull request addresses the scrolling behavior when focusing on the search input field via the shortcut (Ctrl + K / Cmd + K). The previous implementation did not account for the height of the warning banner, resulting in a less-than-ideal user experience.

### Changes Made
- **Adjusted Scroll Behavior**: The scroll position now considers the height of the `#dev-warning` banner, ensuring that the search input is not obscured.
- **Replaced `scrollIntoView`**: The code now uses `window.scrollTo` to smoothly scroll to the search input's position while accounting for the banner's height.
- **Improved User Experience**: This change provides a seamless transition when the search input is focused, improving overall usability.

### Testing
- Tested the functionality across different browsers to ensure compatibility.
- Verified that the scrolling behaves as expected with and without the warning banner present.

---

### Issue Reference
This pull request fixes https://github.com/django/djangoproject.com/issues/1620.