### PR TITLE
Add rel attributes to next/prev links

### DIFF
--- a/djangoproject/templates/aggregator/feeditem_list.html
+++ b/djangoproject/templates/aggregator/feeditem_list.html
@@ -29,13 +29,13 @@
     <div class="pagination">
       <ul class="nav-pagination" role="navigation">
         {% if page_obj.has_previous %}
-          <li><a class="previous" href="?page={{ page_obj.previous_page_number }}">
+          <li><a rel="prev" class="previous" href="?page={{ page_obj.previous_page_number }}">
             <i class="icon icon-chevron-left"></i>
             <span class="visuallyhidden">{% translate "Previous" context "pagination" %}</span>
           </a></li>
         {% endif %}
         {% if page_obj.has_next %}
-          <li><a class="next" href="?page={{ page_obj.next_page_number }}">
+          <li><a rel="next" class="next" href="?page={{ page_obj.next_page_number }}">
             <i class="icon icon-chevron-right"></i>
             <span class="visuallyhidden">{% translate "Next" context "pagination" %}</span>
           </a></li>

--- a/djangoproject/templates/blog/blog_pagination.html
+++ b/djangoproject/templates/blog/blog_pagination.html
@@ -4,7 +4,7 @@
   <div class="pagination">
     <ul class="nav-pagination" role="navigation">
       {% if page_obj.has_previous %}
-        <li><a class="previous" href="?page={{ page_obj.previous_page_number }}">
+        <li><a rel="prev" class="previous" href="?page={{ page_obj.previous_page_number }}">
           <i class="icon icon-chevron-left"></i>
           <span class="visuallyhidden">{% translate "Previous" context "pagination" %}</span>
         </a></li>
@@ -15,7 +15,7 @@
         {% endblocktranslate %}
       </span>
       {% if page_obj.has_next %}
-        <li><a class="next" href="?page={{ page_obj.next_page_number }}">
+        <li><a rel="next" class="next" href="?page={{ page_obj.next_page_number }}">
           <i class="icon icon-chevron-right"></i>
           <span class="visuallyhidden">{% translate "Next" context "pagination" %}</span>
         </a></li>

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -123,10 +123,10 @@
   {% if doc.prev or doc.next %}
     <div class="browse-horizontal">
       {% if doc.prev %}
-        <div class="left"><a href="{{ doc.prev.link }}"><i class="icon icon-chevron-left"></i> {{ doc.prev.title|safe }}</a></div>
+        <div class="left"><a rel="prev" href="{{ doc.prev.link }}"><i class="icon icon-chevron-left"></i> {{ doc.prev.title|safe }}</a></div>
       {% endif %}
       {% if doc.next %}
-        <div class="right"><a href="{{ doc.next.link }}">{{ doc.next.title|safe }} <i class="icon icon-chevron-right"></i></a></div>
+        <div class="right"><a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }} <i class="icon icon-chevron-right"></i></a></div>
       {% endif %}
     </div>
   {% endif %}
@@ -152,10 +152,10 @@
       <ul>
         {% block browse %}
           {% if doc.prev %}
-            <li>{% trans "Prev:" %} <a href="{{ doc.prev.link }}">{{ doc.prev.title|safe }}</a></li>
+            <li>{% trans "Prev:" %} <a rel="prev" href="{{ doc.prev.link }}">{{ doc.prev.title|safe }}</a></li>
           {% endif %}
           {% if doc.next %}
-            <li>{% trans "Next:" %} <a href="{{ doc.next.link }}">{{ doc.next.title|safe }}</a></li>
+            <li>{% trans "Next:" %} <a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }}</a></li>
           {% endif %}
           <li><a href="{% url 'document-detail' lang=lang version=version url="contents" host 'docs' %}">{% trans "Table of contents" %}</a></li>
           {% for doc, title, accesskey, shorttitle in env.rellinks %}

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -57,7 +57,7 @@
       <div class="pagination">
         <ul class="nav-pagination" role="navigation">
           {% if page.has_previous %}
-            <li><a class="previous" href="?q={{ query }}&amp;release={{ release.version }}&amp;page={{ page.previous_page_number }}">
+            <li><a rel="prev" class="previous" href="?q={{ query }}&amp;release={{ release.version }}&amp;page={{ page.previous_page_number }}">
               <i class="icon icon-chevron-left"></i>
               <span class="visuallyhidden">{% trans "Previous" %}</span>
             </a></li>
@@ -68,7 +68,7 @@
             {% endblocktrans %}
           </span>
           {% if page.has_next %}
-            <li><a class="next" href="?q={{ query }}&amp;release={{ release.version }}&amp;page={{ page.next_page_number }}">
+            <li><a rel="next" class="next" href="?q={{ query }}&amp;release={{ release.version }}&amp;page={{ page.next_page_number }}">
               <i class="icon icon-chevron-right"></i>
               <span class="visuallyhidden">{% trans "Next" %}</span>
             </a></li>


### PR DESCRIPTION
Marking up next/prev links with the [`rel="next"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#next) and [`rel="prev"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#prev) links allows the user agent and/or assistive technology to recognise the purpose of these links. For example, [Vimium](https://github.com/philc/vimium) provides keyboard shortcuts to go to the next/previous page, and relies partially on these attributes to do so.