### PR TITLE
Added scroll to text fragment to search.

### DIFF
--- a/docs/models.py
+++ b/docs/models.py
@@ -28,6 +28,8 @@ from . import utils
 from .search import (
     DEFAULT_TEXT_SEARCH_CONFIG,
     DOCUMENT_SEARCH_VECTOR,
+    START_SEL,
+    STOP_SEL,
     TSEARCH_CONFIG_LANGUAGES,
 )
 
@@ -265,15 +267,15 @@ class DocumentQuerySet(models.QuerySet):
                     headline=SearchHeadline(
                         "title",
                         search_query,
-                        start_sel="<mark>",
-                        stop_sel="</mark>",
+                        start_sel=START_SEL,
+                        stop_sel=STOP_SEL,
                         config=models.F("config"),
                     ),
                     highlight=SearchHeadline(
                         KeyTextTransform("body", "metadata"),
                         search_query,
-                        start_sel="<mark>",
-                        stop_sel="</mark>",
+                        start_sel=START_SEL,
+                        stop_sel=STOP_SEL,
                         config=models.F("config"),
                     ),
                     breadcrumbs=models.F("metadata__breadcrumbs"),

--- a/docs/search.py
+++ b/docs/search.py
@@ -48,3 +48,6 @@ DOCUMENT_SEARCH_VECTOR = (
         KeyTextTransform("parents", "metadata"), weight="D", config=F("config")
     )
 )
+
+START_SEL = "<mark>"
+STOP_SEL = "</mark>"

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -36,7 +36,7 @@
         {% for result in page.object_list %}
           <dt>
             <h2 class="result-title">
-              <a href="{% url 'document-detail' lang=result.release.lang version=result.release.version url=result.path host 'docs' %}">{{ result.headline|safe }}</a>
+              <a href="{% url 'document-detail' lang=result.release.lang version=result.release.version url=result.path host 'docs' %}{% if not start_sel in result.headline %}{{ result.highlight|fragment }}{% endif %}">{{ result.headline|safe }}</a>
             </h2>
             <span class="meta breadcrumbs">
               {% for breadcrumb in result.breadcrumbs %}

--- a/docs/views.py
+++ b/docs/views.py
@@ -16,6 +16,7 @@ from django_hosts.resolvers import reverse
 
 from .forms import DocSearchForm
 from .models import Document, DocumentRelease
+from .search import START_SEL
 from .utils import get_doc_path_or_404, get_doc_root_or_404
 
 SIMPLE_SEARCH_OPERATORS = ["+", "|", "-", '"', "*", "(", ")", "~"]
@@ -215,6 +216,7 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                     "query": q,
                     "page": page,
                     "paginator": paginator,
+                    "start_sel": START_SEL,
                 }
             )
 


### PR DESCRIPTION
Following on from this [comment](https://github.com/django/djangoproject.com/issues/1734#issuecomment-2640518969), I have added scroll to text fragment to our search result urls.

Before, when you search for "StackedInline", you get these results: https://docs.djangoproject.com/en/5.1/search/?q=StackedInline

![search results from StackedInline docs search](https://github.com/user-attachments/assets/537855c0-aa07-4ff5-ae50-e528fbddc750)

If you click the first one, the url is: https://docs.djangoproject.com/en/5.1/ref/contrib/admin/
This navigates you to the top of the page.

After these changes the url is: https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#:~:text=StackedInline%5Bsource%5D 
This navigates to StackedInline in view (when the browser supports it, which is most browsers)

![Admin page with line highlighted and in middle of page](https://github.com/user-attachments/assets/b65eeff8-797b-48d0-8b84-7eeb5c1399a7)


~This was difficult to test locally.~ (found the management command)

If there is an issue with the logic, the text fragment will not be found and we still land at the top of the page. e.g https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#:~:text=potato