### PR TITLE
Implemented Docker multi-stage build

### DIFF
--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -1,76 +1,8 @@
-from .common import *  # noqa
-
-DATABASES = {
-    "default": {
-        "ENGINE": os.environ.get("SQL_ENGINE"),
-        "NAME": os.environ.get("SQL_DATABASE"),
-        "USER": os.environ.get("SQL_USER"),
-        "PASSWORD": os.environ.get("SQL_PASSWORD"),
-        "HOST": os.environ.get("SQL_HOST"),
-        "PORT": os.environ.get("SQL_PORT"),
-    }
-}
-
-SECRET_KEY = os.environ.get("SECRET_KEY")
-
-SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
-    "django_recaptcha.recaptcha_test_key_error"  # Default test keys for development.
-]
-
-ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]
-
-LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
-
-DEBUG = True
-THUMBNAIL_DEBUG = DEBUG
-
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "trololololol",
-    },
-    "docs-pages": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "docs-pages",
-    },
-}
-
-CSRF_COOKIE_SECURE = False
-
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
-MEDIA_ROOT = str(DATA_DIR.joinpath("media_root"))
-
-SESSION_COOKIE_SECURE = False
-
-STATIC_ROOT = str(DATA_DIR.joinpath("static_root"))
-
-# Docs settings
-DOCS_BUILD_ROOT = DATA_DIR.joinpath("djangodocs")
+from .dev import *  # noqa
 
 # django-hosts settings
+if parent_host := SECRETS.get("parent_host"):
+    PARENT_HOST = parent_host
 
-PARENT_HOST = "localhost:8000"
-
-# django-push settings
-
-PUSH_SSL_CALLBACK = False
-
-# Enable optional components
-
-if DEBUG:
-    try:
-        import debug_toolbar  # NOQA
-    except ImportError:
-        pass
-    else:
-        INSTALLED_APPS.append("debug_toolbar")
-        INTERNAL_IPS = ["127.0.0.1"]
-        MIDDLEWARE.insert(
-            MIDDLEWARE.index("django.middleware.common.CommonMiddleware") + 1,
-            "debug_toolbar.middleware.DebugToolbarMiddleware",
-        )
-        MIDDLEWARE.insert(
-            MIDDLEWARE.index("debug_toolbar.middleware.DebugToolbarMiddleware") + 1,
-            "djangoproject.middleware.CORSMiddleware",
-        )
+# debug-toolbar settings
+INTERNAL_IPS = SECRETS.get("internal_ips", ["127.0.0.1"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,11 @@ services:
             - POSTGRES_USER=djangoproject
             - POSTGRES_PASSWORD=secret
             - POSTGRES_DB=djangoproject
+    tracdb:
+        image: postgres:14-alpine
+        environment:
+            - POSTGRES_USER=code.djangoproject
+            - POSTGRES_PASSWORD=secret
+            - POSTGRES_DB=code.djangoproject
+        volumes:
+            - ./tracdb/trac.sql:/docker-entrypoint-initdb.d/trac.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
         build:
             context: ./
             dockerfile: Dockerfile
+            target: djangoproject-www-dev
             args:
                 - REQ_FILE=requirements/tests.txt
         entrypoint: ./docker-entrypoint.dev.sh

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ python =
 
 [testenv]
 allowlist_externals = make
-passenv = DJANGO_SETTINGS_MODULE
+passenv = DJANGO_SETTINGS_MODULE, DJANGOPROJECT_DATA_DIR
 deps =
     tests: -r{toxinidir}/requirements/tests.txt
     flake8: flake8


### PR DESCRIPTION
This solves the first part of #1817, where tox fails to install test dependencies due to missing packages.

- Added target inputs to GitHub workflows.
- Added stages to Dockerfile.
- Moved package removal to production stage.
- Added target dev to compose file.

**Notes (and unresolved questions)**

Marking this a draft PR for now, as it could use some feedback :)

- I haven't tested the GH actions, as I am more of a GitLab user, but as per <https://github.com/docker/build-push-action?tab=readme-ov-file#inputs>, I believe that simply adding the `target` should suffice.
- I'm not 100% sure whether the Action stages are correct, as I am not quite sure how they are run but I used the dev stage for tests, production stage for publishing.
- This solves the `install_deps` step, and allows the tests to run, but the actual tests still fail when run.
- Any feedback regarding the stage names (django-web-base, django-web-dev, django-web-prod), or anything else, let me know.
- I'm not sure whether this should be merged as-is (I think it's fine as a standalone commit), or we should fix the test run itself too prior to merging this.