### PR TITLE
Clean pending migrations check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ migrations-check:
 run:
 	python -m manage runserver 0.0.0.0:8000
 
-test: migrations-check
+test:
 	@python -m coverage run --source=. --module manage test --verbosity 2 $(APP_LIST)
 
 watch-scss:

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -118,6 +118,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         self.assertIn("Vary", resp)
 
 
+# https://adamj.eu/tech/2024/06/23/django-test-pending-migrations/
 class PendingMigrationsTests(TestCase):
     def test_no_pending_migrations(self):
         out = StringIO()


### PR DESCRIPTION
The pending migrations check was running twice. I removed it from the makefile and added a reference to the origin of the code block (thinking it would be nice to give credit 🎈)