### PR TITLE
Remove `link` tags for font assets

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -39,11 +39,6 @@
 
     <title>{% block title %}The web framework for perfectionists with deadlines{% endblock %} | Django</title>
 
-    <link href="{% static "fonts/FiraMono-Regular.woff" %}" as="font" type="font/woff" crossorigin="anonymous" />
-    <link href="{% static "fonts/FiraMono-Bold.woff" %}" as="font" type="font/woff" crossorigin="anonymous" />
-
-    <link href="{% static "fonts/fontawesome-webfont.woff" %}" as="font" type="font/woff" crossorigin="anonymous" />
-
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Since we're using `src: url('...')` in CSS, these `link` tags shouldn't be needed. A look in DevTools proves that the font asset requests are coming from the CSS file.

<img width="710" alt="image" src="https://github.com/user-attachments/assets/b368728d-5880-43ac-885a-c0e9459931a2" />

<img width="682" alt="image" src="https://github.com/user-attachments/assets/3c0e809d-f28c-4f90-b50c-f00f27cea7b2" />

<img width="869" alt="image" src="https://github.com/user-attachments/assets/cdd98e7b-fa52-4393-a251-eab1e171b71d" />

Related to #1853