### PR TITLE
Clean duplicate settings from settings/docker.py

### DIFF
--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -64,5 +64,6 @@ if DEBUG:
         )
 
 SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
+    # Default test keys for development.
     "django_recaptcha.recaptcha_test_key_error"
 ]

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -1,4 +1,4 @@
-from .common import *  # noqa
+from .dev import *  # noqa: F403
 
 DATABASES = {
     "default": {
@@ -13,64 +13,9 @@ DATABASES = {
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
-SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
-    "django_recaptcha.recaptcha_test_key_error"  # Default test keys for development.
-]
-
 ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]
 
 LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
 
-DEBUG = True
-THUMBNAIL_DEBUG = DEBUG
-
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "trololololol",
-    },
-    "docs-pages": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "docs-pages",
-    },
-}
-
-CSRF_COOKIE_SECURE = False
-
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
-MEDIA_ROOT = str(DATA_DIR.joinpath("media_root"))
-
-SESSION_COOKIE_SECURE = False
-
-STATIC_ROOT = str(DATA_DIR.joinpath("static_root"))
-
-# Docs settings
-DOCS_BUILD_ROOT = DATA_DIR.joinpath("djangodocs")
-
 # django-hosts settings
-
 PARENT_HOST = "localhost:8000"
-
-# django-push settings
-
-PUSH_SSL_CALLBACK = False
-
-# Enable optional components
-
-if DEBUG:
-    try:
-        import debug_toolbar  # NOQA
-    except ImportError:
-        pass
-    else:
-        INSTALLED_APPS.append("debug_toolbar")
-        INTERNAL_IPS = ["127.0.0.1"]
-        MIDDLEWARE.insert(
-            MIDDLEWARE.index("django.middleware.common.CommonMiddleware") + 1,
-            "debug_toolbar.middleware.DebugToolbarMiddleware",
-        )
-        MIDDLEWARE.insert(
-            MIDDLEWARE.index("debug_toolbar.middleware.DebugToolbarMiddleware") + 1,
-            "djangoproject.middleware.CORSMiddleware",
-        )


### PR DESCRIPTION
`settings/docker.py` file consists of many duplicate settings already covered by `settings/dev.py`. By changing the base, we no longer need to define those and file size can be minimized.

The goal is to clean redundant code and help to minimize https://github.com/django/djangoproject.com/pull/1828

The PR doesn't include any logic or functional change.

Supersedes
- https://github.com/django/djangoproject.com/pull/1904
- https://github.com/django/djangoproject.com/pull/1906