### PR TITLE
Fixed issue reporting link in 404 template

### DIFF
--- a/djangoproject/templates/404.html
+++ b/djangoproject/templates/404.html
@@ -11,7 +11,7 @@
   <p>
     {% blocktranslate trimmed %}
       Looks like you followed a bad link. If you think it's our fault, please
-      <a href="https://code.djangoproject.com/">let us know</a>.
+      <a href="https://github.com/django/djangoproject.com/issues/">let us know</a>.
     {% endblocktranslate %}</p>
 
   {% url 'homepage' as homepage_url %}


### PR DESCRIPTION
This change directs users to report website issues on GitHub rather than on Trac. Trac is for issues about the Django web framework, not the Django website.