### PR TITLE
Updated JavaScript indent size to match `prettier`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ trim_trailing_whitespace = false
 
 [*.{scss,js}]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 
 # Customizations for third party libraries


### PR DESCRIPTION
This was missed in 6dc8f418. The indent size in `.editorconfig` should match `.prettierrc`.