### PR TITLE
Added Trac api to receive information on specific ticket.

### DIFF
--- a/tracdb/tests.py
+++ b/tracdb/tests.py
@@ -3,6 +3,7 @@ from operator import attrgetter
 
 import time_machine
 from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
 
 from .models import (
     Attachment,
@@ -29,7 +30,7 @@ class TestModels(TestCase):
 
 
 class TicketTestCase(TracDBCreateDatabaseMixin, TestCase):
-    databases = {"trac"}
+    databases = {"default", "trac"}
 
     def _create_ticket(self, custom=None, **kwargs):
         """
@@ -223,6 +224,59 @@ class TicketTestCase(TracDBCreateDatabaseMixin, TestCase):
     def test_from_querystring_invalid_time(self):
         with self.assertRaises(ValueError):
             Ticket.objects.from_querystring("time=2024-10-24..")
+
+    def test_api_ticket_404(self):
+        no_ticket_url = reverse("api_ticket", args=[30000])
+        response = self.client.get(no_ticket_url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_api_ticket_405(self):
+        ticket = self._create_ticket(summary="test")
+        ticket_url = reverse("api_ticket", args=[ticket.id])
+        post_response = self.client.post(ticket_url, {})
+        delete_response = self.client.delete(ticket_url)
+        self.assertEqual(post_response.status_code, 405)
+        self.assertEqual(delete_response.status_code, 405)
+
+    def test_api_ticket_200(self):
+        ticket = self._create_ticket(
+            reporter="reporter@email.com",
+            type="Bug",
+            summary="test summary",
+            description="test description",
+            severity="Normal",
+            resolution="fixed",
+            status="assigned",
+            custom={
+                "stage": "Accepted",
+                "has_patch": "1",
+                "needs_better_patch": "0",
+                "needs_tests": "0",
+            },
+        )
+
+        with self.assertNumQueries(1, using="trac"):
+            response = self.client.get(reverse("api_ticket", args=[ticket.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            response.content,
+            {
+                "id": ticket.id,
+                "type": "Bug",
+                "summary": "test summary",
+                "description": "test description",
+                "severity": "Normal",
+                "status": "assigned",
+                "resolution": "fixed",
+                "custom": {
+                    "stage": "Accepted",
+                    "has_patch": "1",
+                    "needs_better_patch": "0",
+                    "needs_tests": "0",
+                },
+            },
+        )
 
 
 class TracTimeTestCase(SimpleTestCase):

--- a/tracdb/urls.py
+++ b/tracdb/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path("bouncing/", views.bouncing_tickets, name="bouncing_tickets"),
+    path("api/tickets/<int:ticket_id>", views.api_ticket, name="api_ticket"),
 ]

--- a/tracdb/views.py
+++ b/tracdb/views.py
@@ -1,6 +1,9 @@
 from django import db
-from django.shortcuts import render
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404, render
+from django.views.decorators.http import require_http_methods
 
+from .models import Ticket
 from .tractime import timestamp_to_datetime
 
 
@@ -29,3 +32,19 @@ def bouncing_tickets(request):
 def dictfetchall(cursor):
     desc = cursor.description
     return [dict(zip([col[0] for col in desc], row)) for row in cursor.fetchall()]
+
+
+@require_http_methods(["GET"])
+def api_ticket(request, ticket_id):
+    ticket_qs = Ticket.objects.with_custom().values(
+        "id",
+        "type",
+        "summary",
+        "description",
+        "severity",
+        "status",
+        "resolution",
+        "custom",
+    )
+    ticket = get_object_or_404(ticket_qs, id=ticket_id)
+    return JsonResponse(ticket)


### PR DESCRIPTION
Relates to https://github.com/django/djangoproject.com/issues/1657
This has a very similar approach to https://github.com/django/djangoproject.com/pull/1656

This only adds an endpoint to receive information on a specific ticket.

This api is simpler than a list endpoint (which would be more useful for statistics) as it doesn't require filters and pagination but is still useful for things such as GitHub actions on PRs to query the associated ticket.

I have avoided information such as owner/reporter as this may contain emails.
I feel we can always add more fields/information in later

I think we will need the list endpoint before the associated issue can be closed (due to the request for statistics)
But I hope we can get this in as something small to get us started :crossed_fingers: 