### PR TITLE
Followed platform conventions for showing search shortcut key

### DIFF
--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -75,7 +75,7 @@ document.querySelector('.menu-button').addEventListener('click', function () {
 
   const original_placeholder = el.getAttribute('placeholder');
   const is_mac = navigator.userAgent.indexOf('Mac') !== -1;
-  const new_value = `${original_placeholder} (${is_mac ? '⌘' : 'Ctrl'} + K)`;
+  const new_value = `${original_placeholder} (${is_mac ? '⌘\u200aK' : 'Ctrl+K'})`;
 
   el.setAttribute('placeholder', new_value);
 })();


### PR DESCRIPTION
Changed display of the search shortcut key to "⌘ K" on Mac and "Ctrl+K" elsewhere.

Fixes #1960.