### PR TITLE
Removed production Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,5 @@ RUN npm install
 # copy project
 COPY . .
 
-# run docker-entrypoint.sh
-ENTRYPOINT ["./docker-entrypoint.prod.sh"]
+# ENTRYPOINT is specified only in the local docker-compose.yml to avoid
+# accidentally running it in deployed environments.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             dockerfile: Dockerfile
             args:
                 - REQ_FILE=requirements/tests.txt
-        entrypoint: docker-entrypoint.dev.sh
+        entrypoint: ./docker-entrypoint.dev.sh
         command: python manage.py runserver 0.0.0.0:8000
         volumes:
             - .:/usr/src/app/

--- a/docker-entrypoint.prod.sh
+++ b/docker-entrypoint.prod.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-python -m manage migrate
-python -m manage compilemessages
-make compile-scss # must come before collectstatic
-python -m manage collectstatic --no-input --clear
-
-exec "$@"


### PR DESCRIPTION
In the deployed environment, these commands are now run by Ansible after the container starts to shorten the startup time. We should remove the entrypoint to avoid the false impression that this file is used.
