### PR TITLE
Fix #1722 -- Add more tests for fundraising webhook

### DIFF
--- a/fundraising/test_data/customer.json
+++ b/fundraising/test_data/customer.json
@@ -1,0 +1,62 @@
+{
+    "account_balance": 0,
+    "address": null,
+    "balance": 0,
+    "cards": {
+      "data": [],
+      "has_more": false,
+      "object": "list",
+      "total_count": 0,
+      "url": "/v1/customers/cus_3MXPY5pvYMWTBf/cards"
+    },
+    "created": 1732222262,
+    "currency": null,
+    "default_card": null,
+    "default_currency": null,
+    "default_source": null,
+    "delinquent": false,
+    "description": null,
+    "discount": null,
+    "email": "customer@email.com",
+    "id": "cus_3MXPY5pvYMWTBf",
+    "invoice_prefix": "17A431B3",
+    "invoice_settings": {
+      "custom_fields": null,
+      "default_payment_method": null,
+      "footer": null,
+      "rendering_options": null
+    },
+    "livemode": false,
+    "metadata": {},
+    "name": null,
+    "next_invoice_sequence": 1,
+    "object": "customer",
+    "phone": null,
+    "preferred_locales": [],
+    "shipping": null,
+    "sources": {
+      "data": [],
+      "has_more": false,
+      "object": "list",
+      "total_count": 0,
+      "url": "/v1/customers/cus_3MXPY5pvYMWTBf/sources"
+    },
+    "subscriptions": {
+      "data": [],
+      "has_more": false,
+      "object": "list",
+      "total_count": 0,
+      "url": "/v1/customers/cus_3MXPY5pvYMWTBf/subscriptions"
+    },
+    "tax_exempt": "none",
+    "tax_ids": {
+      "data": [],
+      "has_more": false,
+      "object": "list",
+      "total_count": 0,
+      "url": "/v1/customers/cus_3MXPY5pvYMWTBf/tax_ids"
+    },
+    "tax_info": null,
+    "tax_info_verification": null,
+    "test_clock": null
+  }

--- a/fundraising/test_data/payment_intent.json
+++ b/fundraising/test_data/payment_intent.json
@@ -1,0 +1,231 @@
+{
+    "allowed_source_types": [
+      "card"
+    ],
+    "amount": 3000,
+    "amount_capturable": 0,
+    "amount_details": {
+      "tip": {}
+    },
+    "amount_received": 3000,
+    "application": null,
+    "application_fee_amount": null,
+    "automatic_payment_methods": null,
+    "canceled_at": null,
+    "cancellation_reason": null,
+    "capture_method": "automatic",
+    "charges": {
+      "data": [
+        {
+          "amount": 3000,
+          "amount_captured": 3000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_2MXkIN4ao19wAZWp0wQIDyAD",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "d@b.com",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "DJANGOPROJECT.COM",
+          "captured": true,
+          "card": {
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_6Mf8HUzoOM5r06",
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 12,
+            "exp_year": 2034,
+            "fingerprint": "xygwMO5bYmv4EmZm",
+            "funding": "credit",
+            "id": "card_6Mf8W5TmoG71AP",
+            "last4": "4242",
+            "metadata": {},
+            "name": "d@b.com",
+            "object": "card",
+            "tokenization_method": null,
+            "wallet": null
+          },
+          "created": 1675511560,
+          "currency": "usd",
+          "customer": "cus_6Mf8HUzoOM5r06",
+          "description": "Invoice 94026E9-0072",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "id": "ch_2MXkIN4ao19wAZWp0yIS2t5T",
+          "invoice": "in_0MXjHW4ao19wAZWpwzZjD8Ie",
+          "livemode": false,
+          "metadata": {},
+          "object": "charge",
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 6,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_2MXkIN4ao19wAZWp0atVBWd2",
+          "payment_method": "card_6Mf8W5TmoG71AP",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 3000,
+              "authorization_code": null,
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": null
+              },
+              "country": "US",
+              "exp_month": 12,
+              "exp_year": 2034,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "xygwMO5bYmv4EmZm",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "overcapture": {
+                "maximum_amount_capturable": 3000,
+                "status": "unavailable"
+              },
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": "d@b.com",
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/invoices/CAcaGwoZYWNjdF8xV01QNGFvMTl3QVpXcGlNb3d0QijtvP65BjIG7quOkp-6OiwWZhwfLUVCB3PgWg7lw1O_qxdCsOOzqKj3Gn7Z16NF5qMYuHEtHxhOJa6nJA?s=ap",
+          "refunded": false,
+          "refunds": {
+            "data": [],
+            "has_more": false,
+            "object": "list",
+            "total_count": 0,
+            "url": "/v1/charges/ch_2MXkIN4ao19wAZWp0yIS2t5T/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_6Mf8HUzoOM5r06",
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 12,
+            "exp_year": 2034,
+            "fingerprint": "xygwMO5bYmv4EmZm",
+            "funding": "credit",
+            "id": "card_6Mf8W5TmoG71AP",
+            "last4": "4242",
+            "metadata": {},
+            "name": "d@b.com",
+            "object": "card",
+            "tokenization_method": null,
+            "wallet": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "paid",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+      ],
+      "has_more": false,
+      "object": "list",
+      "total_count": 1,
+      "url": "/v1/charges?payment_intent=pi_2MXkIN4ao19wAZWp0atVBWd2"
+    },
+    "client_secret": "pi_2MXkIN4ao19wAZWp0atVBWd2_secret_WX2PK2jXLxklt3dHzrTMNpVn2",
+    "confirmation_method": "automatic",
+    "created": 1675511559,
+    "currency": "usd",
+    "customer": "cus_6Mf8HUzoOM5r06",
+    "description": "Invoice 94026E9-0072",
+    "id": "pi_2MXkIN4ao19wAZWp0atVBWd2",
+    "invoice": "in_0MXjHW4ao19wAZWpwzZjD8Ie",
+    "last_payment_error": null,
+    "latest_charge": "ch_2MXkIN4ao19wAZWp0yIS2t5T",
+    "livemode": false,
+    "metadata": {},
+    "next_action": null,
+    "next_source_action": null,
+    "object": "payment_intent",
+    "on_behalf_of": null,
+    "payment_method": null,
+    "payment_method_configuration_details": null,
+    "payment_method_options": {
+      "card": {
+        "installments": null,
+        "mandate_options": null,
+        "network": null,
+        "request_three_d_secure": "automatic"
+      }
+    },
+    "payment_method_types": [
+      "card"
+    ],
+    "processing": null,
+    "receipt_email": "d@b.com",
+    "review": null,
+    "setup_future_usage": null,
+    "shipping": null,
+    "source": "card_6Mf8W5TmoG71AP",
+    "statement_descriptor": null,
+    "statement_descriptor_suffix": null,
+    "status": "succeeded",
+    "transfer_data": null,
+    "transfer_group": null
+  }

--- a/fundraising/test_data/session_completed.json
+++ b/fundraising/test_data/session_completed.json
@@ -1,0 +1,86 @@
+{
+    "id": "evt_103MXP2kbIgHtIBFeIFqPxp7",
+    "object": "event",
+    "api_version": "2015-01-11",
+    "created": 1683928544,
+    "data": {
+        "object": {
+            "id": "cs_test_a11YYufWQzNY63zpQ6QSNRQhkUpVph4WRmzW0zWJO2znZKdVujZ0N0S22u",
+            "object": "checkout.session",
+            "after_expiration": null,
+            "allow_promotion_codes": null,
+            "amount_subtotal": 2198,
+            "amount_total": 2198,
+            "automatic_tax": {
+              "enabled": false,
+              "liability": null,
+              "status": null
+            },
+            "billing_address_collection": null,
+            "cancel_url": null,
+            "client_reference_id": null,
+            "consent": null,
+            "consent_collection": null,
+            "created": 1679600215,
+            "currency": "usd",
+            "custom_fields": [],
+            "custom_text": {
+              "shipping_address": null,
+              "submit": null
+            },
+            "customer": null,
+            "customer_creation": "if_required",
+            "customer_details": null,
+            "customer_email": null,
+            "expires_at": 1679686615,
+            "invoice": null,
+            "invoice_creation": {
+              "enabled": false,
+              "invoice_data": {
+                "account_tax_ids": null,
+                "custom_fields": null,
+                "description": null,
+                "footer": null,
+                "issuer": null,
+                "metadata": {},
+                "rendering_options": null
+              }
+            },
+            "livemode": false,
+            "locale": null,
+            "metadata": {},
+            "mode": "payment",
+            "payment_intent": null,
+            "payment_link": null,
+            "payment_method_collection": "always",
+            "payment_method_options": {},
+            "payment_method_types": [
+              "card"
+            ],
+            "payment_status": "unpaid",
+            "phone_number_collection": {
+              "enabled": false
+            },
+            "recovered_from": null,
+            "setup_intent": null,
+            "shipping_address_collection": null,
+            "shipping_cost": null,
+            "shipping_details": null,
+            "shipping_options": [],
+            "status": "open",
+            "submit_type": null,
+            "subscription": null,
+            "success_url": "https://example.com/success",
+            "total_details": {
+              "amount_discount": 0,
+              "amount_shipping": 0,
+              "amount_tax": 0
+            },
+            "url": "https://checkout.stripe.com/c/pay/cs_test_a11YYufWQzNY63zpQ6QSNRQhkUpVph4WRmzW0zWJO2znZKdVujZ0N0S22u#fidkdWxOYHwnPyd1blpxYHZxWjA0SDdPUW5JbmFMck1wMmx9N2BLZjFEfGRUNWhqTmJ%2FM2F8bUA2SDRySkFdUV81T1BSV0YxcWJcTUJcYW5rSzN3dzBLPUE0TzRKTTxzNFBjPWZEX1NKSkxpNTVjRjN8VHE0YicpJ2N3amhWYHdzYHcnP3F3cGApJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl"
+          }
+    },
+    "livemode": true,
+    "pending_webhooks": 1,
+    "request": null,
+    "type": "checkout.session.completed"
+}

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -14,6 +14,7 @@ from django_hosts.resolvers import reverse as django_hosts_reverse
 from django_recaptcha.client import RecaptchaResponse
 
 from ..models import DjangoHero, Donation
+from ..views import WebhookHandler
 
 
 class TestIndex(TestCase):
@@ -253,3 +254,13 @@ class TestWebhooks(TestCase):
         response = self.post_event()
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.donation.payment_set.count(), 0)
+
+    @patch("stripe.Customer.retrieve")
+    @patch("stripe.PaymentIntent.retrieve")
+    def test_checkout_session_completed(self, payment_intent, customer):
+        customer.return_value = self.stripe_data("customer")
+        payment_intent.return_value = self.stripe_data("payment_intent")
+        event = self.stripe_data("session_completed")
+        WebhookHandler(event).handle()
+        customer.assert_called_once()
+        payment_intent.assert_called_once()


### PR DESCRIPTION
Fix for #1722 

Added test for `checkout_session_completed`. The test fails when reverting the change in [e995213](https://github.com/django/djangoproject.com/commit/e9952130db15e603477a5bc2a3a8f202c99cbd65).

New files are added in `test_data`. They were generated by calling calling `stripe.Customer.list().data[0]`, `stripe.PaymentIntent.list().data[0]`, etc.
- customer.json
- payment_intent.json
- session_completed.json

The `payment_succeeded` webhook still needs a test, but I wanted a quick review to see if I've approached this correctly.