### PR TITLE
1347: improving 404 page

### DIFF
--- a/djangoproject/templates/404.html
+++ b/djangoproject/templates/404.html
@@ -1,23 +1,51 @@
 {% extends 'base_error.html' %}
 {% load i18n %}
+{% load custom_tags %}
 
 {% block title %}{% translate "Page not found" %}{% endblock %}
 
-{% block header %}<h1>404</h1>{% endblock %}
+{% block header %}
+  <h1 class="error-title">404 - Page Not Found</h1>
+  <p class="error-subtitle">
+    {% translate "Oops! The page you’re looking for doesn’t exist." %}
+  </p>
+{% endblock %}
 
 {% block content %}
-  <h2>{% translate "Page not found" %}</h2>
+  <div class="error-container">
+    <h2>{% translate "We couldn’t find the page:" %}</h2>
+    <p class="broken-url">"<strong>{{ broken_path }}</strong>"</p>
 
-  <p>
-    {% blocktranslate trimmed %}
-      Looks like you followed a bad link. If you think it's our fault, please
-      <a href="https://code.djangoproject.com/">let us know</a>.
-    {% endblocktranslate %}</p>
+    <p>
+      {% blocktranslate trimmed %}
+        Looks like you followed a bad link. If you think it's our fault, please
+        <a href="https://code.djangoproject.com/">let us know</a>.
+      {% endblocktranslate %}
+    </p>
 
-  {% url 'homepage' as homepage_url %}
-  <p>
-    {% blocktranslate trimmed %}
-      Here's a link to the <a href="{{ homepage_url }}">homepage</a>. You know, just in case.
-    {% endblocktranslate %}</p>
+    <!-- Search Form -->
+    <div class="search-container">
+      <form method="get" action="{% url 'doc_search' %}">
+        {{ form.as_p }}
+        <button type="submit" class="search-button">{% translate "Search Docs" %}</button>
+      </form>
+    </div>
 
+    <!-- Suggested Closest Matches -->
+    {% if suggestions %}
+      <h3>{% translate "Did you mean?" %}</h3>
+      <ul class="suggestion-list">
+        {% for suggestion in suggestions %}
+          <li><a href="{{ suggestion }}">{{ suggestion }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% url 'homepage' as homepage_url %}
+    <p>
+      {% blocktranslate trimmed %}
+        Here's a link to the <a href="{{ homepage_url }}">homepage</a>. You know, just in case.
+      {% endblocktranslate %}
+    </p>
+  </div>
 {% endblock %}

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -1,14 +1,16 @@
+import difflib
+
 from django import template
+from django.conf import settings
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django.utils.version import get_version_tuple # 
+from django.utils.version import get_version_tuple
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
-import difflib
-from django.shortcuts import get_object_or_404
-from django.urls import reverse
-from django.http import Http404
-from django.conf import settings
+
 from ..forms import DocSearchForm
 from ..models import DocumentRelease
 from ..utils import get_doc_path, get_doc_root
@@ -25,9 +27,11 @@ EXISTING_DOCS_URLS = [
     # Add more known URLs as needed
 ]
 
+
 def get_suggestions(broken_url):
     """Finds close matches for the broken URL using difflib."""
     return difflib.get_close_matches(broken_url, EXISTING_DOCS_URLS, n=3, cutoff=0.6)
+
 
 @register.inclusion_tag("docs/search_form.html", takes_context=True)
 def search_form(context):


### PR DESCRIPTION
Made a change in 404 page.
Uses difflib.get_close_matches to suggest correct URLs.
Uses proper i18n translations and best practices.
Makes it easier to search for documentation.