### PR TITLE
fix #1727: Remove reference to IRC and django-users and django-developers mailing lists in CoC

### DIFF
--- a/djangoproject/templates/conduct/enforcement.html
+++ b/djangoproject/templates/conduct/enforcement.html
@@ -64,7 +64,7 @@
   <p>
     {% blocktranslate trimmed %}
       This information will be collected in writing, and whenever possible the
-      committee's deliberations will be recorded and retained (i.e. IRC transcripts, email
+      committee's deliberations will be recorded and retained (i.e. chat transcripts, email
       discussions, recorded voice conversations, etc).
     {% endblocktranslate %}</p>
 
@@ -79,7 +79,7 @@
 
   <p>
     {% blocktranslate trimmed %}
-      If the act is ongoing (such as someone engaging in harassment in #django), or involves
+      If the act is ongoing (such as someone engaging in harassment on the forum), or involves
       a threat to anyone's safety (e.g. threats of violence), any committee member
       may act immediately (before reaching consensus) to end the situation. In ongoing
       situations, any member may at their discretion employ any of the tools available
@@ -117,18 +117,18 @@
       <li>
         {% blocktranslate trimmed %}
           A public reprimand. In this case, a committee member will deliver that reprimand
-          in the same venue that the violation occurred (i.e. in IRC for an IRC violation;
+          in the same venue that the violation occurred (i.e. in the forum for a forum violation;
           email for an email violation, etc.). The committee may choose to publish this message
           elsewhere for posterity.{% endblocktranslate %}</li>
       <li>
         {% blocktranslate trimmed %}
-          An imposed vacation (i.e. asking someone to "take a week off" from the forum
-          or IRC). A committee member will communicate this "vacation" to the individual(s).
+          An imposed vacation (i.e. asking someone to "take a week off" from the forum).
+          A committee member will communicate this "vacation" to the individual(s).
           They'll be asked to take this vacation voluntarily, but if they don't agree then
           a temporary ban may be imposed to enforce this vacation.{% endblocktranslate %}</li>
       <li>
         {% blocktranslate trimmed %}
-          A permanent or temporary ban from some or all Django spaces (forum, IRC,
+          A permanent or temporary ban from some or all Django spaces (the forum,
           etc.). The committee will maintain records of all such bans so that they may be
           reviewed in the future, extended to new Django fora, or otherwise maintained.
         {% endblocktranslate %}</li>

--- a/djangoproject/templates/conduct/enforcement.html
+++ b/djangoproject/templates/conduct/enforcement.html
@@ -122,13 +122,13 @@
           elsewhere for posterity.{% endblocktranslate %}</li>
       <li>
         {% blocktranslate trimmed %}
-          An imposed vacation (i.e. asking someone to "take a week off" from a mailing list
+          An imposed vacation (i.e. asking someone to "take a week off" from the forum
           or IRC). A committee member will communicate this "vacation" to the individual(s).
           They'll be asked to take this vacation voluntarily, but if they don't agree then
           a temporary ban may be imposed to enforce this vacation.{% endblocktranslate %}</li>
       <li>
         {% blocktranslate trimmed %}
-          A permanent or temporary ban from some or all Django spaces (mailing lists, IRC,
+          A permanent or temporary ban from some or all Django spaces (forum, IRC,
           etc.). The committee will maintain records of all such bans so that they may be
           reviewed in the future, extended to new Django fora, or otherwise maintained.
         {% endblocktranslate %}</li>
@@ -137,7 +137,7 @@
           A request for a public or private apology. a committee member will deliver this request.
           The committee may, if it chooses, attach "strings" to this request: for example,
           the committee may ask a violator to apologize in order to retain his or her membership
-          on a mailing list.{% endblocktranslate %}</li>
+          on the forum.{% endblocktranslate %}</li>
     </ul>
   </p>
 

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -57,10 +57,10 @@
 
   <p>
     {% blocktranslate trimmed %}
-      In practice, this means Django Forum, the various Django IRC channels (<tt>#django</tt>, <tt>#django-dev</tt>, etc.), bug
-      tracking and code review tools, and "official" Django events such as sprints.
-      In addition, violations of this code outside these spaces may affect a person's
-      ability to participate within them.{% endblocktranslate %}</p>
+      In practice, this means the Django forum, bug tracking and code review tools, and
+      "official" Django events such as DjangoCons. In addition, violations of this code
+      outside these spaces may affect a person's ability to participate within them.
+      {% endblocktranslate %}</p>
 
   <h3 id="dsf-events">{% translate "What about events funded by the Django Software Foundation?" %} <a class="plink" href="#dsf-events">¶</a></h3>
   <p>

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -57,8 +57,7 @@
 
   <p>
     {% blocktranslate trimmed %}
-      In practice, this means mailing lists (django-announce, django-updates, etc.),
-      the various Django IRC channels (<tt>#django</tt>, <tt>#django-dev</tt>, etc.), bug
+      In practice, this means Django Forum, the various Django IRC channels (<tt>#django</tt>, <tt>#django-dev</tt>, etc.), bug
       tracking and code review tools, and "official" Django events such as sprints.
       In addition, violations of this code outside these spaces may affect a person's
       ability to participate within them.{% endblocktranslate %}</p>

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -60,7 +60,7 @@
       In practice, this means the Django forum, bug tracking and code review tools, and
       "official" Django events such as DjangoCons. In addition, violations of this code
       outside these spaces may affect a person's ability to participate within them.
-      {% endblocktranslate %}</p>
+    {% endblocktranslate %}</p>
 
   <h3 id="dsf-events">{% translate "What about events funded by the Django Software Foundation?" %} <a class="plink" href="#dsf-events">¶</a></h3>
   <p>

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -57,7 +57,7 @@
 
   <p>
     {% blocktranslate trimmed %}
-      In practice, this means mailing lists (django-users, django-developers, etc.),
+      In practice, this means mailing lists (django-announce, django-updates, etc.),
       the various Django IRC channels (<tt>#django</tt>, <tt>#django-dev</tt>, etc.), bug
       tracking and code review tools, and "official" Django events such as sprints.
       In addition, violations of this code outside these spaces may affect a person's

--- a/djangoproject/templates/conduct/index.html
+++ b/djangoproject/templates/conduct/index.html
@@ -36,7 +36,7 @@
   <p>
     {% blocktranslate trimmed %}
       This code of conduct applies to all spaces managed by the Django project or
-      Django Software Foundation. This includes IRC, the mailing lists, the issue
+      Django Software Foundation. This includes IRC, the forum, the issue
       tracker, DSF events, and any other forums created by the project team
       which the community uses for communication. In addition, violations of this code
       outside these spaces may affect a person's ability to participate within them.

--- a/djangoproject/templates/conduct/index.html
+++ b/djangoproject/templates/conduct/index.html
@@ -36,7 +36,7 @@
   <p>
     {% blocktranslate trimmed %}
       This code of conduct applies to all spaces managed by the Django project or
-      Django Software Foundation. This includes IRC, the forum, the issue
+      Django Software Foundation. This includes the issue
       tracker, DSF events, and any other forums created by the project team
       which the community uses for communication. In addition, violations of this code
       outside these spaces may affect a person's ability to participate within them.

--- a/djangoproject/templates/conduct/reporting.html
+++ b/djangoproject/templates/conduct/reporting.html
@@ -41,7 +41,7 @@
       <li>{% translate "Your contact info (so we can get in touch with you if we need to follow up)" %}</li>
       <li>{% translate "Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well." %}</li>
       <li>{% translate "When and where the incident occurred. Please be as specific as possible." %}</li>
-      <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. the forum or a public IRC logger) please include a link." %}</li>
+      <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. a forum post) please include a link." %}</li>
       <li>{% translate "Any extra context you believe existed for the incident." %}</li>
       <li>{% translate "If you believe this incident is ongoing." %}</li>
       <li>{% translate "Any other information you believe we should have." %}</li>
@@ -80,8 +80,8 @@
       <li>{% translate "Nothing (if we determine no violation occurred)." %}</li>
       <li>{% translate "A private reprimand from the working group to the individual(s) involved." %}</li>
       <li>{% translate "A public reprimand." %}</li>
-      <li>{% blocktranslate %}An imposed vacation (i.e. asking someone to "take a week off" from the forum or IRC).{% endblocktranslate %}</li>
-      <li>{% translate "A permanent or temporary ban from some or all Django spaces (forum, IRC, etc.)" %}</li>
+      <li>{% blocktranslate %}An imposed vacation (i.e. asking someone to "take a week off" from the forum).{% endblocktranslate %}</li>
+      <li>{% translate "A permanent or temporary ban from some or all Django spaces (the forum, etc.)" %}</li>
       <li>{% translate "A request for a public or private apology." %}</li>
     </ul>
   </p>

--- a/djangoproject/templates/conduct/reporting.html
+++ b/djangoproject/templates/conduct/reporting.html
@@ -41,7 +41,7 @@
       <li>{% translate "Your contact info (so we can get in touch with you if we need to follow up)" %}</li>
       <li>{% translate "Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well." %}</li>
       <li>{% translate "When and where the incident occurred. Please be as specific as possible." %}</li>
-      <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link." %}</li>
+      <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. the forum or a public IRC logger) please include a link." %}</li>
       <li>{% translate "Any extra context you believe existed for the incident." %}</li>
       <li>{% translate "If you believe this incident is ongoing." %}</li>
       <li>{% translate "Any other information you believe we should have." %}</li>
@@ -80,8 +80,8 @@
       <li>{% translate "Nothing (if we determine no violation occurred)." %}</li>
       <li>{% translate "A private reprimand from the working group to the individual(s) involved." %}</li>
       <li>{% translate "A public reprimand." %}</li>
-      <li>{% blocktranslate %}An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC).{% endblocktranslate %}</li>
-      <li>{% translate "A permanent or temporary ban from some or all Django spaces (mailing lists, IRC, etc.)" %}</li>
+      <li>{% blocktranslate %}An imposed vacation (i.e. asking someone to "take a week off" from the forum or IRC).{% endblocktranslate %}</li>
+      <li>{% translate "A permanent or temporary ban from some or all Django spaces (forum, IRC, etc.)" %}</li>
       <li>{% translate "A request for a public or private apology." %}</li>
     </ul>
   </p>


### PR DESCRIPTION
Fix #1727

Text changes for the page (https://www.djangoproject.com/conduct/faq/)

Before
<img width="755" alt="Screenshot 2024-12-08 at 10 02 03 AM" src="https://github.com/user-attachments/assets/999e3be2-2850-4dd9-a5dc-0f8d1edee753">

After
<img width="761" alt="Screenshot 2024-12-08 at 10 18 54 AM" src="https://github.com/user-attachments/assets/72de04db-4e32-4b5f-ac22-d909ea7e0bf5">