### PR TITLE
feat: Translation preparation for accounts app

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import Profile
 
@@ -12,10 +13,12 @@ class ProfileForm(forms.ModelForm):
     """
 
     name = forms.CharField(
-        required=False, widget=forms.TextInput(attrs={"placeholder": "Name"})
+        required=False,
+        widget=forms.TextInput(attrs={"placeholder": _("Name")})
     )
     email = forms.EmailField(
-        required=False, widget=forms.TextInput(attrs={"placeholder": "Email"})
+        required=False,
+        widget=forms.TextInput(attrs={"placeholder": _("Email")})
     )
 
     class Meta:

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -13,12 +13,10 @@ class ProfileForm(forms.ModelForm):
     """
 
     name = forms.CharField(
-        required=False,
-        widget=forms.TextInput(attrs={"placeholder": _("Name")})
+        required=False, widget=forms.TextInput(attrs={"placeholder": _("Name")})
     )
     email = forms.EmailField(
-        required=False,
-        widget=forms.TextInput(attrs={"placeholder": _("Email")})
+        required=False, widget=forms.TextInput(attrs={"placeholder": _("Email")})
     )
 
     class Meta:

--- a/djangoproject/templates/accounts/edit_profile.html
+++ b/djangoproject/templates/accounts/edit_profile.html
@@ -48,7 +48,7 @@
         <p>{% blocktranslate trimmed %}
             We hate spam as much as you do. We'll only use it to send you password reset
             emails. We'll also use this email to try to fetch a <a
-                    href="https://en.gravatar.com/">Gravatar</a>. You can change the image for this
+                href="https://en.gravatar.com/">Gravatar</a>. You can change the image for this
             email at <a href="https://en.gravatar.com/">Gravatar</a>.{% endblocktranslate %}</p>
     </div>
 {% endblock %}

--- a/djangoproject/templates/accounts/edit_profile.html
+++ b/djangoproject/templates/accounts/edit_profile.html
@@ -1,14 +1,15 @@
 {% extends "registration/base.html" %}
+{% load i18n %}
 
-{% block title %}Edit your profile{% endblock %}
+{% block title %}{% translate "Edit your profile" %}{% endblock %}
 
 {% block content %}
 
     {% if form.errors %}
-        <p class="errors">Please correct the errors below: {{ form.non_field_errors }}</p>
+        <p class="errors">{% translate "Please correct the errors below:" %} {{ form.non_field_errors }}</p>
     {% endif %}
 
-    <h1>Edit your profile</h1>
+    <h1>{% translate "Edit your profile" %}</h1>
 
     <form method="post" action="" class="form-input">
         {% csrf_token %}
@@ -27,25 +28,27 @@
         </div>
 
         <div class="submit">
-            <input class="cta" type="submit" value="Save"/>
+            <input class="cta" type="submit" value="{% translate "Save" %}"/>
         </div>
     </form>
 {% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">Additional Information</h1>
+    <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
     <div role="complementary">
-        <h2>Help</h2>
+        <h2>{% translate "Help" %}</h2>
 
-        <p>Use this form to edit your profile.</p>
+        <p>{% translate "Use this form to edit your profile." %}</p>
 
-        <p>Use whatever name you'd like to be identified with on djangoproject.com. If
-            you leave it blank, we'll identify you as <b>{{ user.username }}</b>, your
-            username.</p>
+        <p>{% blocktranslate trimmed with username=user.username %}
+            Use whatever name you'd like to be identified with on djangoproject.com. If
+            you leave it blank, we'll identify you as <b>{{ username }}</b>, your
+            username.{% endblocktranslate %}</p>
 
-        <p>We hate spam as much as you do. We'll only use it to send you password reset
+        <p>{% blocktranslate trimmed %}
+            We hate spam as much as you do. We'll only use it to send you password reset
             emails. We'll also use this email to try to fetch a <a
-                href="https://en.gravatar.com/">Gravatar</a>. You can change the image for this
-            email at <a href="https://en.gravatar.com/">Gravatar</a>.</p>
+                    href="https://en.gravatar.com/">Gravatar</a>. You can change the image for this
+            email at <a href="https://en.gravatar.com/">Gravatar</a>.{% endblocktranslate %}</p>
     </div>
 {% endblock %}

--- a/djangoproject/templates/accounts/user_profile.html
+++ b/djangoproject/templates/accounts/user_profile.html
@@ -1,40 +1,40 @@
 {% extends "base_community.html" %}
-{% load humanize %}
+{% load humanize i18n %}
 
 {% block title %}{% firstof user_obj.profile.name user_obj.username %}{% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">Additional Information</h1>
+    <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
     <div role="complementary">
         <h2>
             {% if user_obj == user %}
-                This is you!
+                {% translate "This is you!" %}
             {% else %}
-                Is this you?
+                {% translate "Is this you?" %}
             {% endif %}
         </h2>
 
-        <p>Need to edit something? Here's how:</p>
+        <p>{% translate "Need to edit something? Here's how:" %}</p>
         <ul>
-            <li><a href="{% url 'edit_profile' %}">Edit your name and email here.</a></li>
-            <li>
+            <li><a href="{% url 'edit_profile' %}">{% translate "Edit your name and email here." %}</a></li>
+            <li>{% blocktranslate trimmed %}
                 The image is the <a href="https://en.gravatar.com/">Gravatar</a> linked
                 to the email address you signed up with. You can change the image over
                 at <a href="https://en.gravatar.com/">Gravatar</a>. If you see a robot, that's
                 because you don't have a Gravatar yet.
-                (Robots provided by <a href="https://robohash.org/">Robohash</a>.)
+                (Robots provided by <a href="https://robohash.org/">Robohash</a>.){% endblocktranslate %}
             </li>
-            <li>
+            <li>{% blocktranslate trimmed %}
                 The rest of the data is read-only for the time being. If you see
                 outrageous errors, please file an issue on
-                <a href="https://github.com/django/code.djangoproject.com/issues/new" target="_blank">GitHub</a>.
+                <a href="https://github.com/django/code.djangoproject.com/issues/new" target="_blank">GitHub</a>.{% endblocktranslate %}
             </li>
         </ul>
     </div>
 {% endblock %}
 
 {% block content %}
-    <div class  ="user-info">
+    <div class="user-info">
         <img class='avatar' width='150' height='150'
              src="https://secure.gravatar.com/avatar/{{ email_hash }}?s=150&amp;d=https%3A%2F%2Frobohash.org%2F{{ email_hash }}%3Fset%3Dset3%26size%3D150x150">
 
@@ -43,7 +43,7 @@
         </h1>
 
         {% if stats %}
-            <h2>Lies, damned lies, and statistics:</h2>
+            <h2>{% translate "Lies, damned lies, and statistics:" %}</h2>
             <ul>
                 {% for stat, value in stats.items %}
                     <li>{{ stat }}: {{ value|intcomma }}.</li>
@@ -53,7 +53,7 @@
 
         {% with user_obj.owned_feeds.all as feeds %}
             {% if feeds %}
-                <h2>Community feeds:</h2>
+                <h2>{% translate "Community feeds:" %}</h2>
                 <ul>
                     {% for f in feeds %}
                         <li><a href="{{ f.public_url }}">{{ f.title }}</a></li>


### PR DESCRIPTION
This begins the implementation of translation tags as suggested by [#1648](https://github.com/django/djangoproject.com/issues/1648)

Translations tags are added to the accounts templates and gettext added to the placeholders for `ProfileForm`.