### PR TITLE
Allowed '/' key as alternate shortcut for search box

### DIFF
--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -82,7 +82,8 @@ document.querySelector('.menu-button').addEventListener('click', function () {
 
 // Focus, select, and scroll to search input when key combination is pressed
 window.addEventListener('keydown', function (e) {
-  if (!(e.metaKey || e.ctrlKey) || e.key !== 'k') {
+  const is_ctrl_k = (e.metaKey || e.ctrlKey) && e.key === 'k';
+  if (!(is_ctrl_k || e.key === '/')) {
     return;
   }
 


### PR DESCRIPTION
Added the <kbd>/</kbd> key as a secondary shortcut to focus the search input, for consistency with forum.djangoproject.com, github.com, docs.python.org, and most ReadTheDocs sites.

(Ctrl+K and Command-K are also still supported.)

Fixes #1946.