### PR TITLE
Removed only use of 600 `font-weight` CSS value

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -86,7 +86,7 @@ dl {
 
     &.glossary {
         dt {
-            font-weight: 600;
+            font-weight: 700;
         }
     }
 }


### PR DESCRIPTION
This change causes no visual difference on the site since this font weight is not being requested for Roboto from Google Fonts, but it technically reduces the amount of font variants the site needs.

The 600 value was added in https://github.com/django/djangoproject.com/commit/5d8bd41e9560d6b536a57216efa6b059e4f8642f.

This change can be tested with DevTools [here](https://docs.djangoproject.com/en/dev/topics/i18n/#term-internationalization).

Part of #1003.