### PR TITLE
feat: Translation preparation for releases app

### DIFF
--- a/djangoproject/templates/releases/_download_links.html
+++ b/djangoproject/templates/releases/_download_links.html
@@ -1,12 +1,12 @@
-{% load release_notes %}
+{% load i18n release_notes %}
 
 <a href="{% url 'download-redirect' release.version 'tarball' %}">
   {{ release.tarball.name }}
 </a><br />
 {% if release.checksum %}
-  Checksums:
+  {% translate "Checksums:" %}
   <a href="{% url 'download-redirect' release.version 'checksum' %}">
     {{ release.checksum.name }}
   </a><br />
 {% endif %}
-Release notes: {% release_notes release.version %}
+{% translate "Release notes:" %} {% release_notes release.version %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -30,7 +30,8 @@
   </p>
 
   {% release_notes current.version show_version=True as current_release_version %}
-  <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
+  {% cycle 1 2 3 as options silent %}
+  <h2>{% blocktranslate %}Option {{ options }}: Get the latest official version{% endblocktranslate %}</h2>
   <p>
     {% blocktranslate trimmed with version=current.version %}
       The latest official version is {{ current.version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}.
@@ -46,8 +47,11 @@
 
   {% if preview %}
     {% release_notes preview.version show_version=True as previous_release %}
+    {% cycle options %}
     {% with preview.version|slice:":3" as major_version %}
-      <h2>{% translate "Option" %} {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
+      <h2>{% blocktranslate trimmed with version_display=preview.get_status_display %}
+        Option {{ options }}: Get the latest official version {{ version_display }} for {{ major_version }}
+      {% endblocktranslate %}}</h2>
       <p>
         {% blocktranslate trimmed with preview_version=preview.version preview_status=preview.get_status_display %}
           As part of the
@@ -63,7 +67,8 @@
     {% endwith %}
   {% endif %}
 
-  <h2>{% translate "Option" %} {% cycle options %}: {% translate "Get the latest development version" %}</h2>
+  {% cycle options %}
+  <h2>{% blocktranslate %}Option {{ options }}: Get the latest development version{% endblocktranslate %}</h2>
   <p>
     {% blocktranslate trimmed %}
       The latest and greatest Django version is the one that’s in our Git repository (our revision-control system).
@@ -339,7 +344,7 @@
 
     {% donation_snippet %}
 
-    <h2>{% translate "For the impatient:" %}</h2>
+    <h3>{% translate "For the impatient:" %}</h3>
     <ul>
       <li>{% translate "Latest release:" %}
         {% include "releases/_download_links.html" with release=current %}
@@ -364,8 +369,8 @@
       {% endblocktranslate %}
     </p>
 
-    <p>{% translate "If you're just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading)." %}</p>
-    <h2>{% translate "Previous releases" %}</h2>
+    <p>{% translate "If you're just looking for a stable deployment target and don't mind waiting for the next release, you'll want to stick with the latest official release (which will always include detailed notes on any changes you'll need to make while upgrading)." %}</p>
+    <h3>{% translate "Previous releases" %}</h3>
     <ul>
       <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
         {% include "releases/_download_links.html" with release=previous %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -8,7 +8,7 @@
 {% block og_title %}{% translate "Download Django" %}{% endblock %}
 {% block og_image %}{% static "img/release-roadmap.svg" %}{% endblock %}
 {% block og_image_alt %}{% translate "Django's release roadmap" %}{% endblock %}
-{% block og_description %}{% blocktranslate trimmed with version=current.version %}The latest official version is {{ version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
+{% block og_description %}{% blocktranslate trimmed with version=current.version_with_lts %}The latest official version is {{ version }}{% endblocktranslate %}{% endblock %}
 {% block og_image_width %}1030{% endblock %}
 {% block og_image_height %}480{% endblock %}
 {% block og_image_type %}image/svg+xml{% endblock %}
@@ -19,6 +19,7 @@
 {% block content %}
   <h1>{% translate "How to get Django" %}</h1>
   {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' as faq_install_url %}
+  {% comment %}Translators: The FAQ link is in English, and the hash after the URL should not be translated{% endcomment %}
   <p>{% blocktranslate trimmed %}
     Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
@@ -33,10 +34,11 @@
   {% cycle 1 2 3 as options silent %}
   <h2>{% blocktranslate %}Option {{ options }}: Get the latest official version{% endblocktranslate %}</h2>
   <p>
-    {% blocktranslate trimmed with version=current.version %}
-      The latest official version is {{ current.version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}.
-    {% blocktranslate trimmed %}Read the
-      {{ current_release_version }}, then install it with
+    {% blocktranslate trimmed with version=current.version_with_lts %}
+      The latest official version is {{ version }}.
+    {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+      Read the {{ current_release_version }}, then install it with
       <a href="https://pip.pypa.io/en/latest/">pip</a>:
     {% endblocktranslate %}
   </p>
@@ -86,10 +88,10 @@
   </p>
 
   <h2>{% translate "After you get it" %}</h2>
-  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as stable_url %}
+  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as install_url %}
   <p>
     {% blocktranslate trimmed %}
-      See the <a href="{{ stable_url }}">installation guide</a> for further instructions. Make sure you read the
+      See the <a href="{{ install_url }}">installation guide</a> for further instructions. Make sure you read the
       documentation that corresponds to the version of Django you’ve just installed.
     {% endblocktranslate %}
   </p>
@@ -372,7 +374,7 @@
     <p>{% translate "If you're just looking for a stable deployment target and don't mind waiting for the next release, you'll want to stick with the latest official release (which will always include detailed notes on any changes you'll need to make while upgrading)." %}</p>
     <h3>{% translate "Previous releases" %}</h3>
     <ul>
-      <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
+      <li>Django {{ previous.version_with_lts }}:
         {% include "releases/_download_links.html" with release=previous %}
       </li>
       {% if lts %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -1,23 +1,23 @@
 {% extends "base.html" %}
-{% load fundraising_extras release_notes static %}
+{% load fundraising_extras i18n release_notes static %}
 
 {% block sectionid %}download{% endblock %}
-{% block title %}Download Django{% endblock %}
+{% block title %}{% translate "Download Django" %}{% endblock %}
 {% block layout_class %}sidebar-right{% endblock %}
 
-{% block og_title %}Download Django{% endblock %}
+{% block og_title %}{% translate "Download Django" %}{% endblock %}
 {% block og_image %}{% static "img/release-roadmap.svg" %}{% endblock %}
-{% block og_image_alt %}Django's release roadmap{% endblock %}
-{% block og_description %}The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
+{% block og_image_alt %}{% translate "Django's release roadmap" %}{% endblock %}
+{% block og_description %}{% blocktranslate trimmed with version=current.version %}The latest official version is {{ version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
 {% block og_image_width %}1030{% endblock %}
 {% block og_image_height %}480{% endblock %}
 {% block og_image_type %}image/svg+xml{% endblock %}
 {% block header %}
-  <p>Download</p>
+  <h1>{% translate "Download" %}</h1>
 {% endblock %}
 
 {% block content %}
-  <h1>How to get Django</h1>
+  <h1>{% translate "How to get Django" %}</h1>
   <p>Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
     We recommend using the latest version of Python.
@@ -25,64 +25,112 @@
       the FAQ</a> for the Python versions supported by each version of Django.
     Here’s how to get it:</p>
 
-  <h2>Option {% cycle '1' '2' '3' as options %}: Get the latest official version</h2>
-  <p>The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}. Read the
-    {% release_notes current.version show_version=True %}, then install it with
-    <a href="https://pip.pypa.io/en/latest/">pip</a>:</p>
+  {% release_notes current.version show_version=True as current_release_version %}
+  <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
+  <p>
+    {% blocktranslate trimmed with version=current.version %}
+      The latest official version is {{ current.version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}.
+    {% blocktranslate trimmed %}Read the
+      {{ current_release_version }}, then install it with
+      <a href="https://pip.pypa.io/en/latest/">pip</a>:
+    {% endblocktranslate %}
+  </p>
   <p>Linux / macOS:</p>
   <pre class="literal-block"><code>python -m pip install Django=={{ current.version }}</code></pre>
   <p>Windows:</p>
   <pre class="literal-block"><code>py -m pip install Django=={{ current.version }}</code></pre>
 
   {% if preview %}
+    {% release_notes preview.version show_version=True as previous_release %}
     {% with preview.version|slice:":3" as major_version %}
-      <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
-      <p>As part of the
-        <a href="https://code.djangoproject.com/wiki/Version{{ major_version }}Roadmap">
-          Django {{ major_version }} development process</a>, Django
-        {{ preview.version }} is available. This release is only for users who
-        want to try the new version and help identify remaining bugs before the
-        {{ major_version }} release. Please read the
-        {% release_notes preview.version show_version=True %} before using this package.
-        <p>Install the {{ preview.get_status_display }} with <a href="https://pip.pypa.io/">pip</a>:</p>
+      <h2>{% translate "Option" %} {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
+      <p>
+        {% blocktranslate trimmed with preview_version=preview.version preview_status=preview.get_status_display %}
+          As part of the
+          <a href="https://code.djangoproject.com/wiki/Version{{ major_version }}Roadmap">
+            Django {{ major_version }} development process</a>, Django
+          {{ preview_version }} is available. This release is only for users who
+          want to try the new version and help identify remaining bugs before the
+          {{ major_version }} release. Please read the
+          {{ previous_release }} before using this package.
+          <p>Install the {{ preview_status }} with <a href="https://pip.pypa.io/">pip</a>:</p>
+        {% endblocktranslate %}
       <pre class="literal-block"><code>pip install --pre django</code></pre>
     {% endwith %}
   {% endif %}
 
-  <h2>Option {% cycle options %}: Get the latest development version</h2>
-  <p>The latest and greatest Django version is the one that’s in our Git repository (our revision-control system). This is only for experienced users who want to try incoming changes and help identify bugs before an official release. Get it using this shell command, which requires <a href="https://git-scm.com/">Git</a>:</p>
+  <h2>{% translate "Option" %} {% cycle options %}: {% translate "Get the latest development version" %}</h2>
+  <p>
+    {% blocktranslate trimmed %}
+      The latest and greatest Django version is the one that’s in our Git repository (our revision-control system).
+      This is only for experienced users who want to try incoming changes and help identify bugs before an official
+      release. Get it using this shell command, which requires <a href="https://git-scm.com/">Git</a>:
+    {% endblocktranslate %}
+  </p>
   <p class="literal-block"><code>git clone https://github.com/django/django.git</code></p>
-  <p>You can also download <a href="https://github.com/django/django/archive/main.tar.gz">
-    a gzipped tarball</a> of the development version. This archive is updated
-    every time we commit code.</p>
+  <p>
+    {% blocktranslate trimmed %}
+      You can also download <a href="https://github.com/django/django/archive/main.tar.gz">
+        a gzipped tarball</a> of the development version. This archive is updated
+      every time we commit code.
+    {% endblocktranslate %}
+  </p>
 
-  <h2>After you get it</h2>
-  <p>See the <a href="{% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' %}">installation guide</a> for further instructions. Make sure you read the documentation that corresponds to the version of Django you’ve just installed.</p>
-  <p>And be sure to sign up to the <a href="https://forum.djangoproject.com">Django Forum</a>, where other Django users and the Django developers themselves all hang out to help each other.</p>
+  <h2>{% translate "After you get it" %}</h2>
+  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as stable_url %}
+  <p>
+    {% blocktranslate trimmed %}
+      See the <a href="{{ stable_url }}">installation guide</a> for further instructions. Make sure you read the
+      documentation that corresponds to the version of Django you’ve just installed.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      And be sure to sign up to the <a href="https://forum.djangoproject.com">Django Forum</a>,
+      where other Django users and the Django developers themselves all hang out to help each other.
+    {% endblocktranslate %}
+  </p>
 
-  <h2 id="supported-versions">Supported Versions</h2>
-  <p><strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
-    These releases will contain new features, improvements to existing features, and such.</p>
-  <p><strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
-    fix bugs and/or security issues. These releases will be 100% compatible with
-    the associated feature release, unless this is impossible for security
-    reasons or to prevent data loss. So the answer to "should I upgrade to the
-    latest patch release?” will always be "yes."</p>
-  <p>Certain feature releases will be designated as <strong>long-term support
-    (LTS) releases</strong>. These releases will get security and data loss
-    fixes applied for a guaranteed period of time, typically three years.</p>
-  <p>See the <a href="{% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' %}#supported-versions">
-    supported versions policy</a> for detailed guidelines about what fixes will be backported.</p>
+  <h2 id="supported-versions">{% translate "Supported Versions" %}</h2>
+  <p>
+    {% blocktranslate trimmed %}
+      <strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
+      These releases will contain new features, improvements to existing features, and such.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      <strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
+      fix bugs and/or security issues. These releases will be 100% compatible with
+      the associated feature release, unless this is impossible for security
+      reasons or to prevent data loss. So the answer to "should I upgrade to the
+      latest patch release?” will always be "yes."
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      Certain feature releases will be designated as <strong>long-term support
+        (LTS) releases</strong>. These releases will get security and data loss
+      fixes applied for a guaranteed period of time, typically three years.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' as release_process_url %}
+    {% blocktranslate trimmed %}
+      See the <a href="{{ release_process_url }}#supported-versions">
+        supported versions policy</a> for detailed guidelines about what fixes will be backported.
+    {% endblocktranslate %}
+  </p>
 
   <img src="{% static "img/release-roadmap.svg" %}" class='img-release' style="max-width:100%;" alt="Django release roadmap">
   <hr style="margin-bottom: 20px;">
 
   <table class='django-supported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Latest Release</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Latest Release" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>5.2 LTS</td>
@@ -98,14 +146,14 @@
     </tr>
   </table>
 
-  <h2 id="future-versions">Future Roadmap</h2>
+  <h2 id="future-versions">{% translate "Future Roadmap" %}</h2>
 
   <table class='django-supported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Release Date</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Release Date" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '6.1' %}">6.1</a></td>
@@ -133,15 +181,15 @@
     </tr>
   </table>
 
-  <h2 id="unsupported-versions">Unsupported previous releases</h2>
-  <p>These release series no longer receive security updates or bug fixes.</p>
+  <h2 id="unsupported-versions">{% translate "Unsupported previous releases" %}</h2>
+  <p>{% translate "These release series no longer receive security updates or bug fixes." %}</p>
 
   <table class='django-unsupported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Latest Release</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Latest Release" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>5.1</td>
@@ -266,10 +314,13 @@
   </table>
 
   <p style="max-width: 720px;">
-    <sup id="ft1">[1] Security fixes, data loss bugs, crashing bugs, major functionality
-      bugs in newly-introduced features, and regressions from older versions of Django.</sup><br>
-    <sup id="ft2">[2] Security fixes and data loss bugs.</sup><br>
-    <sup id="ft3">[3] Last version to support Python 2.7.</sup>
+    <sup id="ft1">
+      {% blocktranslate trimmed %}
+        [1] Security fixes, data loss bugs, crashing bugs, major functionality
+        bugs in newly-introduced features, and regressions from older versions of Django.{% endblocktranslate %}
+    </sup><br>
+    <sup id="ft2">{% translate "[2] Security fixes and data loss bugs." %}</sup><br>
+    <sup id="ft3">{% translate "[3] Last version to support Python 2.7." %}</sup>
   </p>
 
 {% endblock %}
@@ -283,24 +334,33 @@
 
     {% donation_snippet %}
 
-    <h3>For the impatient:</h3>
+    <h2>{% translate "For the impatient:" %}</h2>
     <ul>
-      <li>Latest release:
+      <li>{% translate "Latest release:" %}
         {% include "releases/_download_links.html" with release=current %}
       </li>
 
       {% if preview %}
-        <li>Preview release:
+        <li>{% translate "Preview release:" %}
           {% include "releases/_download_links.html" with release=preview %}
         </li>
       {% endif %}
     </ul>
 
-    <h3>Which version is better?</h3>
-    <p>We improve Django almost every day and are pretty good about keeping the code stable. Thus, using the latest development code is a safe and easy way to get access to new features as they’re added. If you choose to follow the development version, keep in mind that there will occasionally be backwards-incompatible changes. You’ll want to pay close attention to the commits by watching <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to <a href="https://groups.google.com/group/django-updates">django-updates</a>.</p>
+    <h3>{% translate "Which version is better?" %}</h3>
+    <p>
+      {% blocktranslate trimmed %}
+        We improve Django almost every day and are pretty good about keeping the code stable.
+        Thus, using the latest development code is a safe and easy way to get access to new features as they’re added.
+        If you choose to follow the development version, keep in mind that there will occasionally be
+        backwards-incompatible changes. You’ll want to pay close attention to the commits by watching
+        <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to
+        <a href="https://groups.google.com/group/django-updates">django-updates</a>.
+      {% endblocktranslate %}
+    </p>
 
-    <p>If you’re just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading).</p>
-    <h3>Previous releases</h3>
+    <p>{% translate "If you're just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading)." %}</p>
+    <h2>{% translate "Previous releases" %}</h2>
     <ul>
       <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
         {% include "releases/_download_links.html" with release=previous %}
@@ -312,7 +372,7 @@
       {% endif %}
     </ul>
 
-    <h3>Unsupported previous releases (no longer receive security updates or bug fixes)</h3>
+    <h3>{% translate "Unsupported previous releases (no longer receive security updates or bug fixes)" %}</h3>
     <ul>
       {% for release in unsupported %}
         <li>Django {{ release.version }}:

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -127,6 +127,7 @@
   </p>
   <p>
     {% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' as release_process_url %}
+    {% comment %}Translators: The release process link is in English, and the hash after the URL should not be translated{% endcomment %}
     {% blocktranslate trimmed %}
       See the <a href="{{ release_process_url }}#supported-versions">
         supported versions policy</a> for detailed guidelines about what fixes will be backported.

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load fundraising_extras i18n release_notes static %}
+{% load date_format fundraising_extras i18n release_notes static %}
 
 {% block sectionid %}download{% endblock %}
 {% block title %}{% translate "Download Django" %}{% endblock %}
@@ -18,12 +18,16 @@
 
 {% block content %}
   <h1>{% translate "How to get Django" %}</h1>
-  <p>Django is available open-source under the
+  {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' as faq_install_url %}
+  <p>{% blocktranslate trimmed %}
+    Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
     We recommend using the latest version of Python.
-    See <a href="{% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' %}#what-python-version-can-i-use-with-django">
+    See <a href="{{ faq_install_url }}#what-python-version-can-i-use-with-django">
       the FAQ</a> for the Python versions supported by each version of Django.
-    Here’s how to get it:</p>
+    Here's how to get it:
+  {% endblocktranslate %}
+  </p>
 
   {% release_notes current.version show_version=True as current_release_version %}
   <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
@@ -104,7 +108,7 @@
       fix bugs and/or security issues. These releases will be 100% compatible with
       the associated feature release, unless this is impossible for security
       reasons or to prevent data loss. So the answer to "should I upgrade to the
-      latest patch release?” will always be "yes."
+      latest patch release?" will always be "yes."
     {% endblocktranslate %}
   </p>
   <p>
@@ -135,14 +139,14 @@
     <tr>
       <td>5.2 LTS</td>
       <td>{% get_latest_micro_release '5.2' %}</td>
-      <td>December 3, 2025</td>
-      <td>April 2028</td>
+      <td>{% isodate '2025-12-03' 'N j, Y' %}</td>
+      <td>{% isodate '2028-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td>6.0</td>
       <td>{% get_latest_micro_release '6.0' %}</td>
-      <td>August 2026</td>
-      <td>April 2027</td>
+      <td>{% isodate '2026-08-01' 'F Y' %}</td>
+      <td>{% isodate '2027-04-01' 'F Y' %}</td>
     </tr>
   </table>
 
@@ -157,27 +161,27 @@
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '6.1' %}">6.1</a></td>
-      <td>August 2026</td>
-      <td>April 2027</td>
-      <td>December 2027</td>
+      <td>{% isodate '2026-08-01' 'F Y' %}</td>
+      <td>{% isodate '2027-04-01' 'F Y' %}</td>
+      <td>{% isodate '2027-12-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '6.2' %}">6.2 LTS</a></td>
-      <td>April 2027</td>
-      <td>December 2027</td>
-      <td>April 2030</td>
+      <td>{% isodate '2027-04-01' 'F Y' %}</td>
+      <td>{% isodate '2027-12-01' 'F Y' %}</td>
+      <td>{% isodate '2030-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '7.0' %}">7.0</a></td>
-      <td>December 2027</td>
-      <td>August 2028</td>
-      <td>April 2029</td>
+      <td>{% isodate '2027-12-01' 'F Y' %}</td>
+      <td>{% isodate '2028-08-01' 'F Y' %}</td>
+      <td>{% isodate '2029-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '7.1' %}">7.1</a></td>
-      <td>August 2028</td>
-      <td>April 2029</td>
-      <td>December 2029</td>
+      <td>{% isodate '2028-08-01' 'F Y' %}</td>
+      <td>{% isodate '2029-04-01' 'F Y' %}</td>
+      <td>{% isodate '2029-12-01' 'F Y' %}</td>
     </tr>
   </table>
 
@@ -194,122 +198,122 @@
     <tr>
       <td>5.1</td>
       <td>{% get_latest_micro_release '5.1' %}</td>
-      <td>April 2, 2025</td>
-      <td>December 3, 2025</td>
+      <td>{% isodate '2025-04-02' 'N j, Y' %}</td>
+      <td>{% isodate '2025-12-03' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>5.0</td>
       <td>{% get_latest_micro_release '5.0' %}</td>
-      <td>August 7, 2024</td>
-      <td>April 2, 2025</td>
+      <td>{% isodate '2024-08-07' 'N j, Y' %}</td>
+      <td>{% isodate '2025-04-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>4.2 LTS</td>
       <td>{% get_latest_micro_release '4.2' %}</td>
-      <td>December 4, 2023</td>
-      <td>April 7, 2026</td>
+      <td>{% isodate '2023-12-04' 'N j, Y' %}</td>
+      <td>{% isodate '2026-04-07' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>4.1</td>
       <td>{% get_latest_micro_release '4.1' %}</td>
-      <td>April 5, 2023</td>
-      <td>December 1, 2023</td>
+      <td>{% isodate '2023-04-05' 'N j, Y' %}</td>
+      <td>{% isodate '2023-12-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>4.0</td>
       <td>{% get_latest_micro_release '4.0' %}</td>
-      <td>August 3, 2022</td>
-      <td>April 1, 2023</td>
+      <td>{% isodate '2022-08-03' 'N j, Y' %}</td>
+      <td>{% isodate '2023-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>3.2 LTS</td>
       <td>{% get_latest_micro_release '3.2' %}</td>
-      <td>December 7, 2021</td>
-      <td>April 1, 2024</td>
+      <td>{% isodate '2021-12-07' 'N j, Y' %}</td>
+      <td>{% isodate '2024-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>3.1</td>
       <td>{% get_latest_micro_release '3.1' %}</td>
-      <td>April 6, 2021</td>
-      <td>December 7, 2021</td>
+      <td>{% isodate '2021-04-06' 'N j, Y' %}</td>
+      <td>{% isodate '2021-12-07' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>3.0</td>
       <td>{% get_latest_micro_release '3.0' %}</td>
-      <td>August 3, 2020</td>
-      <td>April 6, 2021</td>
+      <td>{% isodate '2020-08-03' 'N j, Y' %}</td>
+      <td>{% isodate '2021-04-06' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>2.2 LTS</td>
       <td>{% get_latest_micro_release '2.2' %}</td>
-      <td>December 2, 2019</td>
-      <td>April 11, 2022</td>
+      <td>{% isodate '2019-12-02' 'N j, Y' %}</td>
+      <td>{% isodate '2022-04-11' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>2.1</td>
       <td>{% get_latest_micro_release '2.1' %}</td>
-      <td>April 1, 2019</td>
-      <td>December 2, 2019</td>
+      <td>{% isodate '2019-04-01' 'N j, Y' %}</td>
+      <td>{% isodate '2019-12-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>2.0</td>
       <td>{% get_latest_micro_release '2.0' %}</td>
-      <td>August 1, 2018</td>
-      <td>April 1, 2019</td>
+      <td>{% isodate '2018-08-01' 'N j, Y' %}</td>
+      <td>{% isodate '2019-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.11 LTS <sup><a href="#ft3">3</a></sup></td>
       <td>{% get_latest_micro_release '1.11' %}</td>
-      <td>December 2, 2017</td>
-      <td>April 1, 2020</td>
+      <td>{% isodate '2017-12-02' 'N j, Y' %}</td>
+      <td>{% isodate '2020-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.10</td>
       <td>{% get_latest_micro_release '1.10' %}</td>
-      <td>April 4, 2017</td>
-      <td>December 2, 2017</td>
+      <td>{% isodate '2017-04-04' 'N j, Y' %}</td>
+      <td>{% isodate '2017-12-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.9</td>
       <td>{% get_latest_micro_release '1.9' %}</td>
-      <td>August 1, 2016</td>
-      <td>April 4, 2017</td>
+      <td>{% isodate '2016-08-01' 'N j, Y' %}</td>
+      <td>{% isodate '2017-04-04' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.8 LTS</td>
       <td>{% get_latest_micro_release '1.8' %}</td>
-      <td>December 1, 2015</td>
-      <td>April 1, 2018</td>
+      <td>{% isodate '2015-12-01' 'N j, Y' %}</td>
+      <td>{% isodate '2018-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.7</td>
       <td>{% get_latest_micro_release '1.7' %}</td>
-      <td>April 1, 2015</td>
-      <td>December 1, 2015</td>
+      <td>{% isodate '2015-04-01' 'N j, Y' %}</td>
+      <td>{% isodate '2015-12-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.6</td>
       <td>{% get_latest_micro_release '1.6' %}</td>
-      <td>September 2, 2014</td>
-      <td>April 1, 2015</td>
+      <td>{% isodate '2014-09-02' 'N j, Y' %}</td>
+      <td>{% isodate '2015-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.5</td>
       <td>{% get_latest_micro_release '1.5' %}</td>
-      <td>November 6, 2013</td>
-      <td>September 2, 2014</td>
+      <td>{% isodate '2013-11-06' 'N j, Y' %}</td>
+      <td>{% isodate '2014-09-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.4 LTS</td>
       <td>{% get_latest_micro_release '1.4' %}</td>
-      <td>February 26, 2013</td>
-      <td>October 1, 2015</td>
+      <td>{% isodate '2013-02-26' 'N j, Y' %}</td>
+      <td>{% isodate '2015-10-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.3</td>
       <td>{% get_latest_micro_release '1.3' %}</td>
-      <td>March 23, 2012</td>
-      <td>February 26, 2013</td>
+      <td>{% isodate '2012-03-23' 'N j, Y' %}</td>
+      <td>{% isodate '2013-02-26' 'N j, Y' %}</td>
     </tr>
   </table>
 
@@ -317,7 +321,8 @@
     <sup id="ft1">
       {% blocktranslate trimmed %}
         [1] Security fixes, data loss bugs, crashing bugs, major functionality
-        bugs in newly-introduced features, and regressions from older versions of Django.{% endblocktranslate %}
+        bugs in newly-introduced features, and regressions from older versions of Django.
+      {% endblocktranslate %}
     </sup><br>
     <sup id="ft2">{% translate "[2] Security fixes and data loss bugs." %}</sup><br>
     <sup id="ft3">{% translate "[3] Last version to support Python 2.7." %}</sup>
@@ -328,7 +333,7 @@
 {% block content-related %}
 
   <div role="complementary">
-    <h2 class="visuallyhidden" id="aside-header">Additional Information</h2>
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
 
     {% top_corporate_members "diamond" "platinum" header="Diamond and Platinum Members" %}
 

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -137,6 +137,7 @@
   </p>
   <p>
     {% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' as release_process_url %}
+    {% comment %}Translators: The release process link is in English, and the hash after the URL should not be translated{% endcomment %}
     {% blocktranslate trimmed %}
       See the <a href="{{ release_process_url }}#supported-versions">
         supported versions policy</a> for detailed guidelines about what fixes will be backported.

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -13,7 +13,7 @@
 
 {% block og_image_alt %}{% translate "Django's release roadmap" %}{% endblock %}
 
-{% block og_description %}{% blocktranslate trimmed with version=current.version %}The latest official version is {{ version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
+{% block og_description %}{% blocktranslate trimmed with version=current.version_with_lts %}The latest official version is {{ version }}{% endblocktranslate %}{% endblock %}
 
 {% block og_image_width %}1030{% endblock %}
 
@@ -28,6 +28,7 @@
 {% block content %}
   <h1>{% translate "How to get Django" %}</h1>
   {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' as faq_install_url %}
+  {% comment %}Translators: The FAQ link is in English, and the hash after the URL should not be translated{% endcomment %}
   <p>{% blocktranslate trimmed %}
     Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
@@ -42,10 +43,11 @@
   {% cycle 1 2 3 as options silent %}
   <h2>{% blocktranslate %}Option {{ options }}: Get the latest official version{% endblocktranslate %}</h2>
   <p>
-    {% blocktranslate trimmed with version=current.version %}
-      The latest official version is {{ current.version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}.
-    {% blocktranslate trimmed %}Read the
-      {{ current_release_version }}, then install it with
+    {% blocktranslate trimmed with version=current.version_with_lts %}
+      The latest official version is {{ version }}.
+    {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+      Read the {{ current_release_version }}, then install it with
       <a href="https://pip.pypa.io/en/latest/">pip</a>:
     {% endblocktranslate %}
   </p>
@@ -96,10 +98,10 @@
   </p>
 
   <h2>{% translate "After you get it" %}</h2>
-  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as stable_url %}
+  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as install_url %}
   <p>
     {% blocktranslate trimmed %}
-      See the <a href="{{ stable_url }}">installation guide</a> for further instructions. Make sure you read the
+      See the <a href="{{ install_url }}">installation guide</a> for further instructions. Make sure you read the
       documentation that corresponds to the version of Django you’ve just installed.
     {% endblocktranslate %}
   </p>
@@ -388,7 +390,7 @@
     <p>{% translate "If you're just looking for a stable deployment target and don't mind waiting for the next release, you'll want to stick with the latest official release (which will always include detailed notes on any changes you'll need to make while upgrading)." %}</p>
     <h3>{% translate "Previous releases" %}</h3>
     <ul>
-      <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
+      <li>Django {{ previous.version_with_lts }}:
         {% include "releases/_download_links.html" with release=previous %}
       </li>
       {% if lts %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -39,7 +39,8 @@
   </p>
 
   {% release_notes current.version show_version=True as current_release_version %}
-  <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
+  {% cycle 1 2 3 as options silent %}
+  <h2>{% blocktranslate %}Option {{ options }}: Get the latest official version{% endblocktranslate %}</h2>
   <p>
     {% blocktranslate trimmed with version=current.version %}
       The latest official version is {{ current.version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}.
@@ -56,8 +57,11 @@
   {% if preview %}
     {% release_notes preview.version show_version=True as previous_release %}
     {% url 'roadmap' major_version as major_roadmap_url %}
-    {% with major_version=preview.version|slice:":3" %}
-      <h2>{% translate "Option" %} {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
+    {% cycle options %}
+    {% with preview.version|slice:":3" as major_version %}
+      <h2>{% blocktranslate trimmed with version_display=preview.get_status_display %}
+        Option {{ options }}: Get the latest official version {{ version_display }} for {{ major_version }}
+      {% endblocktranslate %}}</h2>
       <p>
       {% blocktranslate trimmed with preview_version=preview.version preview_status=preview.get_status_display %}
         As part of the
@@ -73,7 +77,8 @@
     {% endwith %}
   {% endif %}
 
-  <h2>{% translate "Option" %} {% cycle options %}: {% translate "Get the latest development version" %}</h2>
+  {% cycle options %}
+  <h2>{% blocktranslate %}Option {{ options }}: Get the latest development version{% endblocktranslate %}</h2>
   <p>
     {% blocktranslate trimmed %}
       The latest and greatest Django version is the one that’s in our Git repository (our revision-control system).
@@ -355,7 +360,7 @@
 
     {% donation_snippet %}
 
-    <h2>{% translate "For the impatient:" %}</h2>
+    <h3>{% translate "For the impatient:" %}</h3>
     <ul>
       <li>{% translate "Latest release:" %}
         {% include "releases/_download_links.html" with release=current %}
@@ -380,8 +385,8 @@
       {% endblocktranslate %}
     </p>
 
-    <p>{% translate "If you're just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading)." %}</p>
-    <h2>{% translate "Previous releases" %}</h2>
+    <p>{% translate "If you're just looking for a stable deployment target and don't mind waiting for the next release, you'll want to stick with the latest official release (which will always include detailed notes on any changes you'll need to make while upgrading)." %}</p>
+    <h3>{% translate "Previous releases" %}</h3>
     <ul>
       <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
         {% include "releases/_download_links.html" with release=previous %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load fundraising_extras i18n release_notes static %}
+{% load date_format fundraising_extras i18n release_notes static %}
 
 {% block sectionid %}download{% endblock %}
 
@@ -27,12 +27,16 @@
 
 {% block content %}
   <h1>{% translate "How to get Django" %}</h1>
-  <p>Django is available open-source under the
+  {% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' as faq_install_url %}
+  <p>{% blocktranslate trimmed %}
+    Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
     We recommend using the latest version of Python.
-    See <a href="{% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' %}#what-python-version-can-i-use-with-django">
+    See <a href="{{ faq_install_url }}#what-python-version-can-i-use-with-django">
       the FAQ</a> for the Python versions supported by each version of Django.
-    Here’s how to get it:</p>
+    Here's how to get it:
+  {% endblocktranslate %}
+  </p>
 
   {% release_notes current.version show_version=True as current_release_version %}
   <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
@@ -114,7 +118,7 @@
       fix bugs and/or security issues. These releases will be 100% compatible with
       the associated feature release, unless this is impossible for security
       reasons or to prevent data loss. So the answer to "should I upgrade to the
-      latest patch release?” will always be "yes."
+      latest patch release?" will always be "yes."
     {% endblocktranslate %}
   </p>
   <p>
@@ -145,20 +149,20 @@
     <tr>
       <td>5.2 LTS</td>
       <td>{% get_latest_micro_release '5.2' %}</td>
-      <td>December 3, 2025</td>
-      <td>April 2028</td>
+      <td>{% isodate '2025-12-03' 'N j, Y' %}</td>
+      <td>{% isodate '2028-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td>6.0</td>
       <td>{% get_latest_micro_release '6.0' %}</td>
-      <td>August 4, 2026</td>
-      <td>April 2027</td>
+      <td>{% isodate '2026-08-01' 'F Y' %}</td>
+      <td>{% isodate '2027-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td>6.1</td>
       <td>{% get_latest_micro_release '6.1' %}</td>
-      <td>April 2027</td>
-      <td>December 2027</td>
+      <td>{% isodate '2027-04-01' 'F Y' %}</td>
+      <td>{% isodate '2027-12-01' 'F Y' %}</td>
     </tr>
   </table>
 
@@ -173,27 +177,27 @@
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '6.2' %}">6.2 LTS</a></td>
-      <td>April 2027</td>
-      <td>December 2027</td>
-      <td>April 2030</td>
+      <td>{% isodate '2027-04-01' 'F Y' %}</td>
+      <td>{% isodate '2027-12-01' 'F Y' %}</td>
+      <td>{% isodate '2030-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '7.0' %}">7.0</a></td>
-      <td>December 2027</td>
-      <td>August 2028</td>
-      <td>April 2029</td>
+      <td>{% isodate '2027-12-01' 'F Y' %}</td>
+      <td>{% isodate '2028-08-01' 'F Y' %}</td>
+      <td>{% isodate '2029-04-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '7.1' %}">7.1</a></td>
-      <td>August 2028</td>
-      <td>April 2029</td>
-      <td>December 2029</td>
+      <td>{% isodate '2028-08-01' 'F Y' %}</td>
+      <td>{% isodate '2029-04-01' 'F Y' %}</td>
+      <td>{% isodate '2029-12-01' 'F Y' %}</td>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '7.2' %}">7.2 LTS</a></td>
-      <td>April 2029</td>
-      <td>December 2029</td>
-      <td>April 2032</td>
+      <td>{% isodate '2029-04-01' 'F Y' %}</td>
+      <td>{% isodate '2029-12-01' 'F Y' %}</td>
+      <td>{% isodate '2032-04-01' 'F Y' %}</td>
     </tr>
   </table>
 
@@ -210,122 +214,122 @@
     <tr>
       <td>5.1</td>
       <td>{% get_latest_micro_release '5.1' %}</td>
-      <td>April 2, 2025</td>
-      <td>December 3, 2025</td>
+      <td>{% isodate '2025-04-02' 'N j, Y' %}</td>
+      <td>{% isodate '2025-12-03' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>5.0</td>
       <td>{% get_latest_micro_release '5.0' %}</td>
-      <td>August 7, 2024</td>
-      <td>April 2, 2025</td>
+      <td>{% isodate '2024-08-07' 'N j, Y' %}</td>
+      <td>{% isodate '2025-04-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>4.2 LTS</td>
       <td>{% get_latest_micro_release '4.2' %}</td>
-      <td>December 4, 2023</td>
-      <td>April 7, 2026</td>
+      <td>{% isodate '2023-12-04' 'N j, Y' %}</td>
+      <td>{% isodate '2026-04-07' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>4.1</td>
       <td>{% get_latest_micro_release '4.1' %}</td>
-      <td>April 5, 2023</td>
-      <td>December 1, 2023</td>
+      <td>{% isodate '2023-04-05' 'N j, Y' %}</td>
+      <td>{% isodate '2023-12-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>4.0</td>
       <td>{% get_latest_micro_release '4.0' %}</td>
-      <td>August 3, 2022</td>
-      <td>April 1, 2023</td>
+      <td>{% isodate '2022-08-03' 'N j, Y' %}</td>
+      <td>{% isodate '2023-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>3.2 LTS</td>
       <td>{% get_latest_micro_release '3.2' %}</td>
-      <td>December 7, 2021</td>
-      <td>April 1, 2024</td>
+      <td>{% isodate '2021-12-07' 'N j, Y' %}</td>
+      <td>{% isodate '2024-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>3.1</td>
       <td>{% get_latest_micro_release '3.1' %}</td>
-      <td>April 6, 2021</td>
-      <td>December 7, 2021</td>
+      <td>{% isodate '2021-04-06' 'N j, Y' %}</td>
+      <td>{% isodate '2021-12-07' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>3.0</td>
       <td>{% get_latest_micro_release '3.0' %}</td>
-      <td>August 3, 2020</td>
-      <td>April 6, 2021</td>
+      <td>{% isodate '2020-08-03' 'N j, Y' %}</td>
+      <td>{% isodate '2021-04-06' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>2.2 LTS</td>
       <td>{% get_latest_micro_release '2.2' %}</td>
-      <td>December 2, 2019</td>
-      <td>April 11, 2022</td>
+      <td>{% isodate '2019-12-02' 'N j, Y' %}</td>
+      <td>{% isodate '2022-04-11' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>2.1</td>
       <td>{% get_latest_micro_release '2.1' %}</td>
-      <td>April 1, 2019</td>
-      <td>December 2, 2019</td>
+      <td>{% isodate '2019-04-01' 'N j, Y' %}</td>
+      <td>{% isodate '2019-12-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>2.0</td>
       <td>{% get_latest_micro_release '2.0' %}</td>
-      <td>August 1, 2018</td>
-      <td>April 1, 2019</td>
+      <td>{% isodate '2018-08-01' 'N j, Y' %}</td>
+      <td>{% isodate '2019-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.11 LTS <sup><a href="#ft3">3</a></sup></td>
       <td>{% get_latest_micro_release '1.11' %}</td>
-      <td>December 2, 2017</td>
-      <td>April 1, 2020</td>
+      <td>{% isodate '2017-12-02' 'N j, Y' %}</td>
+      <td>{% isodate '2020-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.10</td>
       <td>{% get_latest_micro_release '1.10' %}</td>
-      <td>April 4, 2017</td>
-      <td>December 2, 2017</td>
+      <td>{% isodate '2017-04-04' 'N j, Y' %}</td>
+      <td>{% isodate '2017-12-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.9</td>
       <td>{% get_latest_micro_release '1.9' %}</td>
-      <td>August 1, 2016</td>
-      <td>April 4, 2017</td>
+      <td>{% isodate '2016-08-01' 'N j, Y' %}</td>
+      <td>{% isodate '2017-04-04' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.8 LTS</td>
       <td>{% get_latest_micro_release '1.8' %}</td>
-      <td>December 1, 2015</td>
-      <td>April 1, 2018</td>
+      <td>{% isodate '2015-12-01' 'N j, Y' %}</td>
+      <td>{% isodate '2018-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.7</td>
       <td>{% get_latest_micro_release '1.7' %}</td>
-      <td>April 1, 2015</td>
-      <td>December 1, 2015</td>
+      <td>{% isodate '2015-04-01' 'N j, Y' %}</td>
+      <td>{% isodate '2015-12-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.6</td>
       <td>{% get_latest_micro_release '1.6' %}</td>
-      <td>September 2, 2014</td>
-      <td>April 1, 2015</td>
+      <td>{% isodate '2014-09-02' 'N j, Y' %}</td>
+      <td>{% isodate '2015-04-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.5</td>
       <td>{% get_latest_micro_release '1.5' %}</td>
-      <td>November 6, 2013</td>
-      <td>September 2, 2014</td>
+      <td>{% isodate '2013-11-06' 'N j, Y' %}</td>
+      <td>{% isodate '2014-09-02' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.4 LTS</td>
       <td>{% get_latest_micro_release '1.4' %}</td>
-      <td>February 26, 2013</td>
-      <td>October 1, 2015</td>
+      <td>{% isodate '2013-02-26' 'N j, Y' %}</td>
+      <td>{% isodate '2015-10-01' 'N j, Y' %}</td>
     </tr>
     <tr>
       <td>1.3</td>
       <td>{% get_latest_micro_release '1.3' %}</td>
-      <td>March 23, 2012</td>
-      <td>February 26, 2013</td>
+      <td>{% isodate '2012-03-23' 'N j, Y' %}</td>
+      <td>{% isodate '2013-02-26' 'N j, Y' %}</td>
     </tr>
   </table>
 
@@ -333,7 +337,8 @@
     <sup id="ft1">
       {% blocktranslate trimmed %}
         [1] Security fixes, data loss bugs, crashing bugs, major functionality
-        bugs in newly-introduced features, and regressions from older versions of Django.{% endblocktranslate %}
+        bugs in newly-introduced features, and regressions from older versions of Django.
+      {% endblocktranslate %}
     </sup><br>
     <sup id="ft2">{% translate "[2] Security fixes and data loss bugs." %}</sup><br>
     <sup id="ft3">{% translate "[3] Last version to support Python 2.7." %}</sup>
@@ -344,7 +349,7 @@
 {% block content-related %}
 
   <div role="complementary">
-    <h2 class="visuallyhidden" id="aside-header">Additional Information</h2>
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
 
     {% top_corporate_members "diamond" "platinum" header="Diamond and Platinum Members" %}
 

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
-{% load fundraising_extras release_notes static %}
+{% load fundraising_extras i18n release_notes static %}
 
 {% block sectionid %}download{% endblock %}
 
-{% block title %}Download Django{% endblock %}
+{% block title %}{% translate "Download Django" %}{% endblock %}
 
 {% block layout_class %}sidebar-right{% endblock %}
 
-{% block og_title %}Download Django{% endblock %}
+{% block og_title %}{% translate "Download Django" %}{% endblock %}
 
 {% block og_image %}{% static "img/release-roadmap.svg" %}{% endblock %}
 
-{% block og_image_alt %}Django's release roadmap{% endblock %}
+{% block og_image_alt %}{% translate "Django's release roadmap" %}{% endblock %}
 
-{% block og_description %}The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
+{% block og_description %}{% blocktranslate trimmed with version=current.version %}The latest official version is {{ version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
 
 {% block og_image_width %}1030{% endblock %}
 
@@ -22,11 +22,11 @@
 {% block og_image_type %}image/svg+xml{% endblock %}
 
 {% block header %}
-  <p>Download</p>
+  <p>{% translate "Download" %}</p>
 {% endblock header %}
 
 {% block content %}
-  <h1>How to get Django</h1>
+  <h1>{% translate "How to get Django" %}</h1>
   <p>Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
     We recommend using the latest version of Python.
@@ -34,64 +34,113 @@
       the FAQ</a> for the Python versions supported by each version of Django.
     Here’s how to get it:</p>
 
-  <h2>Option {% cycle '1' '2' '3' as options %}: Get the latest official version</h2>
-  <p>The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}. Read the
-    {% release_notes current.version show_version=True %}, then install it with
-    <a href="https://pip.pypa.io/en/latest/">pip</a>:</p>
+  {% release_notes current.version show_version=True as current_release_version %}
+  <h2>{% translate "Option" %} {% cycle '1' '2' '3' as options %}: {% translate "Get the latest official version" %}</h2>
+  <p>
+    {% blocktranslate trimmed with version=current.version %}
+      The latest official version is {{ current.version }}{% endblocktranslate %}{% if current.is_lts %} (LTS){% endif %}.
+    {% blocktranslate trimmed %}Read the
+      {{ current_release_version }}, then install it with
+      <a href="https://pip.pypa.io/en/latest/">pip</a>:
+    {% endblocktranslate %}
+  </p>
   <p>Linux / macOS:</p>
   <pre class="literal-block"><code>python -m pip install Django=={{ current.version }}</code></pre>
   <p>Windows:</p>
   <pre class="literal-block"><code>py -m pip install Django=={{ current.version }}</code></pre>
 
   {% if preview %}
+    {% release_notes preview.version show_version=True as previous_release %}
+    {% url 'roadmap' major_version as major_roadmap_url %}
     {% with major_version=preview.version|slice:":3" %}
-      <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
-      <p>As part of the
-        <a href="{% url 'roadmap' major_version %}">
+      <h2>{% translate "Option" %} {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
+      <p>
+      {% blocktranslate trimmed with preview_version=preview.version preview_status=preview.get_status_display %}
+        As part of the
+        <a href="{{ major_roadmap_url }}">
           Django {{ major_version }} development process</a>, Django
         {{ preview.version }} is available. This release is only for users who
         want to try the new version and help identify remaining bugs before the
         {{ major_version }} release. Please read the
-        {% release_notes preview.version show_version=True %} before using this package.
-        <p>Install the {{ preview.get_status_display }} with <a href="https://pip.pypa.io/">pip</a>:</p>
+        {{ previous_release }} before using this package.
+        <p>Install the {{ preview_status }} with <a href="https://pip.pypa.io/">pip</a>:</p>
+      {% endblocktranslate %}
       <pre class="literal-block"><code>pip install --pre django</code></pre>
     {% endwith %}
   {% endif %}
 
-  <h2>Option {% cycle options %}: Get the latest development version</h2>
-  <p>The latest and greatest Django version is the one that’s in our Git repository (our revision-control system). This is only for experienced users who want to try incoming changes and help identify bugs before an official release. Get it using this shell command, which requires <a href="https://git-scm.com/">Git</a>:</p>
+  <h2>{% translate "Option" %} {% cycle options %}: {% translate "Get the latest development version" %}</h2>
+  <p>
+    {% blocktranslate trimmed %}
+      The latest and greatest Django version is the one that’s in our Git repository (our revision-control system).
+      This is only for experienced users who want to try incoming changes and help identify bugs before an official
+      release. Get it using this shell command, which requires <a href="https://git-scm.com/">Git</a>:
+    {% endblocktranslate %}
+  </p>
   <p class="literal-block"><code>git clone https://github.com/django/django.git</code></p>
-  <p>You can also download <a href="https://github.com/django/django/archive/main.tar.gz">
-    a gzipped tarball</a> of the development version. This archive is updated
-    every time we commit code.</p>
+  <p>
+    {% blocktranslate trimmed %}
+      You can also download <a href="https://github.com/django/django/archive/main.tar.gz">
+        a gzipped tarball</a> of the development version. This archive is updated
+      every time we commit code.
+    {% endblocktranslate %}
+  </p>
 
-  <h2>After you get it</h2>
-  <p>See the <a href="{% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' %}">installation guide</a> for further instructions. Make sure you read the documentation that corresponds to the version of Django you’ve just installed.</p>
-  <p>And be sure to sign up to the <a href="https://forum.djangoproject.com">Django Forum</a>, where other Django users and the Django developers themselves all hang out to help each other.</p>
+  <h2>{% translate "After you get it" %}</h2>
+  {% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' as stable_url %}
+  <p>
+    {% blocktranslate trimmed %}
+      See the <a href="{{ stable_url }}">installation guide</a> for further instructions. Make sure you read the
+      documentation that corresponds to the version of Django you’ve just installed.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      And be sure to sign up to the <a href="https://forum.djangoproject.com">Django Forum</a>,
+      where other Django users and the Django developers themselves all hang out to help each other.
+    {% endblocktranslate %}
+  </p>
 
-  <h2 id="supported-versions">Supported Versions</h2>
-  <p><strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
-    These releases will contain new features, improvements to existing features, and such.</p>
-  <p><strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
-    fix bugs and/or security issues. These releases will be 100% compatible with
-    the associated feature release, unless this is impossible for security
-    reasons or to prevent data loss. So the answer to "should I upgrade to the
-    latest patch release?” will always be "yes."</p>
-  <p>Certain feature releases will be designated as <strong>long-term support
-    (LTS) releases</strong>. These releases will get security and data loss
-    fixes applied for a guaranteed period of time, typically three years.</p>
-  <p>See the <a href="{% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' %}#supported-versions">
-    supported versions policy</a> for detailed guidelines about what fixes will be backported.</p>
+  <h2 id="supported-versions">{% translate "Supported Versions" %}</h2>
+  <p>
+    {% blocktranslate trimmed %}
+      <strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
+      These releases will contain new features, improvements to existing features, and such.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      <strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
+      fix bugs and/or security issues. These releases will be 100% compatible with
+      the associated feature release, unless this is impossible for security
+      reasons or to prevent data loss. So the answer to "should I upgrade to the
+      latest patch release?” will always be "yes."
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% blocktranslate trimmed %}
+      Certain feature releases will be designated as <strong>long-term support
+        (LTS) releases</strong>. These releases will get security and data loss
+      fixes applied for a guaranteed period of time, typically three years.
+    {% endblocktranslate %}
+  </p>
+  <p>
+    {% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' as release_process_url %}
+    {% blocktranslate trimmed %}
+      See the <a href="{{ release_process_url }}#supported-versions">
+        supported versions policy</a> for detailed guidelines about what fixes will be backported.
+    {% endblocktranslate %}
+  </p>
 
   <img src="{% static "img/release-roadmap.svg" %}" class='img-release' style="max-width:100%;" alt="Django release roadmap">
   <hr style="margin-bottom: 20px;">
 
   <table class='django-supported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Latest Release</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Latest Release" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>5.2 LTS</td>
@@ -113,14 +162,14 @@
     </tr>
   </table>
 
-  <h2 id="future-versions">Future Roadmap</h2>
+  <h2 id="future-versions">{% translate "Future Roadmap" %}</h2>
 
   <table class='django-supported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Release Date</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Release Date" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td><a href="{% url 'roadmap' '6.2' %}">6.2 LTS</a></td>
@@ -148,15 +197,15 @@
     </tr>
   </table>
 
-  <h2 id="unsupported-versions">Unsupported previous releases</h2>
-  <p>These release series no longer receive security updates or bug fixes.</p>
+  <h2 id="unsupported-versions">{% translate "Unsupported previous releases" %}</h2>
+  <p>{% translate "These release series no longer receive security updates or bug fixes." %}</p>
 
   <table class='django-unsupported-versions'>
     <tr>
-      <th>Release Series</th>
-      <th>Latest Release</th>
-      <th>End of mainstream support<sup><a href="#ft1">1</a></sup></th>
-      <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
+      <th>{% translate "Release Series" %}</th>
+      <th>{% translate "Latest Release" %}</th>
+      <th>{% translate "End of mainstream support" %}<sup><a href="#ft1">1</a></sup></th>
+      <th>{% translate "End of extended support" %}<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
       <td>5.1</td>
@@ -281,10 +330,13 @@
   </table>
 
   <p style="max-width: 720px;">
-    <sup id="ft1">[1] Security fixes, data loss bugs, crashing bugs, major functionality
-      bugs in newly-introduced features, and regressions from older versions of Django.</sup><br>
-    <sup id="ft2">[2] Security fixes and data loss bugs.</sup><br>
-    <sup id="ft3">[3] Last version to support Python 2.7.</sup>
+    <sup id="ft1">
+      {% blocktranslate trimmed %}
+        [1] Security fixes, data loss bugs, crashing bugs, major functionality
+        bugs in newly-introduced features, and regressions from older versions of Django.{% endblocktranslate %}
+    </sup><br>
+    <sup id="ft2">{% translate "[2] Security fixes and data loss bugs." %}</sup><br>
+    <sup id="ft3">{% translate "[3] Last version to support Python 2.7." %}</sup>
   </p>
 
 {% endblock content %}
@@ -298,24 +350,33 @@
 
     {% donation_snippet %}
 
-    <h3>For the impatient:</h3>
+    <h2>{% translate "For the impatient:" %}</h2>
     <ul>
-      <li>Latest release:
+      <li>{% translate "Latest release:" %}
         {% include "releases/_download_links.html" with release=current %}
       </li>
 
       {% if preview %}
-        <li>Preview release:
+        <li>{% translate "Preview release:" %}
           {% include "releases/_download_links.html" with release=preview %}
         </li>
       {% endif %}
     </ul>
 
-    <h3>Which version is better?</h3>
-    <p>We improve Django almost every day and are pretty good about keeping the code stable. Thus, using the latest development code is a safe and easy way to get access to new features as they’re added. If you choose to follow the development version, keep in mind that there will occasionally be backwards-incompatible changes. You’ll want to pay close attention to the commits by watching <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to <a href="https://groups.google.com/group/django-updates">django-updates</a>.</p>
+    <h3>{% translate "Which version is better?" %}</h3>
+    <p>
+      {% blocktranslate trimmed %}
+        We improve Django almost every day and are pretty good about keeping the code stable.
+        Thus, using the latest development code is a safe and easy way to get access to new features as they’re added.
+        If you choose to follow the development version, keep in mind that there will occasionally be
+        backwards-incompatible changes. You’ll want to pay close attention to the commits by watching
+        <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to
+        <a href="https://groups.google.com/group/django-updates">django-updates</a>.
+      {% endblocktranslate %}
+    </p>
 
-    <p>If you’re just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading).</p>
-    <h3>Previous releases</h3>
+    <p>{% translate "If you're just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading)." %}</p>
+    <h2>{% translate "Previous releases" %}</h2>
     <ul>
       <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
         {% include "releases/_download_links.html" with release=previous %}
@@ -327,7 +388,7 @@
       {% endif %}
     </ul>
 
-    <h3>Unsupported previous releases (no longer receive security updates or bug fixes)</h3>
+    <h3>{% translate "Unsupported previous releases (no longer receive security updates or bug fixes)" %}</h3>
     <ul>
       {% for release in unsupported %}
         <li>Django {{ release.version }}:

--- a/releases/models.py
+++ b/releases/models.py
@@ -10,6 +10,7 @@ from django.core.files.storage import FileSystemStorage
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
 from django.utils.version import get_complete_version, get_main_version
 
 from .utils import get_loose_version_tuple
@@ -161,7 +162,6 @@ def upload_to_checksum(release, filename):
     return f"pgp/Django-{version}.checksum.txt"
 
 
-@total_ordering
 class Release(models.Model):
     DEFAULT_CACHE_KEY = "%s_django_version" % settings.CACHE_MIDDLEWARE_KEY_PREFIX
     STATUS_CHOICES = (
@@ -187,21 +187,25 @@ class Release(models.Model):
         default=False,
     )
     date = models.DateField(
-        "Release date",
+        _("Release date"),
         null=True,
         blank=True,
         default=datetime.date.today,
-        help_text="Leave blank if the release date isn't known yet, typically "
-        "if you're creating the final release just after the alpha "
-        "because you want to build docs for the upcoming version.",
+        help_text=_(
+            "Leave blank if the release date isn't known yet, typically "
+            "if you're creating the final release just after the alpha "
+            "because you want to build docs for the upcoming version."
+        ),
     )
     eol_date = models.DateField(
-        "End of life date",
+        _("End of life date"),
         null=True,
         blank=True,
-        help_text="Leave blank if the end of life date isn't known yet, "
-        "typically because it depends on the release date of a "
-        "later version.",
+        help_text=_(
+            "Leave blank if the end of life date isn't known yet, "
+            "typically because it depends on the release date of a "
+            "later version."
+        ),
     )
 
     major = models.PositiveSmallIntegerField(editable=False)
@@ -210,8 +214,8 @@ class Release(models.Model):
     status = models.CharField(max_length=1, choices=STATUS_CHOICES, editable=False)
     iteration = models.PositiveSmallIntegerField(editable=False)
     is_lts = models.BooleanField(
-        "Long Term Support",
-        help_text=(
+        _("Long Term Support"),
+        help_text=_(
             'Is this a release for an <abbr title="Long Term Support">LTS</abbr> '
             "Django version (e.g. 5.2a1, 5.2, 5.2.4)?"
         ),
@@ -219,19 +223,19 @@ class Release(models.Model):
     )
     # Artifacts.
     tarball = models.FileField(
-        "Tarball artifact as a .tar.gz file",
+        _("Tarball artifact as a .tar.gz file"),
         storage=get_storage,
         upload_to=upload_to_artifact,
         blank=True,
     )
     wheel = models.FileField(
-        "Wheel artifact as a .whl file",
+        _("Wheel artifact as a .whl file"),
         storage=get_storage,
         upload_to=upload_to_artifact,
         blank=True,
     )
     checksum = models.FileField(
-        "Signed checksum as a .asc file",
+        _("Signed checksum as a .asc file"),
         storage=get_storage,
         upload_to=upload_to_checksum,
         blank=True,
@@ -319,14 +323,14 @@ class Release(models.Model):
     def clean(self):
         if self.is_published and not self.tarball:
             raise ValidationError(
-                {"tarball": "This field is required when the release is active."}
+                {"tarball": _("This field is required when the release is active.")}
             )
 
         if (self.tarball or self.wheel) and not self.checksum:
             raise ValidationError(
                 {
                     "checksum": (
-                        "This field is required when an artifact has been uploaded."
+                        _("This field is required when an artifact has been uploaded.")
                     )
                 }
             )

--- a/releases/models.py
+++ b/releases/models.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from functools import total_ordering
 from pathlib import Path
 
 from django.conf import settings
@@ -161,6 +162,7 @@ def upload_to_checksum(release, filename):
     return f"pgp/Django-{version}.checksum.txt"
 
 
+@total_ordering
 class Release(models.Model):
     DEFAULT_CACHE_KEY = "%s_django_version" % settings.CACHE_MIDDLEWARE_KEY_PREFIX
     STATUS_CHOICES = (

--- a/releases/models.py
+++ b/releases/models.py
@@ -1,6 +1,5 @@
 import datetime
 import re
-from functools import total_ordering
 from pathlib import Path
 
 from django.conf import settings
@@ -10,7 +9,7 @@ from django.core.files.storage import FileSystemStorage
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 from django.utils.version import get_complete_version, get_main_version
 
 from .utils import get_loose_version_tuple
@@ -316,6 +315,14 @@ class Release(models.Model):
     def is_dot_zero(self):
         """Return True if this is a final X.Y.0 release."""
         return self.status == "f" and self.micro == 0
+
+    @cached_property
+    def version_with_lts(self):
+        if self.is_lts:
+            # Translators: Long Term Support version
+            return gettext("{version} (LTS)").format(version=self.version)
+        else:
+            return self.version
 
     def __lt__(self, other):
         return self.version_tuple < other.version_tuple

--- a/releases/templatetags/date_format.py
+++ b/releases/templatetags/date_format.py
@@ -12,5 +12,8 @@ def isodate(datestr, dateformat="DATE_FORMAT"):
     Convert the given string to a date object (ISO) then format it using
     the given format (using Django's |date template filter)
     """
-    d = date.fromisoformat(datestr)
+    try:
+        d = date.fromisoformat(datestr)
+    except (ValueError, TypeError):
+        return ""
     return datefilter(d, dateformat)

--- a/releases/templatetags/date_format.py
+++ b/releases/templatetags/date_format.py
@@ -12,8 +12,5 @@ def isodate(datestr, dateformat="DATE_FORMAT"):
     Convert the given string to a date object (ISO) then format it using
     the given format (using Django's |date template filter)
     """
-    try:
-        d = date.fromisoformat(datestr)
-    except (ValueError, TypeError):
-        return ""
+    d = date.fromisoformat(datestr)
     return datefilter(d, dateformat)

--- a/releases/templatetags/release_notes.py
+++ b/releases/templatetags/release_notes.py
@@ -14,7 +14,7 @@ register = template.Library()
 def release_notes(version, show_version=False):
     version_x_dot_y = ".".join(str(x) for x in get_loose_version_tuple(version)[:2])
     is_pre_release = any(c in version for c in ("a", "b", "c"))
-    # links for prereleases don't have their own release notes
+    # links for pre-releases don't have their own release notes
     display_version = version_x_dot_y if is_pre_release else version
     if show_version:
         anchor_text = _("%(version)s release notes") % {"version": display_version}


### PR DESCRIPTION
This adds translations tags to the releases app as suggested in [#1648](https://github.com/django/djangoproject.com/issues/1648)