### PR TITLE
Added documentation type filtering to search.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2578,6 +2578,40 @@ table.docutils th {
     }
 }
 
+search.filters {
+    @include sans-serif;
+
+    display: flex;
+    gap: 10px;
+    border-bottom: 2px solid var(--hairline-color);
+    overflow-x: auto;
+    white-space: nowrap;
+    padding-bottom: 0;
+    position: relative;
+
+    a {
+      padding: 10px 20px;
+      text-decoration: none;
+      border-bottom: 3px solid transparent;
+      transition: color 0.3s ease, border-bottom 0.3s ease;
+      color: var(--text-light);
+      flex-shrink: 0;
+
+      &:not([href]) {
+        color: var(--body-fg);
+        font-weight: bold;
+        border-bottom: 3px solid var(--primary);
+      }
+
+      &[href]:focus,
+      &[href]:active,
+      &[href]:hover {
+        outline: none;
+        border-bottom: 3px solid var(--hairline-color);
+      }
+    }
+}
+
 .search-links {
     @extend .list-links;
 

--- a/docs/models.py
+++ b/docs/models.py
@@ -254,7 +254,7 @@ class DocumentQuerySet(models.QuerySet):
         else:
             return self.none()
 
-    def search(self, query_text, release):
+    def search(self, query_text, release, document_category=None):
         """Use full-text search to return documents matching query_text."""
         query_text = query_text.strip()
         if query_text:
@@ -268,9 +268,12 @@ class DocumentQuerySet(models.QuerySet):
                 stop_sel=STOP_SEL,
                 config=models.F("config"),
             )
+            base_filter = Q(release_id=release.id)
+            if document_category:
+                base_filter &= Q(metadata__parents__startswith=document_category)
             base_qs = (
                 self.select_related("release__release")
-                .filter(release_id=release.id)
+                .filter(base_filter)
                 .annotate(
                     headline=search("title", search_query),
                     highlight=search(

--- a/docs/search.py
+++ b/docs/search.py
@@ -1,6 +1,7 @@
 from django.contrib.postgres.search import SearchVector
-from django.db.models import F
+from django.db.models import F, TextChoices
 from django.db.models.fields.json import KeyTextTransform
+from django.utils.translation import gettext_lazy as _
 
 # Imported from
 # https://github.com/postgres/postgres/blob/REL_14_STABLE/src/bin/initdb/initdb.c#L659
@@ -51,3 +52,23 @@ DOCUMENT_SEARCH_VECTOR = (
 
 START_SEL = "<mark>"
 STOP_SEL = "</mark>"
+
+
+class DocumentationCategory(TextChoices):
+    """
+    Categories used to filter the documentation search.
+    The value must match a folder name within django/docs.
+    """
+
+    # Diátaxis folders.
+    REFERENCE = "ref", _("API Reference")
+    TOPICS = "topics", _("Using Django")
+    HOWTO = "howto", _("How-to guides")
+    RELEASE_NOTES = "releases", _("Release notes")
+
+    @classmethod
+    def parse(cls, value, default=None):
+        try:
+            return cls(value)
+        except ValueError:
+            return None

--- a/docs/templates/docs/search_form.html
+++ b/docs/templates/docs/search_form.html
@@ -1,11 +1,12 @@
 {% load i18n %}
+<search class="search form-input" aria-labelledby="docs-search-label">
+  <form action="{% url 'document-search' version=version lang=lang host 'docs' %}">
+    <label id="docs-search-label" class="visuallyhidden" for="{{ form.q.id_for_label }}">{{ form.q.field.widget.attrs.placeholder }}</label>
+    {{ form.q }}
 
-<form action="{% url 'document-search' version=version lang=lang host 'docs' %}" class="search form-input" role="search">
-  <label class="visuallyhidden" for="id_q">Search:</label>
-  {{ form.q }}
-
-  <button type="submit">
-    <i class="icon icon-search"></i>
-    <span class="visuallyhidden">{% trans 'Search' %}</span>
-  </button>
-</form>
+    <button type="submit">
+      <i class="icon icon-search" aria-hidden="true"></i>
+      <span class="visuallyhidden">{% translate "Submit" %}</span>
+    </button>
+  </form>
+</search>

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -11,6 +11,13 @@
 
 {% block body %}
   {% if query %}
+    <search class="filters">
+      <span id="search-filters" class="visually-hidden">{% translate "Filter the current search results by documentation category" %}</span>
+      <a{% if not active_category %} aria-current="page"{% else %} href="{% querystring category=None page=None %}"{% endif %}>{% translate "All" context "all documentation categories" %}</a>
+      {% for category in DocumentationCategory %}
+        <a{% if active_category == category %} aria-current="page"{% else %} href="{% querystring category=category.value page=None %}"{% endif %}>{{ category.label }}</a>
+      {% endfor %}
+    </search>
     <h2>
       {% if release.is_dev %}
         {% blocktranslate count num_results=paginator.count trimmed %}
@@ -64,6 +71,15 @@
               </ul>
             {% endif %}
           </dd>
+        {% empty %}
+          {% if active_category %}
+            <dt>
+              <p>
+                {% querystring category=None page=None as all_search %}
+                {% blocktranslate trimmed %}Please try searching <a href="{{ all_search }}">all documentation results</a>.{% endblocktranslate %}
+              </p>
+            </dt>
+          {% endif %}
         {% endfor %}
       </dl>
     </div>

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -1,7 +1,7 @@
 {% extends "docs/doc.html" %}
 {% load i18n docs %}
 
-{% block title %}{% trans "Search | Django documentation" %}{% endblock %}
+{% block title %}{% translate "Search | Django documentation" %}{% endblock %}
 
 {% block toc-wrapper %}{% endblock %}
 {% block breadcrumbs-wrapper %}{% endblock %}
@@ -13,21 +13,21 @@
   {% if query %}
     <h2>
       {% if release.is_dev %}
-        {% blocktrans count num_results=paginator.count trimmed %}
+        {% blocktranslate count num_results=paginator.count trimmed %}
           Only 1 result for <em>{{ query }}</em> in the development version
         {% plural %}
           {{ num_results }} results for <em>{{ query }}</em> in the development version
-        {% endblocktrans %}
+        {% endblocktranslate %}
       {% else %}
-        {% blocktrans count num_results=paginator.count trimmed %}
+        {% blocktranslate count num_results=paginator.count trimmed %}
           Only 1 result for <em>{{ query }}</em> in version {{ version }}
         {% plural %}
           {{ num_results }} results for <em>{{ query }}</em> in version {{ version }}
-        {% endblocktrans %}
+        {% endblocktranslate %}
       {% endif %}
     </h2>
   {% else %}
-    <h2>{% trans "No search query given" %}</h2>
+    <h2>{% translate "No search query given" %}</h2>
   {% endif %}
 
   {% if query %}
@@ -72,20 +72,20 @@
       <div class="pagination">
         <ul class="nav-pagination" role="navigation">
           {% if page.has_previous %}
-            <li><a rel="prev" class="previous" href="?q={{ query }}&amp;release={{ release.version }}&amp;page={{ page.previous_page_number }}">
+            <li><a rel="prev" class="previous" href="{% querystring page=page.previous_page_number %}">
               <i class="icon icon-chevron-left"></i>
-              <span class="visuallyhidden">{% trans "Previous" %}</span>
+              <span class="visuallyhidden">{% translate "Previous" context "pagination" %}</span>
             </a></li>
           {% endif %}
           <span class="page-current">
-            {% blocktrans with page_number=page.number num_pages=page.paginator.num_pages trimmed %}
+            {% blocktranslate with page_number=page.number num_pages=page.paginator.num_pages trimmed %}
               Page {{ page_number }} of {{ num_pages }}
-            {% endblocktrans %}
+            {% endblocktranslate %}
           </span>
           {% if page.has_next %}
-            <li><a rel="next" class="next" href="?q={{ query }}&amp;release={{ release.version }}&amp;page={{ page.next_page_number }}">
+            <li><a rel="next" class="next" href="{% querystring page=page.next_page_number %}">
               <i class="icon icon-chevron-right"></i>
-              <span class="visuallyhidden">{% trans "Next" %}</span>
+              <span class="visuallyhidden">{% translate "Next" context "pagination" %}</span>
             </a></li>
           {% endif %}
         </ul>

--- a/docs/views.py
+++ b/docs/views.py
@@ -15,7 +15,7 @@ from django_hosts.resolvers import reverse
 
 from .forms import DocSearchForm
 from .models import Document, DocumentRelease
-from .search import START_SEL
+from .search import START_SEL, DocumentationCategory
 from .utils import get_doc_path_or_404, get_doc_root_or_404
 
 SIMPLE_SEARCH_OPERATORS = ["+", "|", "-", '"', "*", "(", ")", "~"]
@@ -163,7 +163,10 @@ def search_results(request, lang, version, per_page=10, orphans=3):
             if exact is not None:
                 return redirect(exact)
 
-            results = Document.objects.search(q, release)
+            doc_category = DocumentationCategory.parse(request.GET.get("category"))
+            results = Document.objects.search(
+                q, release, document_category=doc_category
+            )
 
             page_number = request.GET.get("page") or 1
             paginator = Paginator(results, per_page=per_page, orphans=orphans)
@@ -192,6 +195,8 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                     "page": page,
                     "paginator": paginator,
                     "start_sel": START_SEL,
+                    "active_category": doc_category,
+                    "DocumentationCategory": DocumentationCategory,
                 }
             )
 


### PR DESCRIPTION
In order to make it easier to refine the search results for the type of information you want, added a filter by docs categories. There are more categories (e.g. "Internals") but I think it is better to only include the most likely categories

This slightly relates to https://github.com/django/djangoproject.com/issues/1628

#### Mobile view

![Search results with new filter - mobile](https://github.com/user-attachments/assets/88cfacad-a745-49a9-ac5d-af59a539660e)

#### Desktop view

![Search results on desktop with new filter](https://github.com/user-attachments/assets/ceabd440-8253-4cb6-9f90-bd833fea1d7e)

