### PR TITLE
Use "run --rm" instead of exec for tests in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -365,8 +365,8 @@ Running Locally with Docker
 
 4. Run the tests::
 
-    docker compose exec web tox
-    docker compose exec web python -m manage test
+    docker compose run --rm web tox
+    docker compose run --rm web python -m manage test
 
 Pre-commit checks
 -----------------


### PR DESCRIPTION
This is something pretty small but I find `run --rm` more robust than `exec`, because:

* exec requires a running container, "run --rm" starts a new one and deletes when the job is done
* exec requires the related container to stay healthy, "run --rm" run things on a separate container