### PR TITLE
Fixed sponsor notes appearing on download page

### DIFF
--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -276,7 +276,7 @@
               <ul class="list-links-small">
                 <li><strong>{{ obj.display_name }}</strong></li>
                 <li><a href="{{ obj.url }}" title="{{ obj.display_name }}">
-                  {{ obj.notes }}
+                  {{ obj.description }}
                 </a></li>
               </ul>
             </div>

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -174,7 +174,7 @@ class CorporateMembersTestCase(TestCase):
             display_name=f"{level_name} Member",
             url=f"https://{level_name.lower()}.example.com",
             membership_level=level,
-            notes=f"Some notes about this {level_name} member",
+            description=f"Some notes about this {level_name} member",
         )
         # ensure each member is included in `for_public_display`
         member.invoice_set.create(
@@ -195,13 +195,13 @@ class CorporateMembersTestCase(TestCase):
 
         self.assertContains(response, "<h2>Diamond and Platinum Members</h2>")
         member_link = (
-            lambda m: f'<a href="{m.url}" title="{m.display_name}">{m.notes}</a>'
+            lambda m: f'<a href="{m.url}" title="{m.display_name}">{m.description}</a>'
         )
         for member in members:
             if member.membership_level < PLATINUM_MEMBERSHIP:
                 self.assertNotContains(response, member.display_name)
                 self.assertNotContains(response, member.url)
-                self.assertNotContains(response, member.notes)
+                self.assertNotContains(response, member.description)
             else:
                 self.assertContains(response, member_link(member), html=True)
 
@@ -218,4 +218,4 @@ class CorporateMembersTestCase(TestCase):
         for member in members:
             self.assertNotContains(response, member.display_name)
             self.assertNotContains(response, member.url)
-            self.assertNotContains(response, member.notes)
+            self.assertNotContains(response, member.description)


### PR DESCRIPTION
Thanks to user TheEpic-dev on the forum for reporting
the issue.

This was introduced in c024b32f65a48b6366baf2930e43c5f2014b1ace
