### PR TITLE
Fix initial position of two icons on overview page

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1752,7 +1752,7 @@ h2+.list-link-soup {
             }
 
             &.icon-lock {
-                background-position: 144px -206px;
+                background-position: 148px -206px;
 
                 &.inview {
                     background-position: -36px -96px;
@@ -1760,7 +1760,7 @@ h2+.list-link-soup {
             }
 
             &.icon-dashboard {
-                background-position: -360px 201px;
+                background-position: -367px 201px;
 
                 &.inview {
                     background-position: -270px -9px;


### PR DESCRIPTION
The initial `background-position`s of the lock and dashboard icons on [the overview page](https://www.djangoproject.com/start/overview/) were not hiding them like the other icons. This patch adjusts the initial `background-position` values so that the icons are out of view when the animation starts.

The bug is subtle in production. You can see it in detail if you remove the following lines:

https://github.com/django/djangoproject.com/blob/429a48d6450972d1369d27309f02b39696c3800e/djangoproject/static/js/main.js#L12-L15

Below is the error state for the two icons whose CSS is being adjusted. The other icons are not visible here.

<img width="788" alt="Screenshot 2024-12-06 at 9 36 44 PM" src="https://github.com/user-attachments/assets/f86488f8-009b-4b09-9ae4-5b5f0e1a6f9a">