### PR TITLE
Fix #1574 -- Upgrade Python version to 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     push:
         branches:
             - main
+            - python312
     pull_request:
 
 jobs:
@@ -31,7 +32,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8
+                  python-version: 3.12
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip setuptools coveralls "tox<4"
@@ -57,7 +58,7 @@ jobs:
                   echo '"secret_key": "a"}' >> conf/secrets.json
             - name: Run tox
               run: |
-                  python -m tox -e py38-tests
+                  python -m tox -e py312-tests
             - name: Coveralls
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       rev: "v3.17.0"
       hooks:
           - id: pyupgrade
-            args: [--py38-plus]
+            args: [--py312-plus]
     - repo: https://github.com/adamchainz/django-upgrade
       rev: "1.20.0"
       hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.8-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 # set work directory
 WORKDIR /usr/src/app

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To run locally, you can either:
 Install and run locally from a virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Create a `Python 3.8+ virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
+#. Create a `Python 3.12 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
 
 #. Install dependencies::
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,4 +19,4 @@ pykismet3==0.1.1
 requests==2.32.3
 sorl-thumbnail==12.10.0
 Sphinx==4.5.0
-stripe==2.56.0
+stripe==3.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =py38-{tests,flake8,black,isort}
+envlist =py312-{tests,flake8,black,isort}
 skipsdist = true
 
 [testenv]

--- a/tracdb/models.py
+++ b/tracdb/models.py
@@ -50,7 +50,7 @@ from urllib.parse import parse_qs
 
 from django.db import models
 
-_epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+_epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
 
 
 class time_property:

--- a/tracdb/views.py
+++ b/tracdb/views.py
@@ -27,7 +27,7 @@ def bouncing_tickets(request):
 
 
 def ts2dt(ts):
-    epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+    epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
     return epoc + datetime.timedelta(microseconds=ts)
 
 


### PR DESCRIPTION
I tried to create the PR with the least possible changes only to support Python 3.12.

The goal is to merge this PRs and thus be able to continue the list of changes blocked by this (eg: the update to Django 5.1 #1633 ) leaving the @django/ops-team free to continue the work with Docker ( e.g. #1627 )

P.S. I increased the Stripe version to the lowest possible version compatible with the code and with Python 3.12 in order to differ as little as possible from the one in use now, in the hope that the flow of donations remains unchanged. I would postpone the update to the latest possible version with the related tests to a specific issue.