### PR TITLE
Remove expired PyCharm offer banner from homepage

### DIFF
--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -8,9 +8,9 @@
 {% block header %}
   <div class="copy-banner" style="background: #44B78B;">
     <div class="container">
-      <h1><a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&amp;utm_content=django-fundraiser-24&amp;utm_medium=referral&amp;utm_source=djangoproject.com"
+      {% comment %} <h1><a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&amp;utm_content=django-fundraiser-24&amp;utm_medium=referral&amp;utm_source=djangoproject.com"
              style="font-weight: bold;">Until October 6, 2024, get PyCharm at 30% off. All money goes to the DSF!</a>
-      </h1>
+      </h1> {% endcomment %}
     </div>
   </div>
   <h1 class="visuallyhidden">Django</h1>


### PR DESCRIPTION
This PR removes the PyCharm banner from the homepage as the offer expired on October 6, 2024.
