### PR TITLE
Used local `fontawesome-webfont.woff` file

### DIFF
--- a/djangoproject/scss/font-awesome/_variables.scss
+++ b/djangoproject/scss/font-awesome/_variables.scss
@@ -1,8 +1,7 @@
 // Variables
 // --------------------------
 
-// $fa-font-path:        "../fonts/font-awesome" !default;
-$fa-font-path: "//netdna.bootstrapcdn.com/font-awesome/4.2.0/fonts" !default; // for referencing Bootstrap CDN font files directly
+$fa-font-path: "../fonts" !default;
 $fa-css-prefix: icon !default;
 $fa-version: "4.2.0" !default;
 $fa-border-color: #eee !default;


### PR DESCRIPTION
For the last ten years (since 7abaceb1), the site has fetched its Font Awesome font asset from a remote CDN. It seems to me that since 7d21f20a, we would rather host our static assets ourselves. This patch makes that change for the current version of Font Awesome.

`base.html` was already referring to the local version, so there was an inconsistency here. Merging #1854 will remove the possibility of inconsistency here.