### PR TITLE
Removed obsolete version element from compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
     web:
         build:


### PR DESCRIPTION
As per <https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete>:

> The top-level `version` property is defined by the Compose Specification for backward compatibility. It is only informative and you'll receive a warning message that it is obsolete if used.

Now that the README refers to Compose V2, I believe it makes sense to remove the reference to the obsolete value, and suppress the warning.