### PR TITLE
Remove `Modernizr` check in `fundraising-heart.js`

### DIFF
--- a/djangoproject/static/js/mod/fundraising-heart.js
+++ b/djangoproject/static/js/mod/fundraising-heart.js
@@ -50,9 +50,7 @@ define([
 
     var Heart = function(heart) {
         this.heart = $(heart);
-        if (Modernizr.svg) {
-            this.init();
-        }
+        this.init();
     };
 
     Heart.prototype = {


### PR DESCRIPTION
`Modernizr` was removed in 132af0b3, and this was missed in that commit.