### PR TITLE
Remove unneeded vendor prefixes for `box-shadow`

### DIFF
--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -172,14 +172,10 @@ html {
 
 // Secondary content box-shadow:
 @mixin secondary-shadow-top {
-    -moz-box-shadow: 0 4px 8px rgba(12, 60, 38, 0.07);
-    -webkit-box-shadow: 0 4px 8px rgba(12, 60, 38, 0.07);
     box-shadow: 0 4px 8px rgba(12, 60, 38, 0.07);
 }
 
 @mixin secondary-shadow-bottom {
-    -moz-box-shadow: 0 -4px 8px rgba(12, 60, 38, 0.07);
-    -webkit-box-shadow: 0 -4px 8px rgba(12, 60, 38, 0.07);
     box-shadow: 0 -4px 8px rgba(12, 60, 38, 0.07);
 }
 


### PR DESCRIPTION
Browser versions that made these vendor prefixes obsolete were released by the middle of 2011: https://caniuse.com/css-boxshadow.

This is the first in what could be a long series of CSS/JS simplification PRs if this kind of thing is desired by the maintainers. I think we can reduce some complexity by taking small steps like this.

For instance, next I would want to factor the two affected mixins out. They are each used in one place.