### PR TITLE
Dropped support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
             matrix:
                 # tox-gh-actions will only run the tox environments which match the currently
                 # running python-version. See [gh-actions] in tox.ini for the mapping.
-                python-version: ["3.8", "3.12"]
+                python-version: ["3.12"]
 
         services:
             postgres:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,7 @@ repos:
       rev: "v3.19.0"
       hooks:
           - id: pyupgrade
-            # TODO: Update to --py312 when dropping support for
-            # Python 3.8
-            args: [--py38-plus]
+            args: [--py312]
     - repo: https://github.com/adamchainz/django-upgrade
       rev: "1.22.1"
       hooks:

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To run locally, you can either:
 Install and run locally from a virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Create a `Python Python 3.8 or 3.12 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
+#. Create a `Python Python 3.12 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
 
 #. Install dependencies::
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist =py{38,312}-{tests,flake8,black,isort}
+envlist =py{312}-{tests,flake8,black,isort}
 skipsdist = true
 
 [gh-actions]
 python =
-    3.8: py38
     3.12: py312
 
 [testenv]

--- a/tracdb/models.py
+++ b/tracdb/models.py
@@ -50,11 +50,7 @@ from urllib.parse import parse_qs
 
 from django.db import models
 
-try:
-    _epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
-except AttributeError:
-    # TODO: Remove when dropping support for Python 3.8
-    _epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+_epoc = datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
 
 
 class time_property:


### PR DESCRIPTION
I used `git grep -FIw 3.8` to find mentions of Python 3.8 and deleted everything that seemed relevant.

The tests now pass, not sure if I might have missed anything 🤔 