### PR TITLE
Use 'docker compose' instead of 'docker-compose'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -370,18 +370,18 @@ Running Locally with Docker
 
 1. Build the images::
 
-    docker-compose build
+    docker compose build
 
 2. Spin up the containers::
 
-    docker-compose up
+    docker compose up
 
 3. View the site at http://localhost:8000/
 
 4. Run the tests::
 
-    docker-compose exec web tox
-    docker-compose exec web python -m manage test
+    docker compose exec web tox
+    docker compose exec web python -m manage test
 
 Pre-commit checks
 -----------------


### PR DESCRIPTION
Compose v2 was released on June 2021 and hit GA on April 2022, changing how should we call compose.

> Unlike Compose V1, Compose V2 integrates into the Docker CLI platform and the recommended command-line syntax is `docker compose`.

https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2