### PR TITLE
Remove unneeded `box-shadow` mixins

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -362,7 +362,7 @@ blockquote {
 
     .mdzr-boxshadow & {
         border: none;
-        @include secondary-shadow-top;
+        box-shadow: 0 4px 8px rgba(12, 60, 38, 0.07);
     }
 }
 
@@ -436,7 +436,7 @@ blockquote {
 
     .mdzr-boxshadow & {
         border: none;
-        @include secondary-shadow-bottom;
+        box-shadow: 0 -4px 8px rgba(12, 60, 38, 0.07);
     }
 }
 

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -170,15 +170,6 @@ html {
 
 }
 
-// Secondary content box-shadow:
-@mixin secondary-shadow-top {
-    box-shadow: 0 4px 8px rgba(12, 60, 38, 0.07);
-}
-
-@mixin secondary-shadow-bottom {
-    box-shadow: 0 -4px 8px rgba(12, 60, 38, 0.07);
-}
-
 @mixin framed-image {
     padding: 20px;
     border: 1px solid var(--hairline-color);


### PR DESCRIPTION
As of 3851b2f2, these are only used once and contain a single rule each.