### PR TITLE
Added debug toolbar in dev requirements.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r common.txt
+django-debug-toolbar==4.4.6
 pre-commit~=3.5.0
 watchdog==4.0.2


### PR DESCRIPTION
Debug toolbar is already configured in the project, but the dependency in the requirements for local development was missing.