### PR TITLE
Restored PyCharm 2024 banner

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -8,8 +8,11 @@
 {% block og_description %}Support Django development by donating to the Django Software Foundation{% endblock %}
 
 {% block header %}
+  <h1><a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&amp;utm_content=django-fundraiser-24&amp;utm_medium=referral&amp;utm_source=djangoproject.com">Until October 6, 2024, <em>get PyCharm for 30% off</em>. All money goes to the <em>Django Software Foundation</em>!</a></h1>
+{% comment %}
   <h1 class="visuallyhidden">Support Django</h1>
   <p><em>Support Django development</em> by donating to the <em>Django Software Foundation</em>.</p>
+{% endcomment %}
 {% endblock %}
 
 {% block messages %}

--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -6,6 +6,13 @@
 {% block layout_class %}sidebar-right{% endblock %}
 
 {% block header %}
+  <div class="copy-banner" style="background: #44B78B;">
+    <div class="container">
+      <h1><a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&amp;utm_content=django-fundraiser-24&amp;utm_medium=referral&amp;utm_source=djangoproject.com"
+             style="font-weight: bold;">Until October 6, 2024, get PyCharm at 30% off. All money goes to the DSF!</a>
+      </h1>
+    </div>
+  </div>
   <h1 class="visuallyhidden">Django</h1>
   <p>
     <em>Django makes it easier to build better web apps more quickly and with less code.</em>

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -13,7 +13,10 @@
 {% block og_image_height %}480{% endblock %}
 
 {% block header %}
-  <h1>Download</h1>
+  <h1>
+    Download &ndash;
+    <a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&amp;utm_content=django-fundraiser-24&amp;utm_medium=referral&amp;utm_source=djangoproject.com">Until October 6, 2024, <em>get PyCharm for 30% off</em>. All money goes to the <em>Django Software Foundation</em>!</a>
+  </h1>
 {% endblock %}
 
 {% block content %}

--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -10,7 +10,15 @@
 {% endblock %}
 
 {% block header %}
-  <h1><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></h1>
+  {% comment %}
+    <h1><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></h1>
+  {% endcomment %}
+  <h1>
+    <a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a> &ndash;
+    <a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&amp;utm_content=django-fundraiser-24&amp;utm_medium=referral&amp;utm_source=djangoproject.com">
+      Until October 6, 2024, <em>get PyCharm at 30% off</em>.<br>All money goes to the <em>DSF!</em>
+    </a>
+  </h1>
   {% search_form %}
 {% endblock %}
 


### PR DESCRIPTION
The banner was removed a bit too hastily, as it turns out.

This reverts commit 41718b8022cbf01a03f34c6cee5012d068f1f08e.