### PR TITLE
Removed unused arguments in messages JavaScript

### DIFF
--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -14,8 +14,8 @@ document.querySelectorAll('#doc-versions a').forEach(function (el) {
 
 // Fade out and remove message elements when close icon is clicked
 document.querySelectorAll('.messages li .close').forEach(function (el) {
-  el.addEventListener('click', function (e) {
-    this.parentElement.addEventListener('transitionend', function (e) {
+  el.addEventListener('click', function () {
+    this.parentElement.addEventListener('transitionend', function () {
       this.style.display = 'none';
     });
 


### PR DESCRIPTION
These event arguments must have been left from a previous approach. They are not used, so they can be removed.

This was missed in 20cec455.