### PR TITLE
Added billboard for 2024 developer survey

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -676,6 +676,7 @@ blockquote {
 /* banner for billboard */
 #billboard {
     background-color: $green-medium;
+    border-top: 1px solid $black;
 
     * {
         color: $black;

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -700,6 +700,7 @@ blockquote {
 
     a, h1 a {
         color: $black;
+        font-weight: bold;
         text-decoration: none;
         &:hover {
             text-decoration: underline;

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -84,7 +84,17 @@
     elements.
     {% endcomment %}
 
-    <div id="billboard">{% block billboard %}{% endblock %}</div>
+    <div id="billboard">
+      {% block billboard %}
+        <div class="banner">
+          <p>
+            Please take a few minutes to complete the
+            <a href="https://jb.gg/asjljo">2024 Django Developers Survey</a>.<br>
+            Your feedback will help guide future efforts.
+          </p>
+        </div>
+      {% endblock %}
+    </div>
 
     <div class="container {% block layout_class %}{% endblock %}">
       <div role="main">


### PR DESCRIPTION
This was requested by @thibaudcolas .

I took inspiration from a4799dc44be834c6376c07739a222b1a55d6ffd1 for the wording (found using `git log -S survey`).

Here's how it looks (light mode):

![Screenshot 2024-11-21 at 21-07-37 Django overview Django](https://github.com/user-attachments/assets/b22d537b-7ec0-4ba8-b4d3-5ff64dd66ce1)
