### PR TITLE
Fixed stripe crash in fundraising view

### DIFF
--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -156,7 +156,9 @@ def manage_donations(request, hero):
 def update_card(request):
     donation = get_object_or_404(Donation, id=request.POST["donation_id"])
     try:
-        customer = stripe.Customer.retrieve(donation.stripe_customer_id)
+        customer = stripe.Customer.retrieve(
+            donation.stripe_customer_id, expand=["subscriptions"]
+        )
         subscription = customer.subscriptions.retrieve(donation.stripe_subscription_id)
         subscription.source = request.POST["stripe_token"]
         subscription.save()


### PR DESCRIPTION
This was caught by Sentry (issue `DJANGOPROJECT-21T`). For some reason accessing the `subscriptions` attribute without `expand`-ing it first results in an `AttributeError`.

I tested this in a shell in production and it seems to fix the issue.