### PR TITLE
fix #1727: Replace reference to mailing list with Django Forum

### DIFF
--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -65,7 +65,7 @@
 
   <p>
     {% blocktranslate trimmed %}
-      As a member of the DSF, you will be recognized for your contributions to the community. Your name will appear below and you'll be added to the DSF Members Forum and Discord channel. You will also be eligible to vote for the DSF Board and Steering Council.
+      As a member of the DSF, you will be recognized for your contributions to the community. Your name will appear below and you'll be added to the various DSF Members communication channels (mailing list, forum, Discord). You will also be eligible to vote for the DSF Board and Steering Council.
     {% endblocktranslate %}
   </p>
 

--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -65,7 +65,7 @@
 
   <p>
     {% blocktranslate trimmed %}
-      As a member of the DSF, you will be recognized for your contributions to the community. Your name will appear below and you'll be added to the DSF Members Mailing list. You will also be eligible to vote for the DSF Board and Steering Council.
+      As a member of the DSF, you will be recognized for your contributions to the community. Your name will appear below and you'll be added to the DSF Members Forum and Discord channel. You will also be eligible to vote for the DSF Board and Steering Council.
     {% endblocktranslate %}
   </p>
 


### PR DESCRIPTION
fix #1727

Text changes for the page https://www.djangoproject.com/foundation/individual-members/

Before
<img width="767" alt="Screenshot 2024-12-08 at 9 37 29 AM" src="https://github.com/user-attachments/assets/763f6b0d-a643-4bc3-9869-5e43a07b9ef6">


After
<img width="748" alt="Screenshot 2024-12-08 at 9 49 24 AM" src="https://github.com/user-attachments/assets/9cb35615-35a1-47de-ab7b-eea59060a920">
