### PR TITLE
fix #1806: N+1 query issue on dashboard index page

### DIFF
--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -2,25 +2,28 @@
 {% load i18n static %}
 
 {% block content %}
-  <div>
-    {% for report in data %}
-      {% ifchanged report.metric.category %}
-        {% if report.metric.category %}<h2>{{ report.metric.category }}</h2>{% endif %}
+
+  <div class="dashboard-index">
+    {% for metric in data %}
+      {% ifchanged metric.category %}
+        {% if metric.category %}<h2>{{ metric.category }}</h2>{% endif %}
       {% endifchanged %}
-      <div class="metric{% if report.metric.show_sparkline %} has-sparkline{% endif %}">
-        <h3><a href="{{ report.metric.link }}">{{ report.metric.name }}</a></h3>
+      <div class="metric{% if metric.show_sparkline %} has-sparkline{% endif %}">
+        <h3><a href="{{ metric.link }}">{{ metric.name }}</a></h3>
         <div class="value" >
-          <a href="{{ report.metric.get_absolute_url }}">{{ report.latest.measurement }}{% if report.metric.unit == "%" %}%{% endif %}</a>
+          <a href="{{ metric.get_absolute_url }}">{{ metric.latest.measurement }}{% if metric.unit == "%" %}%{% endif %}</a>
           <div class="timestamp">&nbsp;</div>
         </div>
-        {% if report.metric.show_sparkline %}
-          <div class="sparkline" id="spark{{ forloop.counter0 }}" data-path="{% url "metric-list" host "dashboard" %}" data-metric="{{ report.metric.slug }}"></div>
+        {% if metric.show_sparkline %}
+          <div class="sparkline" id="spark{{ forloop.counter0 }}" data-path="{% url "metric-list" host "dashboard" %}" data-metric="{{ metric.slug }}"></div>
         {% endif %}
       </div>
     {% endfor %}
-    <p class="updated">
-      {% blocktranslate with timestamp=data.0.latest.timestamp|timesince %}Updated {{ timestamp }} ago.{% endblocktranslate %}
-    </p>
+    {% if last_updated %}
+      <p class="updated">
+        {% blocktranslate with timestamp=last_updated|timesince %}Updated {{ timestamp }} ago.{% endblocktranslate %}
+      </p>
+    {% endif %}
   </div>
 {% endblock content %}
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -17,17 +17,23 @@ def index(request):
 
     data = cache.get(key, version=generation)
     if data is None:
-        metrics = []
-        for MC in Metric.__subclasses__():
-            metrics.extend(MC.objects.filter(show_on_dashboard=True))
-        metrics = sorted(metrics, key=operator.attrgetter("display_position"))
-
-        data = []
-        for metric in metrics:
-            data.append({"metric": metric, "latest": metric.data.latest()})
+        data = [m for MC in Metric.__subclasses__() for m in MC.objects.for_dashboard()]
+        data.sort(key=operator.attrgetter("display_position"))
         cache.set(key, data, 60 * 60, version=generation)
 
-    return render(request, "dashboard/index.html", {"data": data})
+    # Due to the way `with_latest()` is implemented, the timestamps we get back
+    # are actually strings (because JSON) so they need converting to proper
+    # datetime objects first.
+    timestamps = [
+        datetime.datetime.fromisoformat(m.latest["timestamp"])
+        for m in data
+        if m.latest is not None
+    ]
+    last_updated = max(timestamps, default=None)
+
+    return render(
+        request, "dashboard/index.html", {"data": data, "last_updated": last_updated}
+    )
 
 
 def metric_detail(request, metric_slug):


### PR DESCRIPTION
fix #1806 

The existing query was looping on metrics to grab the latest Datum for each metric, which led to 18 similar queries reported by django-debug-toolbar. There were 45 sql queries overall for the page.

<img width="1304" alt="Screenshot 2024-12-09 at 7 33 50 AM" src="https://github.com/user-attachments/assets/08ef27a5-abae-4fae-9c86-09bf0270c258">

This is WIP. The change here reduces the number of queries down to 1 large statement of unions of each metric's latest datum. There are 9 sql queries overall for the page.

Changes include:
- Query on the content type for each metric, which is used to build the union.
- Query on Datum by building a union of all the metric querysets.
- Adding a `select_related('category')` for the metric query that is used for sorting based on `display_position`.

![Screenshot 2024-12-10 at 10 28 08 AM](https://github.com/user-attachments/assets/4962699b-4a7e-4a47-83cd-0b38e24ba8e4)