### PR TITLE
Remove Debian packages from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,8 @@ RUN apt-get update \
         git \
         libpq5 \
         make \
-        netcat-openbsd \
         postgresql-client-15 \
         rsync \
-        zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
 ARG REQ_FILE=requirements/prod.txt
@@ -34,6 +32,7 @@ RUN apt-get update \
         zlib1g-dev \
     && python3 -m pip install --no-cache-dir -r ${REQ_FILE} \
     && apt-get purge --assume-yes --auto-remove \
+        g++ \
         gcc \
         libc6-dev \
         libpq-dev \

--- a/docker-entrypoint.dev.sh
+++ b/docker-entrypoint.dev.sh
@@ -2,7 +2,7 @@
 
 echo "Waiting for postgres..."
 
-while ! nc -z db 5432; do
+while ! pg_isready -h db -p 5432 -q; do
   sleep 0.1
 done
 


### PR DESCRIPTION
This contains the following changes:
- removing `zlib1g` from Dockerfile because it's already part of the base image
- used `pg_isready` to check the database readiness, removing `netcat-openbsd` from Dockerfile
- uninstalling `g++` after installing requirements