### PR TITLE
Updated Sphinx and related dependencies.

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ django-read-only==1.16.0
 django-recaptcha==4.0.0
 django-registration-redux==2.13
 Django==4.2.16
-docutils==0.20.1
+docutils==0.21.2
 feedparser==6.0.11
 Jinja2==3.1.4
 libsass==0.23.0
@@ -19,5 +19,5 @@ Pygments==2.18.0
 pykismet3==0.1.1
 requests==2.32.3
 sorl-thumbnail==12.11.0
-Sphinx==7.1.2
+Sphinx==8.1.3
 stripe==3.1.0


### PR DESCRIPTION
As noted in #1634, the latest version of Sphinx has been used in the Django repository for a long time without any problems.

I tested locally the documentation generation without any problems: `python -m manage update_docs --update-index --force`

Of course, this PR is blocked by the Python 3.8 removal issue #1644