### PR TITLE
Reduced references to #django IRC.

### DIFF
--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -149,11 +149,6 @@
 
     <h3>{% translate "Get Help" %}</h3>
     <dl class="list-links-small">
-      <dt><a href="irc://irc.libera.chat/django">{% translate "#django IRC channel" %}</a></dt>
-      <dd>
-        {% translate "Chat with other Django users" %}
-      </dd>
-
       <dt><a href="https://discord.gg/xcRH6mN4fa" target="_blank">{% translate "Django Discord Server" %}</a></dt>
       <dd>
         {% translate "Join the Django Discord Community" %}

--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -38,7 +38,6 @@
           <ul>
             <li><a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">Getting Help FAQ</a>
             </li>
-            <li><a href="irc://irc.libera.chat/django">#django IRC channel</a></li>
             <li><a href="https://discord.gg/xcRH6mN4fa" target="_blank">Django Discord</a></li>
             <li><a href="https://forum.djangoproject.com/" target="_blank">Official Django Forum</a></li>
           </ul>

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -188,9 +188,6 @@
         <dt><a href="/en/stable/genindex/">{% trans "Index" %}</a>, <a href="/en/stable/py-modindex/">{% trans "Module Index" %}</a>, or <a href="/en/stable/contents/">{% trans "Table of Contents" %}</a></dt>
         <dd>{% blocktrans %}Handy when looking for specific information.{% endblocktrans %}</dd>
 
-        <dt><a href="irc://irc.libera.chat/django">{% trans "#django IRC channel" %}</a></dt>
-        <dd>{% blocktrans %}Ask a question in the #django IRC channel, or search the IRC logs to see if it’s been asked before.{% endblocktrans %}</dd>
-
         <dt><a href="https://discord.gg/xcRH6mN4fa">{% trans "Django Discord Server" %}</a></dt>
         <dd>{% blocktrans %}Join the Django Discord Community.{% endblocktrans %}</dd>
 


### PR DESCRIPTION
Following https://forum.djangoproject.com/t/proposal-retire-irc/37129 and https://code.djangoproject.com/ticket/35999, these are my suggested updates for the website.

I have chosen to:
- keep IRC on the community `More Help` section
- ~replace references of IRC in the code of conduct sections with the forum. These are still valid and we could leave IRC, however, I think the forum or Discord would be a more common case.~ moved to https://github.com/django/djangoproject.com/pull/1823