### PR TITLE
Fix broken dashboard metrics

### DIFF
--- a/dashboard/management/commands/fix_trac_metrics.py
+++ b/dashboard/management/commands/fix_trac_metrics.py
@@ -1,0 +1,93 @@
+from datetime import date, timedelta
+
+import time_machine
+from django.core.management.base import CommandError, LabelCommand
+from django.db.models import Case, Max, Min, When
+
+from ...models import TracTicketMetric
+
+
+def _get_data(metric, options):
+    """
+    Return a queryset of Datum instances for the given metric, taking into
+    account the from_date/to_date keys of the given options dict.
+    """
+    queryset = metric.data.all()
+    if options["from_date"]:
+        queryset = queryset.filter(timestamp__date__gte=options["from_date"])
+    if options["to_date"]:
+        queryset = queryset.filter(timestamp__date__lte=options["to_date"])
+    return queryset
+
+
+def _daterange(queryset):
+    """
+    Given a queryset of Datum objects, generate all dates (as date objects)
+    between the earliest and latest data points in the queryset.
+    """
+    aggregated = queryset.aggregate(
+        start=Min("timestamp__date"), end=Max("timestamp__date")
+    )
+    if aggregated["start"] is None or aggregated["end"] is None:
+        raise ValueError("queryset cannot be empty")
+
+    d = aggregated["start"]
+    while d <= aggregated["end"]:
+        yield d
+        d += timedelta(days=1)
+
+
+def _refetched_case_when(dates, metric):
+    """
+    Refetch the given metric for all the given dates and build a CASE database
+    expression with one WHEN per date.
+    """
+    whens = []
+    for d in dates:
+        with time_machine.travel(d):
+            whens.append(When(timestamp__date=d, then=metric.fetch()))
+    return Case(*whens)
+
+
+class Command(LabelCommand):
+    help = "Retroactively refetch measurements for Trac metrics."
+    label = "slug"
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--yes", action="store_true", help="Commit the changes to the database"
+        )
+        parser.add_argument(
+            "--from-date",
+            type=date.fromisoformat,
+            help="Restrict the timestamp range (ISO format)",
+        )
+        parser.add_argument(
+            "--to-date",
+            type=date.fromisoformat,
+            help="Restrict the timestamp range (ISO format)",
+        )
+
+    def handle_label(self, label, **options):
+        try:
+            metric = TracTicketMetric.objects.get(slug=label)
+        except TracTicketMetric.DoesNotExist as e:
+            raise CommandError from e
+
+        verbose = int(options["verbosity"]) > 0
+
+        if verbose:
+            self.stdout.write(f"Fixing metric {label}...")
+        dataset = _get_data(metric, options)
+
+        if options["yes"]:
+            dates = _daterange(dataset)
+            updated_measurement_expression = _refetched_case_when(dates, metric)
+            updated = dataset.update(measurement=updated_measurement_expression)
+            if verbose:
+                self.stdout.write(self.style.SUCCESS(f"{updated} rows updated"))
+        else:
+            if verbose:
+                self.stdout.write(f"{dataset.count()} rows will be updated.")
+                self.stdout.write("Re-run the command with --yes to apply the change")

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,3 +21,4 @@ requests==2.32.3
 sorl-thumbnail==12.11.0
 Sphinx==8.1.3
 stripe==3.1.0
+time-machine==2.15.0

--- a/tracdb/testutils.py
+++ b/tracdb/testutils.py
@@ -67,6 +67,17 @@ def create_db_tables_for_unmanaged_models(schema_editor):
         _create_db_table_for_model(model, schema_editor)
 
 
+def destroy_db_tables_for_unmanaged_models(schema_editor):
+    """
+    Destroy tables for all unmanaged models in the tracdb app
+    """
+    appconfig = apps.get_app_config("tracdb")
+    for model in appconfig.get_models():
+        if model._meta.managed:
+            continue
+        schema_editor.delete_model(model)
+
+
 class TracDBCreateDatabaseMixin:
     """
     A TestCase mixin that creates test tables for all the tracdb apps.
@@ -75,6 +86,12 @@ class TracDBCreateDatabaseMixin:
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
         with connections["trac"].schema_editor() as schema_editor:
             create_db_tables_for_unmanaged_models(schema_editor)
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        with connections["trac"].schema_editor() as schema_editor:
+            destroy_db_tables_for_unmanaged_models(schema_editor)

--- a/tracdb/tractime.py
+++ b/tracdb/tractime.py
@@ -1,0 +1,65 @@
+import datetime
+
+from django.utils import timezone
+
+_epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
+
+
+class time_property:
+    """
+    Convert Trac timestamps into UTC datetimes.
+
+    See http://trac.edgewall.org/browser//branches/0.12-stable/trac/util/datefmt.py
+    for Trac's version of all this. Mine's something of a simplification.
+
+    Like the rest of this module this is far from perfect -- no setters, for
+    example! That's good enough for now.
+    """
+
+    def __init__(self, fieldname):
+        self.fieldname = fieldname
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return timestamp_to_datetime(getattr(instance, self.fieldname))
+
+
+def datetime_to_timestamp(dt):
+    """
+    Convert a python datetime object to a Trac-style timestamp.
+    """
+    return (dt - _epoc).total_seconds() * 1000000
+
+
+def timestamp_to_datetime(ts):
+    """
+    Convert a Trac-style timestamp to a python datetime object.
+    """
+    if ts is None:
+        return None
+    return _epoc + datetime.timedelta(microseconds=ts)
+
+
+def dayrange(d, days):
+    """
+    Return a tuple of two timestamps (Trac-style) corresponding to the bounds
+    of the range of `days` days before the given date (included). That is to
+    say, `dayrange(TODAY, 1)` will return the range for today, and
+    `dayrange(TODAY, 7)` will be the last 7 days.
+    """
+    if days <= 0:
+        raise ValueError(f"days must be greater than 0, not {days!r}")
+    if type(d) is not datetime.date:
+        raise TypeError(f"d must be a date object, not {d.__class__.__name__}")
+
+    tz = timezone.get_current_timezone()
+    start = datetime.datetime.combine(
+        d - datetime.timedelta(days=days - 1), datetime.time(0, 0, 0), tzinfo=tz
+    )
+    end = datetime.datetime.combine(d, datetime.time(23, 59, 59, 999_999), tzinfo=tz)
+
+    return (
+        datetime_to_timestamp(start),
+        datetime_to_timestamp(end),
+    )

--- a/tracdb/views.py
+++ b/tracdb/views.py
@@ -1,9 +1,7 @@
-import datetime
-
 from django import db
 from django.shortcuts import render
 
-from .models import _epoc
+from .tractime import timestamp_to_datetime
 
 
 def bouncing_tickets(request):
@@ -17,7 +15,7 @@ def bouncing_tickets(request):
 
     # Fix timestamps. LOLTrac.
     for t in tickets:
-        t["last_reopen_time"] = ts2dt(t["last_reopen_time"])
+        t["last_reopen_time"] = timestamp_to_datetime(t["last_reopen_time"])
 
     return render(
         request,
@@ -26,10 +24,6 @@ def bouncing_tickets(request):
             "tickets": tickets,
         },
     )
-
-
-def ts2dt(ts):
-    return _epoc + datetime.timedelta(microseconds=ts)
 
 
 def dictfetchall(cursor):


### PR DESCRIPTION
This should fix #1690 

Once merged, the missing data can be fixed by running the new management command on the server:
```
python manage.py fix_trac_metrics --yes --from-date=2024-04-16 new-tickets-today new-tickets-week
```