### PR TITLE
Fix #1686 -- Remove reference to Django core team

### DIFF
--- a/djangoproject/templates/conduct/changes.html
+++ b/djangoproject/templates/conduct/changes.html
@@ -15,11 +15,9 @@
     proposed via a pull request to the
     <a href="https://github.com/django/djangoproject.com">djangoproject.com repository
       on GitHub</a>. Changes will be reviewed by the conduct committee first, and then
-    sent to the DSF, the Django core team, and the Django community for comment.
+    sent to the DSF and the Django community for comment.
     We'll hold a comment period of at least one week,  and then each group will vote
-    on the change using its normal process (a board for the DSF,
-    <a href="{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' %}#how-we-make-decisions">
-      a core dev vote</a> for the core team).
+    on the change using its normal process (a board for the DSF).
     Approved changes will be merged, published, and noted below.</p>
 
   <p>This only applies to material changes; changes that don't effect the intent

--- a/djangoproject/templates/conduct/changes.html
+++ b/djangoproject/templates/conduct/changes.html
@@ -16,9 +16,8 @@
     <a href="https://github.com/django/djangoproject.com">djangoproject.com repository
       on GitHub</a>. Changes will be reviewed by the conduct committee first, and then
     sent to the DSF and the Django community for comment.
-    We'll hold a comment period of at least one week,  and then each group will vote
-    on the change using its normal process (a board for the DSF).
-    Approved changes will be merged, published, and noted below.</p>
+    We'll hold a comment period of at least one week, then the DSF board will vote on
+    the change. Approved changes will be merged, published, and noted below.</p>
 
   <p>This only applies to material changes; changes that don't effect the intent
     (typo fixes, re-wordings, etc.) can be made immediately.</p>

--- a/djangoproject/templates/diversity/changes.html
+++ b/djangoproject/templates/diversity/changes.html
@@ -13,11 +13,9 @@
     to the
     <a href="https://github.com/django/djangoproject.com">djangoproject.com repository
       on GitHub</a>. Changes will be reviewed by the membership first, and then
-    sent to the DSF, the Django core team, and the Django community for comment.
+    sent to the DSF and the Django community for comment.
     We'll hold a comment period of at least one week,  and then each group will vote
-    on the change using its normal process (a board for the DSF,
-    <a href="{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' %}#how-we-make-decisions">
-      a core dev vote</a> for the core team).
+    on the change using its normal process (a board for the DSF).
     Approved changes will be merged, published, and noted below.</p>
 
   <p>This only applies to material changes; changes that don't effect the intent

--- a/djangoproject/templates/diversity/changes.html
+++ b/djangoproject/templates/diversity/changes.html
@@ -14,9 +14,8 @@
     <a href="https://github.com/django/djangoproject.com">djangoproject.com repository
       on GitHub</a>. Changes will be reviewed by the membership first, and then
     sent to the DSF and the Django community for comment.
-    We'll hold a comment period of at least one week,  and then each group will vote
-    on the change using its normal process (a board for the DSF).
-    Approved changes will be merged, published, and noted below.</p>
+    We'll hold a comment period of at least one week, then the DSF board will vote on
+    the change. Approved changes will be merged, published, and noted below.</p>
 
   <p>This only applies to material changes; changes that don't effect the intent
     (typo fixes, re-wordings, etc.) can be made immediately.</p>


### PR DESCRIPTION
Fix for #1686 

Removed references to the "core team" on the pages "Code Of Conduct - Changes" and "Diversity - Changes".

Before:
![Screenshot 2024-11-13 at 11 19 17 AM](https://github.com/user-attachments/assets/6f78bc6f-ec76-4284-a9d1-312925bbb50f)

After:
![Screenshot 2024-11-13 at 11 19 40 AM](https://github.com/user-attachments/assets/2f639e3a-c4c8-425e-baed-a905705adb9c)