### PR TITLE
Added default silenced system checks to dev

### DIFF
--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -63,4 +63,6 @@ if DEBUG:
             "djangoproject.middleware.CORSMiddleware",
         )
 
-SILENCED_SYSTEM_CHECKS = ["django_recaptcha.recaptcha_test_key_error"]
+SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
+    "django_recaptcha.recaptcha_test_key_error"
+]


### PR DESCRIPTION
After the setting was deleted and added anew, it overrides the original rather than extending it. This adds the default silenced checks back.