### PR TITLE
Refactored `messages.js`

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3416,6 +3416,8 @@ ul.corporate-members li {
         color: $green-dark;
         border: 1px solid $green-dark;
         border-radius: 4px;
+        opacity: 1;
+        transition: opacity 400ms;
 
         &::before {
             @include fa-icon();
@@ -3425,6 +3427,10 @@ ul.corporate-members li {
             float: left;
             margin-left: -5px;
             margin-right: 10px;
+        }
+
+        &.fade-out {
+            opacity: 0;
         }
 
         &.info {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3416,7 +3416,6 @@ ul.corporate-members li {
         color: $green-dark;
         border: 1px solid $green-dark;
         border-radius: 4px;
-        transition: opacity 400ms;
 
         &::before {
             @include fa-icon();
@@ -3430,6 +3429,7 @@ ul.corporate-members li {
 
         &.fade-out {
             opacity: 0;
+            transition: opacity 400ms;
         }
 
         &.info {

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3416,7 +3416,6 @@ ul.corporate-members li {
         color: $green-dark;
         border: 1px solid $green-dark;
         border-radius: 4px;
-        opacity: 1;
         transition: opacity 400ms;
 
         &::before {

--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -15,10 +15,10 @@ document.querySelectorAll('#doc-versions a').forEach(function (el) {
 // Fade out and remove message elements when close icon is clicked
 document.querySelectorAll('.messages li .close').forEach(function (el) {
   el.addEventListener('click', function (e) {
-    this.parentElement.classList.add('fade-out');
+    this.parentElement.addEventListener('transitionend', function (e) {
+      this.style.display = 'none';
+    });
 
-    setTimeout(function () {
-      el.parentElement.style.display = 'none';
-    }, 400);
+    this.parentElement.classList.add('fade-out');
   });
 });

--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -11,3 +11,14 @@ document.querySelectorAll('#doc-versions a').forEach(function (el) {
     this.href = this.href.split('#')[0] + window.location.hash;
   });
 });
+
+// Fade out and remove message elements when close icon is clicked
+document.querySelectorAll('.messages li .close').forEach(function (el) {
+  el.addEventListener('click', function (e) {
+    this.parentElement.classList.add('fade-out');
+
+    setTimeout(function () {
+      el.parentElement.style.display = 'none';
+    }, 400);
+  });
+});

--- a/djangoproject/static/js/main.js
+++ b/djangoproject/static/js/main.js
@@ -57,10 +57,6 @@ define(function () {
     mods.push('mod/corporate-member-join');
   }
 
-  if (hasClass('messages')) {
-    mods.push('mod/messages');
-  }
-
   if (hasClass('code-block-caption') || hasClass('snippet')) {
     mods.push('mod/clippify');
   }

--- a/djangoproject/static/js/mod/messages.js
+++ b/djangoproject/static/js/mod/messages.js
@@ -1,7 +1,0 @@
-define([
-  'jquery', //requires jquery
-], function ($) {
-  $('.messages li').on('click', '.close', function () {
-    $(this).parents('.messages > li').fadeOut();
-  });
-});


### PR DESCRIPTION
- Simplified code using a combination of CSS and JavaScript
- Stopped using jQuery
- Moved refactored code to `djangoproject.js`

This patch should bring no user-facing changes.

Refs #1827

The easiest way I found to test with was to add the following code to the bottom of `blog.views.BlogViewMixin` right before the return:

```python
        from django.contrib import messages

        messages.info(self.request, 'abc')
        messages.success(self.request, 'def')
```

Then test this way:

1. Navigate to the "News" (`/weblog/`) section of the site
2. Dismiss the two message