### PR TITLE
Add a link to Individual membership in the site footer

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -29,6 +29,7 @@
             <li><a
               href="{% url 'document-detail' lang='en' version='dev' url="internals/security" host 'docs' %}#reporting-security-issues">Report
               a Security Issue</a></li>
+            <li><a href="{% url 'members:individual-members' %}">Individual membership</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Finding information about Individual membership can be difficult if one does not already know where to look. The current path to this page from the homepage is via the footer at Learn More -> Django Software Foundation -> Individual Members. This change is in the same spirit as pull request #1461, which added a link to the Corporate membership page in the footer for similar discoverability reasons.