### PR TITLE
Added code references to search results.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2635,6 +2635,39 @@ table.docutils th {
             color: var(--search-mark-text);
         }
     }
+
+    .code-links {
+        margin-top: 15px;
+        margin-left: 10px;
+        list-style-type: none;
+        padding-left: 0;
+
+        a {
+            &:active,
+            &:focus,
+            &:hover {
+                code {
+                    color: var(--primary);
+                }
+                .meta {
+                    color: var(--text-light);
+                }
+            }
+        }
+
+        code {
+            color: var(--primary-accent);
+            font-weight: 700;
+        }
+
+        div {
+            margin: 0;
+            .meta {
+                margin: 5px 0 0;
+                color: var(--body-fg);
+            }
+        }
+    }
 }
 
 .list-links-small {

--- a/docs/builder.py
+++ b/docs/builder.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from functools import cached_property
+
+from sphinxcontrib.serializinghtml import JSONHTMLBuilder
+
+IGNORED_DOMAIN_TYPES = {"module"}
+
+
+@dataclass
+class DomainObject:
+    """
+    A wrapper around sphinx's domain object descriptions
+    https://www.sphinx-doc.org/en/master/extdev/domainapi.html#sphinx.domains.Domain.get_objects
+    """
+
+    name: str
+    dispname: str
+    type: str
+    docname: str
+    anchor: str
+    priority: int
+
+    @property
+    def short_name(self) -> str:
+        """
+        Returns a shortened version of the object's name.
+
+        - If the second-to-last part of the name starts with an uppercase letter
+          (indicating a class method or class attribute), returns the last two parts.
+        - Otherwise, returns only the last part (likely a function, or class).
+
+        Examples:
+        - "django.db.models.query.QuerySet.select_related" → "QuerySet.select_related"
+        - "django.db.models.query.QuerySet" → "QuerySet"
+        - "django.template.context_processors.static" → "static"
+        """
+        parts = self.name.split(".")
+
+        if len(parts) < 2:
+            return self.name
+
+        last, second_last = parts[-1], parts[-2]
+        return f"{second_last}.{last}" if second_last[0].isupper() else last
+
+
+class PythonObjectsJSONHTMLBuilder(JSONHTMLBuilder):
+    @cached_property
+    def domain_objects(self):
+        domain = self.env.get_domain("py")
+        return [
+            DomainObject(*item)
+            for item in domain.get_objects()
+            if item[2] not in IGNORED_DOMAIN_TYPES  # item[2] is 'type'.
+        ]
+
+    def get_doc_context(self, docname, body, metatags):
+        out_dict = super().get_doc_context(docname, body, metatags)
+        python_objects = self.get_python_objects(docname)
+        out_dict["python_objects"] = python_objects
+        out_dict["python_objects_search"] = " ".join(
+            # Keeps the code suffix to improve the search results for terms such as
+            # "select" for QuerySet.select_related.
+            [key.split(".")[-1] for key in python_objects.keys()]
+        )
+        return out_dict
+
+    def get_python_objects(self, docname):
+        return {
+            obj.short_name: obj.name
+            for obj in self.domain_objects
+            if obj.docname == docname
+        }
+
+
+def setup(app):
+    app.add_builder(PythonObjectsJSONHTMLBuilder, override=True)

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -4,6 +4,7 @@ app.
 """
 
 import json
+import multiprocessing
 import os
 import shutil
 import subprocess
@@ -16,6 +17,9 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.utils.translation import to_locale
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.errors import SphinxError
 
 from ...models import DocumentRelease
 
@@ -175,29 +179,30 @@ class Command(BaseCommand):
 
             if self.verbosity >= 2:
                 self.stdout.write(f"  building {builder} ({source_dir} -> {build_dir})")
+            # Retrieve the extensions from the conf.py so we can append to them.
+            conf_extensions = Config.read(source_dir.resolve()).extensions
+            extensions = [*conf_extensions, "docs.builder"]
             try:
-                # Translated docs builds generate a lot of warnings, so send
-                # stderr to stdout to be logged (rather than generating an
-                # email)
-                subprocess.check_call(
-                    [
-                        "sphinx-build",
-                        "-b",
-                        builder,
-                        "-D",
-                        "language=%s" % to_locale(release.lang),
-                        "-j",
-                        "auto",
-                        "-Q" if self.verbosity == 0 else "-q",
-                        str(source_dir),  # Source file directory
-                        str(build_dir),  # Destination directory
-                    ],
-                    stderr=sys.stdout,
-                )
-            except subprocess.CalledProcessError:
+                Sphinx(
+                    srcdir=source_dir,
+                    confdir=source_dir,
+                    outdir=build_dir,
+                    doctreedir=build_dir.joinpath(".doctrees"),
+                    buildername=builder,
+                    # Translated docs builds generate a lot of warnings, so send
+                    # stderr to stdout to be logged (rather than generating an email)
+                    warning=sys.stdout,
+                    parallel=multiprocessing.cpu_count(),
+                    verbosity=self.verbosity,
+                    confoverrides={
+                        "language": to_locale(release.lang),
+                        "extensions": extensions,
+                    },
+                ).build()
+            except SphinxError as e:
                 self.stderr.write(
-                    "sphinx-build returned an error (release %s, builder %s)"
-                    % (release, builder)
+                    "sphinx-build returned an error (release %s, builder %s): %s"
+                    % (release, builder, str(e))
                 )
                 return
 

--- a/docs/models.py
+++ b/docs/models.py
@@ -2,7 +2,7 @@ import datetime
 import html
 import json
 import operator
-from functools import reduce
+from functools import partial, reduce
 from pathlib import Path
 
 from django.conf import settings
@@ -252,6 +252,12 @@ class DocumentQuerySet(models.QuerySet):
                 query_text, config=models.F("config"), search_type="websearch"
             )
             search_rank = SearchRank(models.F("search"), search_query)
+            search = partial(
+                SearchHeadline,
+                start_sel=START_SEL,
+                stop_sel=STOP_SEL,
+                config=models.F("config"),
+            )
             base_qs = (
                 self.prefetch_related(
                     Prefetch(
@@ -264,21 +270,18 @@ class DocumentQuerySet(models.QuerySet):
                 )
                 .filter(release_id=release.id)
                 .annotate(
-                    headline=SearchHeadline(
-                        "title",
-                        search_query,
-                        start_sel=START_SEL,
-                        stop_sel=STOP_SEL,
-                        config=models.F("config"),
-                    ),
-                    highlight=SearchHeadline(
+                    headline=search("title", search_query),
+                    highlight=search(
                         KeyTextTransform("body", "metadata"),
                         search_query,
-                        start_sel=START_SEL,
-                        stop_sel=STOP_SEL,
-                        config=models.F("config"),
+                    ),
+                    searched_python_objects=search(
+                        KeyTextTransform("python_objects_search", "metadata"),
+                        search_query,
+                        highlight_all=True,
                     ),
                     breadcrumbs=models.F("metadata__breadcrumbs"),
+                    python_objects=models.F("metadata__python_objects"),
                 )
                 .only(
                     "path",

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -48,6 +48,21 @@
             {% if result.highlight %}
               …&nbsp;{{ result.highlight|cut:"¶"|safe }}&nbsp;…
             {% endif %}
+            {% code_links result.searched_python_objects result.python_objects as result_code_links %}
+            {% if result_code_links %}
+              <ul class="code-links">
+                {% for name, value in result_code_links.items %}
+                  <li>
+                    <a href="{% url 'document-detail' lang=result.release.lang version=result.release.version url=result.path host 'docs' %}#{{ value.full_path }}">
+                      <div>
+                        <code>{{ name }}</code>
+                        {% if value.module_path %}<div class="meta">{{ value.module_path }}</div>{% endif %}
+                      </div>
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
           </dd>
         {% endfor %}
       </dl>

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -12,7 +12,7 @@ from pygments.lexers import get_lexer_by_name
 from ..forms import DocSearchForm
 from ..models import DocumentRelease
 from ..search import START_SEL, STOP_SEL
-from ..utils import get_doc_path, get_doc_root
+from ..utils import get_doc_path, get_doc_root, get_module_path
 
 register = template.Library()
 
@@ -121,3 +121,68 @@ def generate_scroll_to_text_fragment(highlighted_text):
     # Due to Python code such as timezone.now(), remove the space after a bracket.
     single_spaced = re.sub(r"([(\[])\s", r"\1", single_spaced)
     return f"#:~:text={quote(single_spaced)}"
+
+
+@register.simple_tag
+def code_links(searched_python_objects, python_objects):
+    """
+    Processes a highlighted search result (from a `SearchHeadline` annotation)
+    to extract Python object references and map them to their full paths.
+
+    Args:
+        searched_python_objects (str):
+            A string from a `SearchHeadline` queryset annotation, containing
+            highlighted Python object names wrapped with `START_SEL` and `STOP_SEL`.
+            Example:
+                "QuerySet {START_SEL}select_related{STOP_SEL} prefetch_related"
+
+        python_objects (dict):
+            A dictionary mapping object short names to their full path. This is
+            generated from PythonObjectsJSONHTMLBuilder.
+            Example:
+                {
+                    "QuerySet": "django.db.models.query.QuerySet",
+                    "QuerySet.select_related": (
+                        "django.db.models.query.QuerySet.select_related"
+                    ),
+                    "QuerySet.prefetch_related": (
+                        "django.db.models.query.QuerySet.prefetch_related"
+                    ),
+                }
+
+    Returns:
+        dict: A sorted dictionary where:
+            - Keys are matched Python object short names.
+            - Values are dictionaries containing:
+                - `"full_path"` (str): The full path of the object.
+                - `"module_path"` (str): The module path derived from the object name.
+            Example:
+                {
+                    "QuerySet.select_related": {
+                        "full_path": "django.db.models.query.QuerySet.select_related",
+                        "module_path": "django.db.models.query",
+                    }
+                }
+    """
+    if not searched_python_objects or START_SEL not in searched_python_objects:
+        return {}
+    python_objects_matched_short_names = [
+        word.replace(START_SEL, "").replace(STOP_SEL, "")
+        for word in searched_python_objects.split(" ")
+        if START_SEL in word
+    ]
+    matched_reference = {}
+    # Map "select_related" to "QuerySet.select_related" in code_references.
+    reference_map = {key.split(".")[-1]: key for key in python_objects.keys()}
+    for short_name in python_objects_matched_short_names:
+        if full_path := python_objects.get(short_name):
+            matched_reference[short_name] = {
+                "full_path": full_path,
+                "module_path": get_module_path(short_name, full_path),
+            }
+        elif name := reference_map.get(short_name):
+            matched_reference[name] = {
+                "full_path": python_objects[name],
+                "module_path": get_module_path(name, python_objects[name]),
+            }
+    return dict(sorted(matched_reference.items()))

--- a/docs/tests/test_builder.py
+++ b/docs/tests/test_builder.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+
+from ..builder import DomainObject, PythonObjectsJSONHTMLBuilder
+
+
+class TestPythonObjectsJSONHTMLBuilder(SimpleTestCase):
+    def setUp(self):
+        self.app = Mock()
+        self.env = Mock()
+        self.app.doctreedir = "/tmp"
+        self.env.get_domain = Mock()
+        self.mock_domain = Mock()
+        self.env.get_domain.return_value = self.mock_domain
+        self.builder = PythonObjectsJSONHTMLBuilder(self.app, self.env)
+
+    def test_domain_objects_excludes_modules(self):
+        self.mock_domain.get_objects.return_value = [
+            ("module1", "module1", "module", "doc1", "", 0),
+            ("ClassA", "ClassA", "class", "doc2", "", 0),
+            ("function_b", "function_b", "function", "doc2", "", 0),
+        ]
+
+        expected_objects = [
+            DomainObject("ClassA", "ClassA", "class", "doc2", "", 0),
+            DomainObject("function_b", "function_b", "function", "doc2", "", 0),
+        ]
+        self.assertEqual(self.builder.domain_objects, expected_objects)
+
+    def test_get_python_objects(self):
+        self.mock_domain.get_objects.return_value = [
+            (
+                "module1.ClassA.method",
+                "module1.ClassA.method",
+                "method",
+                "doc1",
+                "",
+                "",
+            ),
+            ("module1.ClassA", "module1.ClassA", "class", "doc1", "", ""),
+            ("module1.function_b", "module1.function_b", "function", "doc1", "", ""),
+        ]
+        expected_result = {
+            "ClassA": "module1.ClassA",
+            "ClassA.method": "module1.ClassA.method",
+            "function_b": "module1.function_b",
+        }
+        self.assertEqual(self.builder.get_python_objects("doc1"), expected_result)
+
+    @patch("docs.builder.JSONHTMLBuilder.get_doc_context")
+    def test_get_doc_context(self, mock_super_get_doc_context):
+        mock_super_get_doc_context.return_value = {}
+        self.mock_domain.get_objects.return_value = [
+            ("module1", "module1", "module", "doc1", "", ""),
+            ("module1.ClassA", "module1.ClassA", "class", "doc1", "", ""),
+            ("function_b", "function_b", "function", "doc2", "", ""),
+        ]
+        result = self.builder.get_doc_context("doc1", "", "")
+        self.assertIn("python_objects", result)
+        self.assertIn("python_objects_search", result)
+        self.assertEqual(result["python_objects"], {"ClassA": "module1.ClassA"})
+        self.assertEqual(result["python_objects_search"], "ClassA")

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -57,3 +57,38 @@ def sanitize_for_trigram(text):
     text = unicodedata.normalize("NFKD", text)
     text = re.sub(r"[^\w\s]", "", text, flags=re.UNICODE)
     return " ".join(text.split())
+
+
+def get_module_path(name, full_path):
+    """
+    Checks if the `full_path` ends with `.name` and, if so, removes it to return
+    the module path. Otherwise, it returns `None`.
+
+    Args:
+        name (str):
+            The short name of the object (e.g., `"QuerySet.select_related"`).
+        full_path (str):
+            The full path of the object (e.g.,
+            `"django.db.models.query.QuerySet.select_related"`).
+
+    Returns:
+        str or None:
+            The module path if `full_path` ends with `.name`, otherwise `None`.
+
+    Example:
+        >>> get_module_path(
+        ...   "QuerySet.select_related",
+        ...   "django.db.models.query.QuerySet.select_related"
+        ... )
+        'django.db.models.query'
+
+        >>> get_module_path("Model", "django.db.models.Model")
+        'django.db.models'
+
+        >>> get_module_path("django", "django")
+        None
+    """
+    name_suffix = f".{name}"
+    if full_path.endswith(name_suffix):
+        return full_path.removesuffix(name_suffix)
+    return None


### PR DESCRIPTION
#### Description

Recently, we added a scroll to text fragment to improve the search result navigation experience.
This takes the first line that was found in the body and scrolls you to this line. 

This PR adds references to our Python class/class method/function definitions which will appear as a sub-item of the page search result if they match the search.
This means that when someone searches for "select" they have choice as to what to navigate to. They can chose the "QuerySet.select_related" or "QuerySet.select_for_update". The anchors of these are also robust and so you will navigate to the definition of these (the scroll for text logic is a little fragile due to the html stripping logic of full text search).

![search for "select"](https://github.com/user-attachments/assets/1201a5d2-43bf-4f7e-91fc-93b06e7bac0c)

This "choice" is even more useful when searching for something like "field":

![search for "field"](https://github.com/user-attachments/assets/6a5616ca-d48f-4756-9f44-ecac7d3c4c26)

------

#### Issues aiming to fix

Ideally this along with the previous highlight text change fixes https://github.com/django/djangoproject.com/issues/1649 and fixes https://github.com/django/djangoproject.com/issues/1734

#### Review notes

Note that I have added some folks as possible reviewers.
I am not 100% sure the review process given the new website WG but would appreciate feedback as I'd love to land the PR :heart_hands: 

This PR has 2 commits, the first commit is a refactor commit to split the test file into multiple test files, the second is the feature.

I originally used regex to full out these code references. @bmispelon rightly pointed out this is brittle. I have since written a custom Sphinx builder in order to use Sphinx's own functionality for getting the python objects.