### PR TITLE
Syntax fix 'URLs and views' collapsing-content in start.html template

### DIFF
--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -71,7 +71,7 @@
       <a class="plink" href="{{ coc_url }}">require a code of conduct</a>.
       Isn't this redundant?{% endblocktranslate %}</p>
 
-  <p>{% translate "No: there's a difference between the two, and they're complementary.</p>
+  <p>{% translate "No: there's a difference between the two, and they're complementary." %}</p>
 
   <p>
     {% blocktranslate trimmed %}

--- a/djangoproject/templates/start.html
+++ b/djangoproject/templates/start.html
@@ -136,7 +136,7 @@ class Member(models.Model):
           </div>
         </li>
         <li>
-          <h2>{% translate "URLs and views</h2>
+          <h2>{% translate "URLs and views" %}</h2>
           <div class="collapsing-content">
             <p>A clean, elegant URL scheme is an important detail in a high-quality web application. Django encourages beautiful URL design and doesn’t put any cruft in URLs, like .php or .asp.</p>
             <p>To design URLs for an application, you create a Python module called a URLconf. Like a table of contents for your app, it contains a simple mapping between URL patterns and your views.</p>


### PR DESCRIPTION
## start.html template syntax fix

Before:
<img width="768" alt="Screenshot 2024-12-03 at 20 44 41" src="https://github.com/user-attachments/assets/f515d40d-ee18-4cd7-9528-9acb7c3054be">
After:
<img width="773" alt="Screenshot 2024-12-03 at 20 46 59" src="https://github.com/user-attachments/assets/71888690-ecda-47f8-a21a-42d7ae6ef947">
