### PR TITLE
feat: Translation preparation for the contact app 

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -5,6 +5,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.utils.encoding import force_bytes
+from django.utils.translation import gettext_lazy as _
 from django_contact_form.forms import ContactForm
 from django_recaptcha.fields import ReCaptchaField
 from django_recaptcha.widgets import ReCaptchaV3
@@ -17,19 +18,19 @@ class BaseContactForm(ContactForm):
     message_subject = forms.CharField(
         max_length=100,
         widget=forms.TextInput(
-            attrs={"class": "required", "placeholder": "Message subject"}
+            attrs={"class": "required", "placeholder": _("Message subject")}
         ),
-        label="Message subject",
+        label=_("Message subject"),
     )
     email = forms.EmailField(
-        widget=forms.TextInput(attrs={"class": "required", "placeholder": "E-mail"})
+        widget=forms.TextInput(attrs={"class": "required", "placeholder": _("E-mail")})
     )
     name = forms.CharField(
-        widget=forms.TextInput(attrs={"class": "required", "placeholder": "Name"})
+        widget=forms.TextInput(attrs={"class": "required", "placeholder": _("Name")})
     )
     body = forms.CharField(
         widget=forms.Textarea(
-            attrs={"class": "required", "placeholder": "Your message"}
+            attrs={"class": "required", "placeholder": _("Your message")}
         )
     )
     captcha = ReCaptchaField(widget=ReCaptchaV3)

--- a/djangoproject/templates/contact/coc.html
+++ b/djangoproject/templates/contact/coc.html
@@ -1,8 +1,9 @@
 {% extends "base_3col.html" %}
+{% load i18n %}
 
-{% block title %}Django Code of Conduct Feedback{% endblock %}
+{% block title %}{% translate "Django Code of Conduct Feedback" %}{% endblock %}
 
 {% block content %}
-    <h1>Django Code of Conduct Feedback</h1>
+    <h1>{% translate "Django Code of Conduct Feedback" %}</h1>
     {% include "contact/coc_form.html" %}
 {% endblock %}

--- a/djangoproject/templates/contact/coc_form.html
+++ b/djangoproject/templates/contact/coc_form.html
@@ -1,22 +1,23 @@
+{% load i18n %}
 <form action="{% url "contact_coc" %}" method="post" accept-charset="utf-8" class="wide">
   {% csrf_token %}
 
 {# hardcoding inputs because they'll be included on the CoC page itself #}
   <p>
-    <label for="id_name">Your name (optional):</label>
+    <label for="id_name">{% translate "Your name (optional):" %}</label>
     {% if form.name.errors %}<p class="errors">{{ form.name.errors.as_text }}</p>{% endif %}
     <input id="id_name" class="required" type="text" name="name">
   </p>
   <p>
-    <label for="id_email">Your email address (optional):</label>
+    <label for="id_email">{% translate "Your email address (optional):" %}</label>
     {% if form.email.errors %}<p class="errors">{{ form.email.errors.as_text }}</p>{% endif %}
     <input id="id_email" class="required" type="text" name="email">
   </p>
   <p>
-    <label for="id_body">Your message:</label>
+    <label for="id_body">{% translate "Your message:" %}</label>
     {% if form.body.errors %}<p class="errors">{{ form.body.errors.as_text }}</p>{% endif %}
     <textarea id="id_body" class="required" rows="10" name="body" cols="40"></textarea>
   </p>
-  <p class="submit"><input type="submit" value="Send &rarr;"></p>
+  <p class="submit"><input type="submit" value="{% translate 'Send' %} &rarr;"></p>
 
 </form>

--- a/djangoproject/templates/contact/coc_form.html
+++ b/djangoproject/templates/contact/coc_form.html
@@ -18,6 +18,6 @@
     {% if form.body.errors %}<p class="errors">{{ form.body.errors.as_text }}</p>{% endif %}
     <textarea id="id_body" class="required" rows="10" name="body" cols="40"></textarea>
   </p>
-  <p class="submit"><input type="submit" value="{% translate 'Send' %} &rarr;"></p>
+  <p class="submit"><input type="submit" value="{% translate "Send &rarr;" %}"></p>
 
 </form>

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -1,17 +1,34 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
-{% block title %}Contact the Django Software Foundation{% endblock %}
+{% block title %}{% translate "Contact the Django Software Foundation" %}{% endblock %}
 
 {% block content %}
-  <h1>Contact the Django Software Foundation</h1>
-  <p>This contact form is for the Django Software Foundation - the legal and
-    fundraising arm of the Django project.</p>
-  <p>If you want to report a bug, feature request, or documentation issue in Django,
-    use the <a href="https://code.djangoproject.com">ticket tracker</a>.</p>
-  <p>If you want to report a problem with this website, use the
-    <a href="https://github.com/django/djangoproject.com">GitHub repo</a>.</p>
-  <p>If you've got questions about how to use Django, use the
-    <a href="https://groups.google.com/forum/#!forum/django-users">django-users mailing list</a>.</p>
+  <h1>{% translate "Contact the Django Software Foundation" %}</h1>
+  <p>
+    {% blocktranslate trimmed %}
+      This contact form is for the Django Software Foundation - the legal and
+      fundraising arm of the Django project.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      If you want to report a bug, feature request, or documentation issue in Django,
+      use the <a href="https://code.djangoproject.com">ticket tracker</a>.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      If you want to report a problem with this website, use the
+      <a href="https://github.com/django/djangoproject.com">GitHub repo</a>.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      If you've got questions about how to use Django, use the
+      <a href="https://groups.google.com/forum/#!forum/django-users">django-users mailing list</a>.
+    {% endblocktranslate %}
+  </p>
   <form action="." method="post" accept-charset="utf-8" class="form-input">
     {% csrf_token %}
     <p>
@@ -31,6 +48,6 @@
       {{ form.body }}
     </p>
     <p>{{ form.captcha }}</p>
-    <p class="submit"><input type="submit" class="cta" value="Send &rarr;"></p>
+    <p class="submit"><input type="submit" class="cta" value="{% translate 'Send' %} &rarr;"></p>
   </form>
 {% endblock %}

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -48,6 +48,6 @@
       {{ form.body }}
     </p>
     <p>{{ form.captcha }}</p>
-    <p class="submit"><input type="submit" class="cta" value="{% translate 'Send' %} &rarr;"></p>
+    <p class="submit"><input type="submit" class="cta" value="{% translate "Send &rarr;" %}"></p>
   </form>
 {% endblock %}

--- a/djangoproject/templates/contact/sent.html
+++ b/djangoproject/templates/contact/sent.html
@@ -1,18 +1,23 @@
 {% extends "base_foundation.html" %}
+{% load i18n %}
 
-{% block title %}Message sent{% endblock %}
+{% block title %}{% translate "Message sent" %}{% endblock %}
 
 {% block content %}
-  <h1>Message sent</h1>
-  <h2 class="deck">Your message has been sent; thanks!</h2>
+  <h1>{% translate "Message sent" %}</h1>
+  <h2 class="deck">{% translate "Your message has been sent; thanks!" %}</h2>
   <p>
-    Your mail <em>will</em> be read by a real, live human being. We can't
-    guarantee when or whether you'll get a reply, but your message
-    <em>will</em> be read, generally within the next couple of days.
+    {% blocktranslate trimmed %}
+      Your mail <em>will</em> be read by a real, live human being. We can't
+      guarantee when or whether you'll get a reply, but your message
+      <em>will</em> be read, generally within the next couple of days.
+    {% endblocktranslate %}
   </p>
   <p>
-    If you're expecting a reply and don't get one, please feel free
-    to send a reminder. Please wait a few days, however, unless
-    it's an emergency.
+    {% blocktranslate trimmed %}
+      If you're expecting a reply and don't get one, please feel free
+      to send a reminder. Please wait a few days, however, unless
+      it's an emergency.
+    {% endblocktranslate %}
   </p>
 {% endblock %}


### PR DESCRIPTION
This adds translations tags to the contact app as suggested in [#1648](https://github.com/django/djangoproject.com/issues/1648).