### PR TITLE
Removed IRC from example Django spaces for CoC violations.

### DIFF
--- a/djangoproject/templates/conduct/enforcement.html
+++ b/djangoproject/templates/conduct/enforcement.html
@@ -64,7 +64,7 @@
   <p>
     {% blocktranslate trimmed %}
       This information will be collected in writing, and whenever possible the
-      committee's deliberations will be recorded and retained (i.e. IRC transcripts, email
+      committee's deliberations will be recorded and retained (i.e. chat transcripts, email
       discussions, recorded voice conversations, etc).
     {% endblocktranslate %}</p>
 
@@ -79,7 +79,7 @@
 
   <p>
     {% blocktranslate trimmed %}
-      If the act is ongoing (such as someone engaging in harassment in #django), or involves
+      If the act is ongoing (such as someone engaging in harassment on the forum), or involves
       a threat to anyone's safety (e.g. threats of violence), any committee member
       may act immediately (before reaching consensus) to end the situation. In ongoing
       situations, any member may at their discretion employ any of the tools available
@@ -117,18 +117,18 @@
       <li>
         {% blocktranslate trimmed %}
           A public reprimand. In this case, a committee member will deliver that reprimand
-          in the same venue that the violation occurred (i.e. in IRC for an IRC violation;
+          in the same venue that the violation occurred (i.e. in the forum for a forum violation;
           email for an email violation, etc.). The committee may choose to publish this message
           elsewhere for posterity.{% endblocktranslate %}</li>
       <li>
         {% blocktranslate trimmed %}
           An imposed vacation (i.e. asking someone to "take a week off" from a mailing list
-          or IRC). A committee member will communicate this "vacation" to the individual(s).
+          or the forum). A committee member will communicate this "vacation" to the individual(s).
           They'll be asked to take this vacation voluntarily, but if they don't agree then
           a temporary ban may be imposed to enforce this vacation.{% endblocktranslate %}</li>
       <li>
         {% blocktranslate trimmed %}
-          A permanent or temporary ban from some or all Django spaces (mailing lists, IRC,
+          A permanent or temporary ban from some or all Django spaces (mailing lists, the forum,
           etc.). The committee will maintain records of all such bans so that they may be
           reviewed in the future, extended to new Django fora, or otherwise maintained.
         {% endblocktranslate %}</li>

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -58,10 +58,9 @@
   <p>
     {% blocktranslate trimmed %}
       In practice, this means mailing lists (django-users, django-developers, etc.),
-      the various Django IRC channels (<tt>#django</tt>, <tt>#django-dev</tt>, etc.), bug
-      tracking and code review tools, and "official" Django events such as sprints.
-      In addition, violations of this code outside these spaces may affect a person's
-      ability to participate within them.{% endblocktranslate %}</p>
+      the Django forum, bug tracking and code review tools, and "official" Django events
+      such as DjangoCons. In addition, violations of this code outside these spaces may
+      affect a person's ability to participate within them.{% endblocktranslate %}</p>
 
   <h3 id="dsf-events">{% translate "What about events funded by the Django Software Foundation?" %} <a class="plink" href="#dsf-events">¶</a></h3>
   <p>

--- a/djangoproject/templates/conduct/index.html
+++ b/djangoproject/templates/conduct/index.html
@@ -36,7 +36,7 @@
   <p>
     {% blocktranslate trimmed %}
       This code of conduct applies to all spaces managed by the Django project or
-      Django Software Foundation. This includes IRC, the mailing lists, the issue
+      Django Software Foundation. This includes the mailing lists, the issue
       tracker, DSF events, and any other forums created by the project team
       which the community uses for communication. In addition, violations of this code
       outside these spaces may affect a person's ability to participate within them.

--- a/djangoproject/templates/conduct/reporting.html
+++ b/djangoproject/templates/conduct/reporting.html
@@ -41,7 +41,7 @@
       <li>{% translate "Your contact info (so we can get in touch with you if we need to follow up)" %}</li>
       <li>{% translate "Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well." %}</li>
       <li>{% translate "When and where the incident occurred. Please be as specific as possible." %}</li>
-      <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link." %}</li>
+      <li>{% translate "Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a forum post) please include a link." %}</li>
       <li>{% translate "Any extra context you believe existed for the incident." %}</li>
       <li>{% translate "If you believe this incident is ongoing." %}</li>
       <li>{% translate "Any other information you believe we should have." %}</li>
@@ -80,8 +80,8 @@
       <li>{% translate "Nothing (if we determine no violation occurred)." %}</li>
       <li>{% translate "A private reprimand from the working group to the individual(s) involved." %}</li>
       <li>{% translate "A public reprimand." %}</li>
-      <li>{% blocktranslate %}An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC).{% endblocktranslate %}</li>
-      <li>{% translate "A permanent or temporary ban from some or all Django spaces (mailing lists, IRC, etc.)" %}</li>
+      <li>{% blocktranslate %}An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or the forum).{% endblocktranslate %}</li>
+      <li>{% translate "A permanent or temporary ban from some or all Django spaces (mailing lists, the forum, etc.)" %}</li>
       <li>{% translate "A request for a public or private apology." %}</li>
     </ul>
   </p>


### PR DESCRIPTION
Following https://forum.djangoproject.com/t/proposal-retire-irc/37129 and https://code.djangoproject.com/ticket/35999, I suggest that IRC is not used as an example for CoC violations.
Although it is still valid, we should use a space which is more active (and more likely to have a CoC violation)

We may want to combine these changes with https://github.com/django/djangoproject.com/pull/1808