### PR TITLE
Remove unneeded `getElementsByClassName` polyfill

### DIFF
--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -6,30 +6,6 @@ define(function() {
 
     //detect Class function
     function hasClass( className ) {
-        if (!document.getElementsByClassName) { //class name function in old IE
-            document.getElementsByClassName = function(search) {
-                var d = document, elements, pattern, i, results = [];
-                if (d.querySelectorAll) { // IE8
-                    return d.querySelectorAll("." + search);
-                }
-                if (d.evaluate) { // IE6, IE7
-                    pattern = ".//*[contains(concat(' ', @class, ' '), ' " + search + " ')]";
-                    elements = d.evaluate(pattern, d, null, 0, null);
-                    while ((i = elements.iterateNext())) {
-                        results.push(i);
-                    }
-                } else {
-                    elements = d.getElementsByTagName("*");
-                    pattern = new RegExp("(^|\\s)" + search + "(\\s|$)");
-                    for (i = 0; i < elements.length; i++) {
-                        if ( pattern.test(elements[i].className) ) {
-                            results.push(elements[i]);
-                        }
-                    }
-                }
-                return results;
-            };
-        }
         return !!document.getElementsByClassName( className ).length; //return a boolean
     }
 


### PR DESCRIPTION
The `document.getElementsByClassName` method has been a standard browser feature for many years, so we no longer need a polyfill for it. See https://caniuse.com/getelementsbyclassname.

It may be worth refactoring this file a bit in a future pull request. I'll add that to my list to evaluate.