### PR TITLE
Only return published blog entries.

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -197,115 +197,6 @@ class ViewsTestCase(DateTimeMixin, TestCase):
         entries in the list, but can view the detail page
     """
 
-    # def test_anonymous_user_cant_see_entries(self):
-    #     """
-    #     A test which creates an unpublished entry and then loads the list view
-    #     followed by detail view as an anonymous user to check that the entry cannot
-    #     be seen.
-    #     """
-    #     e1 = Entry.objects.create(
-    #         pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
-    #     )
-    #     e2 = Entry.objects.create(
-    #         pub_date=self.yesterday, is_active=True, headline="active", slug="b"
-    #     )
-    #     response = self.client.get(reverse("weblog:index"))
-    #     self.assertNotContains(response, "active")
-    #     response = self.client.get(
-    #         reverse(
-    #             "weblog:entry",
-    #             kwargs={
-    #                 "year": e1.pub_date.year,
-    #                 "month": e1.pub_date.month,
-    #                 "day": e1.pub_date.day,
-    #                 "slug": e1.slug,
-    #             },
-    #         )
-    #     )
-    #     self.assertEqual(response.status_code, 404)
-    #     response = self.client.get(
-    #         reverse(
-    #             "weblog:entry",
-    #             kwargs={
-    #                 "year": e2.pub_date.year,
-    #                 "month": e2.pub_date.month,
-    #                 "day": e2.pub_date.day,
-    #                 "slug": e2.slug,
-    #             },
-    #         )
-    #     )
-    #     self.assertEqual(response.status_code, 404)
-    #
-    # def test_logged_in_user_cant_see_entries(self):
-    #     """
-    #     A test which creates an unpublished entry and then loads the list view
-    #     followed by detail view as a non-staff user to check that the entry cannot be
-    #     seen.
-    #     """
-    #     e = Entry.objects.create(
-    #         pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
-    #     )
-    #     user = User.objects.create_user("user", "user@example.com", "password")
-    #     self.client.force_login(user)
-    #     response = self.client.get(reverse("weblog:index"))
-    #     self.assertNotContains(response, "active")
-    #     response = self.client.get(
-    #         reverse(
-    #             "weblog:entry",
-    #             kwargs={
-    #                 "year": e.pub_date.year,
-    #                 "month": e.pub_date.month,
-    #                 "day": e.pub_date.day,
-    #                 "slug": e.slug,
-    #             },
-    #         )
-    #     )
-    #     self.assertEqual(response.status_code, 404)
-    #
-    # def test_staff_no_write_permission_cant_see_entries(self):
-    #     """
-    #     A test which creates an unpublished entry and then loads the list view
-    #     followed by detail view as a staff user without blog write permissions to
-    #     check that the entry cannot be seen.
-    #     """
-    #     e1 = Entry.objects.create(
-    #         pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
-    #     )
-    #     e2 = Entry.objects.create(
-    #         pub_date=self.yesterday, is_active=True, headline="active", slug="b"
-    #     )
-    #     user = User.objects.create_user(
-    #         "staff", "staff@example.com", "password", is_staff=True
-    #     )
-    #     self.client.force_login(user)
-    #     response = self.client.get(reverse("weblog:index"))
-    #
-    #     self.assertContains(response, "active")
-    #     response = self.client.get(
-    #         reverse(
-    #             "weblog:entry",
-    #             kwargs={
-    #                 "year": e1.pub_date.year,
-    #                 "month": e1.pub_date.month,
-    #                 "day": e1.pub_date.day,
-    #                 "slug": e1.slug,
-    #             },
-    #         )
-    #     )
-    #     self.assertEqual(response.status_code, 404)
-    #     response = self.client.get(
-    #         reverse(
-    #             "weblog:entry",
-    #             kwargs={
-    #                 "year": e2.pub_date.year,
-    #                 "month": e2.pub_date.month,
-    #                 "day": e2.pub_date.day,
-    #                 "slug": e2.slug,
-    #             },
-    #         )
-    #     )
-    #     self.assertEqual(response.status_code, 404)
-
     def test_staff_with_write_permission_can_see_unpublished_detail_view(self):
         """
         staff users with write permission on BlogEntry can't see unpublished entries
@@ -325,7 +216,7 @@ class ViewsTestCase(DateTimeMixin, TestCase):
                 "weblog:entry",
                 kwargs={
                     "year": e1.pub_date.year,
-                    "month": e1.pub_date.month,
+                    "month": e1.pub_date.strftime("%b").lower(),
                     "day": e1.pub_date.day,
                     "slug": e1.slug,
                 },

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -187,6 +187,154 @@ class EventTestCase(DateTimeMixin, TestCase):
 
 
 class ViewsTestCase(DateTimeMixin, TestCase):
+    """
+    TODO:
+        * anon users can't see unpublished entries at all (list or detail)
+        * logged in users (non-staff) can't see unpublished entries at all
+        * staff users without write permission on BlogEntry can't see unpublished
+        entries at all
+        * staff users with write permission on BlogEntry can't see unpublished
+        entries in the list, but can view the detail page
+    """
+
+    # def test_anonymous_user_cant_see_entries(self):
+    #     """
+    #     A test which creates an unpublished entry and then loads the list view
+    #     followed by detail view as an anonymous user to check that the entry cannot
+    #     be seen.
+    #     """
+    #     e1 = Entry.objects.create(
+    #         pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
+    #     )
+    #     e2 = Entry.objects.create(
+    #         pub_date=self.yesterday, is_active=True, headline="active", slug="b"
+    #     )
+    #     response = self.client.get(reverse("weblog:index"))
+    #     self.assertNotContains(response, "active")
+    #     response = self.client.get(
+    #         reverse(
+    #             "weblog:entry",
+    #             kwargs={
+    #                 "year": e1.pub_date.year,
+    #                 "month": e1.pub_date.month,
+    #                 "day": e1.pub_date.day,
+    #                 "slug": e1.slug,
+    #             },
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, 404)
+    #     response = self.client.get(
+    #         reverse(
+    #             "weblog:entry",
+    #             kwargs={
+    #                 "year": e2.pub_date.year,
+    #                 "month": e2.pub_date.month,
+    #                 "day": e2.pub_date.day,
+    #                 "slug": e2.slug,
+    #             },
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, 404)
+    #
+    # def test_logged_in_user_cant_see_entries(self):
+    #     """
+    #     A test which creates an unpublished entry and then loads the list view
+    #     followed by detail view as a non-staff user to check that the entry cannot be
+    #     seen.
+    #     """
+    #     e = Entry.objects.create(
+    #         pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
+    #     )
+    #     user = User.objects.create_user("user", "user@example.com", "password")
+    #     self.client.force_login(user)
+    #     response = self.client.get(reverse("weblog:index"))
+    #     self.assertNotContains(response, "active")
+    #     response = self.client.get(
+    #         reverse(
+    #             "weblog:entry",
+    #             kwargs={
+    #                 "year": e.pub_date.year,
+    #                 "month": e.pub_date.month,
+    #                 "day": e.pub_date.day,
+    #                 "slug": e.slug,
+    #             },
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, 404)
+    #
+    # def test_staff_no_write_permission_cant_see_entries(self):
+    #     """
+    #     A test which creates an unpublished entry and then loads the list view
+    #     followed by detail view as a staff user without blog write permissions to
+    #     check that the entry cannot be seen.
+    #     """
+    #     e1 = Entry.objects.create(
+    #         pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
+    #     )
+    #     e2 = Entry.objects.create(
+    #         pub_date=self.yesterday, is_active=True, headline="active", slug="b"
+    #     )
+    #     user = User.objects.create_user(
+    #         "staff", "staff@example.com", "password", is_staff=True
+    #     )
+    #     self.client.force_login(user)
+    #     response = self.client.get(reverse("weblog:index"))
+    #
+    #     self.assertContains(response, "active")
+    #     response = self.client.get(
+    #         reverse(
+    #             "weblog:entry",
+    #             kwargs={
+    #                 "year": e1.pub_date.year,
+    #                 "month": e1.pub_date.month,
+    #                 "day": e1.pub_date.day,
+    #                 "slug": e1.slug,
+    #             },
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, 404)
+    #     response = self.client.get(
+    #         reverse(
+    #             "weblog:entry",
+    #             kwargs={
+    #                 "year": e2.pub_date.year,
+    #                 "month": e2.pub_date.month,
+    #                 "day": e2.pub_date.day,
+    #                 "slug": e2.slug,
+    #             },
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, 404)
+
+    def test_staff_with_write_permission_can_see_unpublished_detail_view(self):
+        """
+        staff users with write permission on BlogEntry can't see unpublished entries
+        in the list, but can view the detail page
+        """
+        e1 = Entry.objects.create(
+            pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"
+        )
+        user = User.objects.create(username="staff", is_staff=True)
+        self.client.force_login(user)
+        self.assertEqual(Entry.objects.all().count(), 1)
+        response = self.client.get(reverse("weblog:index"))
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get(
+            reverse(
+                "weblog:entry",
+                kwargs={
+                    "year": e1.pub_date.year,
+                    "month": e1.pub_date.month,
+                    "day": e1.pub_date.day,
+                    "slug": e1.slug,
+                },
+            )
+        )
+        request = response.context["request"]
+        self.assertTrue(request.user.is_staff)
+        self.assertEqual(response.status_code, 200)
+
     def test_no_past_upcoming_events(self):
         """
         Make sure there are no past event in the "upcoming events" sidebar (#399)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -3,7 +3,8 @@ from datetime import date, timedelta
 from io import StringIO
 
 import time_machine
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.urls import reverse
@@ -187,10 +188,9 @@ class EventTestCase(DateTimeMixin, TestCase):
 
 
 class ViewsTestCase(DateTimeMixin, TestCase):
-
-    def test_staff_with_write_permission_can_see_unpublished_detail_view(self):
+    def test_staff_with_change_permission_can_see_unpublished_detail_view(self):
         """
-        staff users with write permission on BlogEntry can't see unpublished entries
+        Staff users with change permission on BlogEntry can't see unpublished entries
         in the list, but can view the detail page
         """
         e1 = Entry.objects.create(
@@ -198,8 +198,6 @@ class ViewsTestCase(DateTimeMixin, TestCase):
         )
         user = User.objects.create(username="staff", is_staff=True)
         # Add blog entry change permission
-        from django.contrib.auth.models import Permission
-        from django.contrib.contenttypes.models import ContentType
 
         content_type = ContentType.objects.get_for_model(Entry)
         change_permission = Permission.objects.get(
@@ -227,9 +225,9 @@ class ViewsTestCase(DateTimeMixin, TestCase):
         self.assertTrue(request.user.has_perm("blog.change_entry"))
         self.assertEqual(response.status_code, 200)
 
-    def test_staff_without_write_permission_cannot_see_unpublished_detail_view(self):
+    def test_staff_without_change_permission_cannot_see_unpublished_detail_view(self):
         """
-        staff users without write permission on BlogEntry can't see unpublished entries
+        Staff users without change permission on BlogEntry can't see unpublished entries
         """
         e1 = Entry.objects.create(
             pub_date=self.yesterday, is_active=False, headline="inactive", slug="a"

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -189,8 +189,6 @@ class EventTestCase(DateTimeMixin, TestCase):
 class ViewsTestCase(DateTimeMixin, TestCase):
     """
     TODO:
-        * anon users can't see unpublished entries at all (list or detail)
-        * logged in users (non-staff) can't see unpublished entries at all
         * staff users without write permission on BlogEntry can't see unpublished
         entries at all
         * staff users with write permission on BlogEntry can't see unpublished
@@ -275,6 +273,61 @@ class ViewsTestCase(DateTimeMixin, TestCase):
         """
         Anonymous users can't see unpublished entries at all (list or detail view)
         """
+        # Create a published entry to ensure the list view works
+        published_entry = Entry.objects.create(
+            pub_date=self.yesterday,
+            is_active=True,
+            headline="published",
+            slug="published",
+        )
+
+        # Create an unpublished entry
+        unpublished_entry = Entry.objects.create(
+            pub_date=self.tomorrow,
+            is_active=True,
+            headline="unpublished",
+            slug="unpublished",
+        )
+
+        # Test list view - should return 200 but not include the unpublished entry
+        response = self.client.get(reverse("weblog:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "published")
+        self.assertNotContains(response, "unpublished")
+
+        # Test detail view for unpublished entry - should return 404
+        unpublished_url = reverse(
+            "weblog:entry",
+            kwargs={
+                "year": unpublished_entry.pub_date.year,
+                "month": unpublished_entry.pub_date.strftime("%b").lower(),
+                "day": unpublished_entry.pub_date.day,
+                "slug": unpublished_entry.slug,
+            },
+        )
+        response = self.client.get(unpublished_url)
+        self.assertEqual(response.status_code, 404)
+
+        # Test detail view for published entry - should return 200
+        published_url = reverse(
+            "weblog:entry",
+            kwargs={
+                "year": published_entry.pub_date.year,
+                "month": published_entry.pub_date.strftime("%b").lower(),
+                "day": published_entry.pub_date.day,
+                "slug": published_entry.slug,
+            },
+        )
+        response = self.client.get(published_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_cannot_see_unpublished_entries(self):
+        """
+        Non-staff users can't see unpublished entries at all (list or detail view)
+        """
+        user = User.objects.create(username="non-staff", is_staff=False)
+        self.client.force_login(user)
+
         # Create a published entry to ensure the list view works
         published_entry = Entry.objects.create(
             pub_date=self.yesterday,

--- a/blog/views.py
+++ b/blog/views.py
@@ -51,8 +51,10 @@ class BlogDateDetailView(BlogViewMixin, DateDetailView):
     banner_is_title = False
 
     def get_queryset(self):
-        """Allows staff users to view unpublished entries"""
-        if self.request.user.is_staff:
+        """Allows staff users with blog write permission to view unpublished entries"""
+        if self.request.user.is_staff and self.request.user.has_perm(
+            "blog.change_entry"
+        ):
             return Entry.objects.all()
         else:
             return Entry.objects.published()

--- a/blog/views.py
+++ b/blog/views.py
@@ -53,6 +53,8 @@ class BlogDateDetailView(BlogViewMixin, DateDetailView):
     def get_queryset(self):
         """Allows staff users to view unpublished entries"""
         if self.request.user.is_staff:
+            print("\n\nSTAFF USER\n\n")
             return Entry.objects.all()
         else:
+            print("\n\nNORMAL USER\n\n")
             return Entry.objects.published()

--- a/blog/views.py
+++ b/blog/views.py
@@ -21,7 +21,6 @@ class BlogViewMixin:
         return Entry.objects.published()
 
     def get_context_data(self, **kwargs):
-        """ """
         context = super().get_context_data(**kwargs)
 
         events_queryset = Event.objects.future().published()
@@ -50,3 +49,10 @@ class BlogDayArchiveView(BlogViewMixin, DayArchiveView):
 
 class BlogDateDetailView(BlogViewMixin, DateDetailView):
     banner_is_title = False
+
+    def get_queryset(self):
+        """Allows staff users to view unpublished entries"""
+        if self.request.user.is_staff:
+            return Entry.objects.all()
+        else:
+            return Entry.objects.published()

--- a/blog/views.py
+++ b/blog/views.py
@@ -51,10 +51,10 @@ class BlogDateDetailView(BlogViewMixin, DateDetailView):
     banner_is_title = False
 
     def get_queryset(self):
-        """Allows staff users with blog write permission to view unpublished entries"""
+        """Allows staff users with blog write permission to view unpublished entries."""
         if self.request.user.is_staff and self.request.user.has_perm(
             "blog.change_entry"
         ):
             return Entry.objects.all()
         else:
-            return Entry.objects.published()
+            return self.get_queryset()

--- a/blog/views.py
+++ b/blog/views.py
@@ -57,4 +57,4 @@ class BlogDateDetailView(BlogViewMixin, DateDetailView):
         ):
             return Entry.objects.all()
         else:
-            return self.get_queryset()
+            return super().get_queryset()

--- a/blog/views.py
+++ b/blog/views.py
@@ -18,12 +18,10 @@ class BlogViewMixin:
         return self.request.user.is_staff
 
     def get_queryset(self):
-        if self.request.user.is_staff:
-            return Entry.objects.all()
-        else:
-            return Entry.objects.published()
+        return Entry.objects.published()
 
     def get_context_data(self, **kwargs):
+        """ """
         context = super().get_context_data(**kwargs)
 
         events_queryset = Event.objects.future().published()

--- a/blog/views.py
+++ b/blog/views.py
@@ -53,8 +53,6 @@ class BlogDateDetailView(BlogViewMixin, DateDetailView):
     def get_queryset(self):
         """Allows staff users to view unpublished entries"""
         if self.request.user.is_staff:
-            print("\n\nSTAFF USER\n\n")
             return Entry.objects.all()
         else:
-            print("\n\nNORMAL USER\n\n")
             return Entry.objects.published()


### PR DESCRIPTION
This fixes #1755 to only return published blog entries, even for staff users.

Unpublished entries can still be previewed via the admin.