### PR TITLE
Made typos in docs searches return some results.

### DIFF
--- a/docs/utils.py
+++ b/docs/utils.py
@@ -1,3 +1,6 @@
+import re
+import unicodedata
+
 from django.conf import settings
 from django.http import Http404
 
@@ -39,3 +42,18 @@ def get_doc_path_or_404(docroot, subpath):
     if doc is None:
         raise Http404(doc)
     return doc
+
+
+def sanitize_for_trigram(text):
+    """
+    Sanitize search query for PostgreSQL Trigram search.
+
+    - Removes parts starting with '-'
+    - Normalizes Unicode characters (NFKD)
+    - Keeps only letters, numbers and spaces
+    - Removes multiple spaces and trims
+    """
+    text = re.sub(r'(\s|^)-[^\s"\']+|(\s|^)-["\'][^"\']+["\']', "", text)
+    text = unicodedata.normalize("NFKD", text)
+    text = re.sub(r"[^\w\s]", "", text, flags=re.UNICODE)
+    return " ".join(text.split())


### PR DESCRIPTION
When looking into https://github.com/django/djangoproject.com/issues/1347, there is a suggestion that we should show search results for "databasess" instead of a 404. However, this currently returns no results: https://docs.djangoproject.com/en/5.1/search/?q=databasess

Our search isn't very forgiving for spelling errors (not a "fuzzy" search).
As a suggestion, I think we can return some results that have a ranking instead of returning no results.

Fixes https://github.com/django/djangoproject.com/issues/1932