### PR TITLE
Use a Bookworm based Postgres image in Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
             db:
                 condition: service_healthy
     db:
-        image: postgres:14-alpine
+        image: postgres:14-bookworm
         environment:
             - POSTGRES_USER=djangoproject
             - POSTGRES_PASSWORD=secret


### PR DESCRIPTION
The Alpine-based Postgres Docker image has some limitations compared to the standard one (eg: locale, extensions, ...), also I believe that the production version is not based on musl but on glibc.

I propose to use the standard version of the Postgres image in Docker compose to increase compatibility with the production system, having the same functionality locally without using too much more space since the standard version image is only a few megabytes larger than the Alpine one (eg: 142 MB vs 103MB).