### PR TITLE
test github action for collectstatic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,42 +36,42 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: "${{ matrix.python-version }}"
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip setuptools coveralls "tox<5" "tox-gh-actions<4"
-            - name: Set up databases
-              run: |
-                  PGPASSWORD="postgres" createuser -U postgres -d djangoproject --superuser -h localhost
-                  PGPASSWORD="postgres" createdb -U postgres -O djangoproject djangoproject -h localhost
-                  PGPASSWORD="postgres" createuser -U postgres -d code.djangoproject --superuser -h localhost
-                  PGPASSWORD="postgres" createdb -U postgres -O code.djangoproject code.djangoproject -h localhost
-                  PGPASSWORD="postgres" psql -U postgres -h localhost -c "ALTER USER djangoproject WITH PASSWORD 'secret';"
-                  PGPASSWORD="postgres" psql -U postgres -h localhost -c "ALTER USER \"code.djangoproject\" WITH PASSWORD 'secret';"
-            - name: Load Trac data
-              run: |
-                  PGPASSWORD="postgres" psql -U postgres -d code.djangoproject -h localhost < tracdb/trac.sql
-            - name: Create secrets.json
-              working-directory: ..
-              run: |
-                  mkdir conf
-                  echo '{"db_host": "localhost", ' > conf/secrets.json
-                  echo '"db_password": "secret", ' >> conf/secrets.json
-                  echo '"trac_db_host": "localhost", ' >> conf/secrets.json
-                  echo '"trac_db_password": "secret", ' >> conf/secrets.json
-                  echo '"secret_key": "a"}' >> conf/secrets.json
-            - name: Run tox
-              run: |
-                  python -m tox
-            - name: Coveralls
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_PARALLEL: true
-                  COVERALLS_FLAG_NAME: "${{ matrix.python-version }}"
-                  COVERALLS_SERVICE_NAME: github
-                  COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
-                  COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
-              run: coveralls --service=github
+            # - name: Install dependencies
+            #   run: |
+            #       python -m pip install --upgrade pip setuptools coveralls "tox<5" "tox-gh-actions<4"
+            # - name: Set up databases
+            #   run: |
+            #       PGPASSWORD="postgres" createuser -U postgres -d djangoproject --superuser -h localhost
+            #       PGPASSWORD="postgres" createdb -U postgres -O djangoproject djangoproject -h localhost
+            #       PGPASSWORD="postgres" createuser -U postgres -d code.djangoproject --superuser -h localhost
+            #       PGPASSWORD="postgres" createdb -U postgres -O code.djangoproject code.djangoproject -h localhost
+            #       PGPASSWORD="postgres" psql -U postgres -h localhost -c "ALTER USER djangoproject WITH PASSWORD 'secret';"
+            #       PGPASSWORD="postgres" psql -U postgres -h localhost -c "ALTER USER \"code.djangoproject\" WITH PASSWORD 'secret';"
+            # - name: Load Trac data
+            #   run: |
+            #       PGPASSWORD="postgres" psql -U postgres -d code.djangoproject -h localhost < tracdb/trac.sql
+            # - name: Create secrets.json
+            #   working-directory: ..
+            #   run: |
+            #       mkdir conf
+            #       echo '{"db_host": "localhost", ' > conf/secrets.json
+            #       echo '"db_password": "secret", ' >> conf/secrets.json
+            #       echo '"trac_db_host": "localhost", ' >> conf/secrets.json
+            #       echo '"trac_db_password": "secret", ' >> conf/secrets.json
+            #       echo '"secret_key": "a"}' >> conf/secrets.json
+            # - name: Run tox
+            #   run: |
+            #       python -m tox
+            # - name: Coveralls
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #       COVERALLS_PARALLEL: true
+            #       COVERALLS_FLAG_NAME: "${{ matrix.python-version }}"
+            #       COVERALLS_SERVICE_NAME: github
+            #       COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
+            #       COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
+            #   run: coveralls --service=github
             - name: Run collectstatic for production
               run: |
                   python -m pip install -r requirements/prod.txt
-                  python -m manage collectstatic --djangoproject.settings.prod
+                  python -m manage collectstatic --settings=djangoproject.settings.prod

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,3 +71,7 @@ jobs:
                   COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
                   COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
               run: coveralls --service=github
+            - name: Run collectstatic for production
+              run: |
+                  python -m pip install -r requirements/prod.txt
+                  python -m manage collectstatic --djangoproject.settings.prod

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ deps =
     flake8: flake8
     isort: isort
 commands =
-    tests: make ci
+    tests:
+        make ci
+        python manage.py collectstatic --settings=djangoproject.settings.prod
     flake8: flake8
     isort: make isort-check
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,7 @@ deps =
     flake8: flake8
     isort: isort
 commands =
-    tests:
-        make ci
-        python manage.py collectstatic --settings=djangoproject.settings.prod
+    tests: make ci
     flake8: flake8
     isort: make isort-check
 


### PR DESCRIPTION
Fix #1831 

WIP. This is probably not the right approach. It adds the collectstatic command to tox, although tox is running under development environment and we are trying to test production.

### To Do
- [ ] Remove jquery.min.map file, then run collectstatic to observe the ValueError.
- [ ] Try adding a new step in github actions to `.github/workflows/tests.yml`, something along the lines of:
```
            - name: Run collectstatic for production
              run: |
                pip install -r djangoproject/requirements/prod.txt
                python manage.py collectstatic --settings=djangoproject.settings.prod
```
What environment variables need to be set?
