### PR TITLE
Fixed page header structure and used semantic HTML.

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -12,6 +12,7 @@ from .models import Entry, Event
 class BlogViewMixin:
     date_field = "pub_date"
     paginate_by = 10
+    banner_is_title = True
 
     def get_allow_future(self):
         return self.request.user.is_staff
@@ -28,6 +29,7 @@ class BlogViewMixin:
         events_queryset = Event.objects.future().published()
 
         context["events"] = events_queryset[:3]
+        context["banner_is_title"] = self.banner_is_title
 
         return context
 
@@ -49,4 +51,4 @@ class BlogDayArchiveView(BlogViewMixin, DayArchiveView):
 
 
 class BlogDateDetailView(BlogViewMixin, DateDetailView):
-    pass
+    banner_is_title = False

--- a/dashboard/templates/base_dashboard.html
+++ b/dashboard/templates/base_dashboard.html
@@ -6,6 +6,5 @@
 {% block title %}{% translate 'Development dashboard' %}{% endblock %}
 {% block layout_class %}full-width{% endblock %}
 {% block header %}
-  <h1 class="visuallyhidden">Development dashboard</h1>
-  <p>Development <em>dashboard</em></p>
+  <h1>Development <em>dashboard</em></h1>
 {% endblock %}

--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -149,7 +149,7 @@ html[data-theme="light"],
         }
     }
 
-    body [role="contentinfo"] {
+    body footer {
         background: darken($green, 10%);
     }
 
@@ -256,7 +256,7 @@ html[data-theme="dark"] {
         }
     }
 
-    [role="contentinfo"] {
+    footer {
         background: darken($green, 10%);
     }
 }
@@ -352,7 +352,7 @@ html[data-theme="light"] .theme-toggle .theme-label-when-light {
     }
 }
 
-[role="banner"] [role="navigation"] li:last-child {
+header nav li:last-child {
     @include respond-max(768px) {
         display: none;
     }

--- a/djangoproject/scss/_dashboard.scss
+++ b/djangoproject/scss/_dashboard.scss
@@ -1,5 +1,5 @@
 #dashboard {
-    .full-width [role="main"] {
+    .full-width main {
         margin: 0 auto;
         text-align: center;
     }

--- a/djangoproject/scss/_print.scss
+++ b/djangoproject/scss/_print.scss
@@ -62,11 +62,11 @@
     .news-search,
     .backtotop,
     .nav-pagination,
-    [role="contentinfo"]>.container,
-    [role="contentinfo"] .logo,
+    footer>.container,
+    footer .logo,
     .thanks,
     [role="complementary"],
-    [role="navigation"],
+    nav,
     .form-input {
         display: none !important;
     }
@@ -75,8 +75,8 @@
         text-indent: 0 !important;
     }
 
-    [role="contentinfo"],
-    [role="contentinfo"] .copyright {
+    footer,
+    footer .copyright {
         margin: 0 !important;
         padding: 0 !important;
     }

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -122,7 +122,7 @@ h1 {
         color: var(--body-fg);
     }
 
-    [role="main"] & {
+    main & {
         @include font-size(32);
         margin: 40px 0px 30px;
         color: var(--body-fg);
@@ -159,7 +159,7 @@ h2 {
         }
     }
 
-    [role="main"] & {
+    main & {
         margin-top: 40px;
         margin-bottom: 15px;
     }
@@ -174,20 +174,24 @@ h3 {
 
     [role="complementary"] &,
     .layout-secondary & {
-        @include font-size(18);
+        @include font-size(20);
+        border-bottom: 1px solid var(--hairline-color);
         font-weight: 400;
         padding-bottom: 15px;
+        margin-top: 30px;
+
+        &:first-of-type {
+            margin-top: inherit;
+        }
 
         &:first-child {
             @include respond-min(768px) {
-                margin-top: 12px;
+                margin-top: 20px;
             }
         }
-    }
-
-    [role="complementary"] & {
-        @include font-size(18);
-        border-bottom: 1px solid var(--hairline-color);
+        .full-width & {
+            @include font-size(24);
+        }
     }
 }
 
@@ -236,7 +240,7 @@ a:focus {
 p {
 
     //increase top margin if first item in container
-    [role="main"]>&:first-child {
+    main>&:first-child {
         margin-top: 30px;
     }
 }
@@ -274,7 +278,7 @@ blockquote {
 //------------------- Layout
 
 
-[role="main"] {
+main {
     //Main column. Left aligned by default. See /styleguide for explanation.
     background: var(--white-color);
     padding: 1px 10px 40px;
@@ -447,7 +451,7 @@ blockquote {
 
 //-------------------  Site Chrome (Header/Footer)
 
-[role="banner"] {
+header {
     // Includes global navigation, logo, and tagline at top of document
     @include clearfix;
     background: $green-dark;
@@ -529,7 +533,7 @@ blockquote {
         }
     }
 
-    [role="navigation"] {
+    nav {
         width: 100%;
         background: $green-dark;
         transition: max-height 0.3s ease-out;
@@ -583,6 +587,10 @@ blockquote {
             color: var(--menu);
             display: block;
             text-decoration: none;
+
+            &:visited {
+              color: var(--menu);
+            }
 
             &:active,
             &:hover {
@@ -697,6 +705,7 @@ blockquote {
         line-height: 1.3;
         padding: 1px 0 6px;
         margin: .45em 0 .35em;
+        letter-spacing: -1px;
 
         em {
             font-style: normal;
@@ -715,6 +724,7 @@ blockquote {
         a {
             font-weight: 300;
             color: var(--secondary-accent);
+            text-decoration: none;
         }
 
         a.cta,
@@ -864,7 +874,7 @@ blockquote {
 
 }
 
-[role="contentinfo"] {
+footer {
     // Global Footer at bottom of page
     @include clearfix;
     @include sans-serif;
@@ -912,7 +922,7 @@ blockquote {
 
     }
 
-    h2 {
+    h3 {
         @include font-size(16);
         border-top: 1px solid var(--hairline-color);
         color: var(--menu);
@@ -942,10 +952,15 @@ blockquote {
             color: var(--menu);
             text-decoration: none;
 
+            &:visited {
+              color: var(--menu);
+            }
+
             &:hover,
             &:active,
             &:focus {
                 text-decoration: underline;
+                color: var(--menu);
             }
         }
     }
@@ -2558,7 +2573,7 @@ table.docutils th {
         }
     }
 
-    +h2 {
+    +h3 {
         margin-top: 34px;
     }
 }
@@ -3544,7 +3559,9 @@ ul.corporate-members li {
         border-radius: 20px;
     }
 
-    .community-cta svg, h3 {
-        color: var(--community-img-fg);
+    .community-cta {
+        svg, h3 {
+            color: var(--community-img-fg);
+        }
     }
 }

--- a/djangoproject/templates/accounts/edit_profile.html
+++ b/djangoproject/templates/accounts/edit_profile.html
@@ -34,9 +34,8 @@
 {% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
     <div role="complementary">
-        <h2>{% translate "Help" %}</h2>
+        <h2 id="aside-header">{% translate "Help" %}</h2>
 
         <p>{% translate "Use this form to edit your profile." %}</p>
 

--- a/djangoproject/templates/accounts/user_profile.html
+++ b/djangoproject/templates/accounts/user_profile.html
@@ -4,9 +4,8 @@
 {% block title %}{% firstof user_obj.profile.name user_obj.username %}{% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
     <div role="complementary">
-        <h2>
+        <h2 id="aside-header">
             {% if user_obj == user %}
                 {% translate "This is you!" %}
             {% else %}

--- a/djangoproject/templates/aggregator/index.html
+++ b/djangoproject/templates/aggregator/index.html
@@ -4,7 +4,7 @@
 {% block layout_class %}column-container sidebar-right{% endblock %}
 
 {% block content %}
-
+  <h1>{% translate "Community" %}</h1>
   <h2 class="community-title">{% translate "Get Help" %}</h2>
   <div class="community-cta-wrapper">
     <a href="https://forum.djangoproject.com/" class="community-cta-a">

--- a/djangoproject/templates/aggregator/local-django-community.html
+++ b/djangoproject/templates/aggregator/local-django-community.html
@@ -7,7 +7,7 @@
   {% regroup django_communities|dictsort:"continent" by continent as grouped_django_communities %}
 
 
-  <h2>{% translate "Local Django Communities" %}</h2>
+  <h1>{% translate "Local Django Communities" %}</h1>
 
   <p>{% blocktranslate trimmed %}Something missing? <a href="https://github.com/django/djangoproject.com/issues/new?assignees=&amp;labels=type%3Acommunity&amp;projects=&amp;template=community_request.md">Suggest your community{% endblocktranslate %}</a>.</p>
 

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -49,11 +49,11 @@
 
     {% include "includes/header.html" %}
 
-    <div class="copy-banner">
+    <section class="copy-banner">
       <div class="container {% block header-classes %}{% endblock %}">
         {% block header %}{% endblock %}
       </div>
-    </div>
+    </section>
 
     {% comment %}
     Replace the div#billboard below with banner using the skeleton here to
@@ -72,7 +72,7 @@
     <div id="billboard">{% block billboard %}{% endblock %}</div>
 
     <div class="container {% block layout_class %}{% endblock %}">
-      <div role="main">
+      <main>
 
         {% block messages %}
           {% if messages %}
@@ -89,7 +89,7 @@
 
         {% block content %}{% endblock %}
         <a href="#top" class="backtotop"><i class="icon icon-chevron-up"></i> Back to Top</a>
-      </div>
+      </main>
 
       {% block content-related %}{% endblock %}
       {% block content-extra %}{% endblock %}

--- a/djangoproject/templates/base_2col.html
+++ b/djangoproject/templates/base_2col.html
@@ -6,9 +6,9 @@
     {% endblock %}
   </div>
   <!-- END #content-main -->
-  <div id="content-related" class="sidebar">
+  <aside id="content-related" class="sidebar" aria-labelledby="aside-header">
     {% block content-related %}
     {% endblock %}
-  </div>
+  </aside>
   <!-- END #content-related -->
 {% endblock %}

--- a/djangoproject/templates/base_3col.html
+++ b/djangoproject/templates/base_3col.html
@@ -6,9 +6,9 @@
       {% block content %}{% endblock %}
     </div>
     <!-- END #content-main -->
-    <div id="content-related" class="sidebar">
+    <aside id="content-related" class="sidebar" aria-labelledby="aside-header">
       {% block content-related %}{% endblock %}
-    </div>
+    </aside>
     <!-- END #content-related -->
   </div>
   <!-- END #subwrap -->

--- a/djangoproject/templates/base_community.html
+++ b/djangoproject/templates/base_community.html
@@ -8,7 +8,6 @@
 {% block title %}{% translate "Django Community" %}{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">{% translate "Community" %}</h1>
   <p>
     {% if community_stats.age %}
       {% blocktranslate trimmed with age=community_stats.age %}
@@ -22,11 +21,11 @@
 {% endblock %}
 
 {% block content-related %}
-  <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
     {% donation_snippet %}
 
-    <h2>{% translate "More Help" %}</h2>
+    <h3>{% translate "More Help" %}</h3>
     <dl class="list-links">
       <dt>
         <a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">
@@ -42,7 +41,7 @@
       <dd>{% translate "Chat with other Django users like it's 1999" %}</dd>
     </dl>
 
-    <h2>{% translate "Dive In" %}</h2>
+    <h3>{% translate "Dive In" %}</h3>
     <dl class="list-links">
       <dt><a href="https://code.djangoproject.com/">{% translate "Ticket System" %}</a></dt>
       <dd>{% translate "View and update bug reports" %}</dd>
@@ -52,7 +51,7 @@
       <dd>{% translate "Get updated for each code and ticket change" %}</dd>
     </dl>
 
-    <h2>{% translate "More Links" %}</h2>
+    <h3>{% translate "More Links" %}</h3>
     <dl class="list-links">
       <dt><a href="https://www.djangopackages.com/" rel="nofollow">{% translate "Django Packages" %}</a></dt>
       <dd>{% translate "Find third-party packages to supercharge your project" %}</dd>

--- a/djangoproject/templates/base_foundation.html
+++ b/djangoproject/templates/base_foundation.html
@@ -7,17 +7,17 @@
 {% block title %}Django Software Foundation{% endblock %}
 
 {% block header %}
-  <h1>Django Software Foundation</h1>
+  <p>Django Software Foundation</p>
 {% endblock %}
 
 {% block content-related %}
 
-{# Always include <h1> label and <div> with aria role. #}
-  <h1 class="visuallyhidden">Additional Information</h1>
+{# Always include <h2> label and <div> with aria role. #}
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
     {% donation_snippet %}
 
-    <h2>About the foundation</h2>
+    <h3>About the foundation</h3>
     <ul class="list-links">
       <li><a href="/foundation/faq/">FAQ</a></li>
       <li><a href="/foundation/records/">Records</a></li>

--- a/djangoproject/templates/base_weblog.html
+++ b/djangoproject/templates/base_weblog.html
@@ -6,7 +6,9 @@
 {% block og_title %}{% translate "News &amp; Events" %}{% endblock %}
 
 {% block header %}
-  <h1><a href="{% url 'weblog:index' %}">{% translate "News &amp; Events" %}</a></h1>
+  {% if banner_is_title %}<h1>{% else %}<p>{% endif %}
+  <a href="{% url 'weblog:index' %}">{% translate "News &amp; Events" %}</a>
+  {% if banner_is_title %}</h1>{% else %}</p>{% endif %}
 {% endblock %}
 
 {% block head_extra %}
@@ -14,12 +16,12 @@
 {% endblock %}
 
 {% block content-related %}
-  <h1 class="visuallyhidden">{% translate "Additional Information" %}</h1>
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
     {% donation_snippet %}
 
     {% if events %}
-      <h2>{% translate "Upcoming Events" %}</h2>
+      <h3>{% translate "Upcoming Events" %}</h3>
       <ul class="list-events">
         {% for event in events %}
           <li>
@@ -34,7 +36,7 @@
 
     {% comment %}
     {# tags not implemented in backend yet #}
-    <h2><span>Tags</span></h2>
+    <h3><span>Tags</span></h3>
     <ul class="list-tags">
       <li><a href="#">Django Software Foundation</a></li>
       <li><a href="#">Events</a></li>
@@ -44,10 +46,10 @@
     </ul>
     {% endcomment %}
 
-    <h2><span>{% translate "Archives" %}</span></h2>
+    <h3><span>{% translate "Archives" %}</span></h3>
     {% render_month_links %}
 
-    <h2><span>{% translate "RSS Feeds" %}</span></h2>
+    <h3><span>{% translate "RSS Feeds" %}</span></h3>
     <ul class="list-links-small rss-list">
       <li><a href="{% url 'weblog-feed' %}">{% translate "Latest news entries" %}</a></li>
       <li><a href="https://code.djangoproject.com/timeline?daysback=90&max=50&wiki=on&ticket=on&changeset=on&milestone=on&format=rss">{% translate "Recent code changes" %}</a></li>

--- a/djangoproject/templates/blog/entry_detail.html
+++ b/djangoproject/templates/blog/entry_detail.html
@@ -9,7 +9,7 @@
 {% endblocktranslate %}{% endblock %}
 
 {% block content %}
-    <h2>{{ object.headline|safe }}</h2>
+    <h1>{{ object.headline|safe }}</h1>
 
     <span class="meta">{% blocktranslate trimmed with author=object.author pub_date=object.pub_date|date:"DATE_FORMAT" %}
         Posted by <strong>{{ author }}</strong> on {{ pub_date }} </span>

--- a/djangoproject/templates/conduct/base.html
+++ b/djangoproject/templates/conduct/base.html
@@ -2,13 +2,12 @@
 {% load i18n %}
 
 {% block header %}
-  <h1 class="visuallyhidden">{% translate "Code of Conduct" %}</h1>
   <p>{% translate "Code of Conduct" %}</p>
 {% endblock %}
 
 {% block content-related %}
   <div role="complementary">
-    <h2>{% translate "Django Community Code of Conduct" %}</h2>
+    <h2 id="aside-header">{% translate "Django Community Code of Conduct" %}</h2>
 
     <ul class="list-links">
       <li><a href="{% url 'code_of_conduct' %}">{% translate "Code of Conduct" %}</a></li>
@@ -19,7 +18,7 @@
       <li><a href="{% url 'conduct_changes' %}">{% translate "Changes" %}</a></li>
     </ul>
 
-    <h2>{% translate "License" %}</h2>
+    <h3>{% translate "License" %}</h3>
     <p>
       {% blocktranslate trimmed %}
         All content on this page is licensed under a

--- a/djangoproject/templates/diversity/base.html
+++ b/djangoproject/templates/diversity/base.html
@@ -5,20 +5,19 @@
 {% block og_description %}{% translate "We welcome you." %}{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">{% translate "Community Diversity Statement" %}</h1>
   <p>{% translate "Community Diversity Statement" %}</p>
 {% endblock %}
 
 {% block content-related %}
   <div role="complementary">
-    <h2>{% translate "Django Community Diversity Statement" %}</h2>
+    <h2 id="aside-header">{% translate "Django Community Diversity Statement" %}</h2>
 
     <ul class="list-links">
       <li><a href="{% url 'diversity' %}">{% translate "Diversity Statement" %}</a></li>
       <li><a href="{% url 'diversity_changes' %}">{% translate "Changes" %}</a></li>
     </ul>
 
-    <h2>{% translate "License" %}</h2>
+    <h3>{% translate "License" %}</h3>
     <p>
       {% blocktranslate trimmed %}
         All content on this page is licensed under a

--- a/djangoproject/templates/fundraising/includes/donation_snippet.html
+++ b/djangoproject/templates/fundraising/includes/donation_snippet.html
@@ -2,7 +2,7 @@
 
 {% if donation %}
   <div class="fundraising-sidebar">
-    <h2>{% translate "Support Django!" %}</h2>
+    <h3>{% translate "Support Django!" %}</h3>
 
     <div class="small-heart">
       <img src="{% static "img/fundraising-heart.svg" %}" alt="Support Django!" />

--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -8,7 +8,6 @@
 {% block og_description %}{% translate "Support Django development by donating to the Django Software Foundation" %}{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">{% translate "Support Django" %}</h1>
   <p>
     {% blocktranslate trimmed %}
       <em>Support Django development</em> by donating to the <em>Django Software Foundation</em>.
@@ -33,7 +32,7 @@
 
   {% donation_form_with_heart %}
 
-  <h1>{% translate "Other ways to give" %}</h1>
+  <h2>{% translate "Other ways to give" %}</h2>
   <ul>
     <li>
       {% blocktranslate trimmed %}
@@ -233,7 +232,7 @@
   <hr style="margin: 40px 0" />
 
   <div class="heroes-section">
-    <h1 id="dsf-supporters">{% translate "DSF Supporters" %}</h1>
+    <h2 id="dsf-supporters">{% translate "DSF Supporters" %}</h2>
     <p>
       {% blocktranslate trimmed %}
         Our donors make our work possible! We are incredibly grateful for the

--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -6,7 +6,6 @@
 {% block layout_class %}column-container sidebar-right{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">Django</h1>
   <p>
     <em>{% translate "Django makes it easier to build better web apps more quickly and with less code." %}</em>
   </p>
@@ -104,7 +103,9 @@
 {% endblock %}
 
 {% block content-related %}
+  <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
     <a href="{% url 'download' %}" class="cta">
       {% blocktranslate trimmed %}
         Download <em>latest release: {{ DJANGO_VERSION }}</em>

--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -1,10 +1,10 @@
-<div role="contentinfo">
+<footer>
   <div class="subfooter">
     <div class="container">
-      <h1 class="visuallyhidden">Django Links</h1>
+      <h2 class="visuallyhidden">Django Links</h2>
       <div class="column-container">
         <div class="col-learn-more">
-          <h2>Learn More</h2>
+          <h3>Learn More</h3>
           <ul>
             <li><a href="{% url 'overview' %}">About Django</a></li>
             {% comment %}<li><a href="{% url 'case_study_index' %}">Case Studies</a></li>{% endcomment %}
@@ -18,7 +18,7 @@
         </div>
 
         <div class="col-get-involved">
-          <h2>Get Involved</h2>
+          <h3>Get Involved</h3>
           <ul>
             <li><a href="{% url 'community-index' %}">Join a Group</a></li>
             <li><a href="{% url 'document-detail' lang='en' version='dev' url="internals/contributing" host 'docs' %}">Contribute
@@ -34,7 +34,7 @@
         </div>
 
         <div class="col-get-help">
-          <h2>Get Help</h2>
+          <h3>Get Help</h3>
           <ul>
             <li><a href="{% url 'document-detail' lang='en' version='stable' url='faq' host 'docs' %}">Getting Help FAQ</a>
             </li>
@@ -44,7 +44,7 @@
         </div>
 
         <div class="col-follow-us">
-          <h2>Follow Us</h2>
+          <h3>Follow Us</h3>
           <ul>
             <li><a href="https://github.com/django">GitHub</a></li>
             <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
@@ -54,7 +54,7 @@
         </div>
 
         <div class="col-support-us">
-          <h2>Support Us</h2>
+          <h3>Support Us</h3>
           <ul>
             <li><a href="{% url "fundraising:index" %}">Sponsor Django</a></li>
             <li><a href="/foundation/corporate-membership/">Corporate membership</a></li>
@@ -87,4 +87,4 @@
     </div>
   </div>
 
-</div>
+</footer>

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -1,4 +1,4 @@
-<div role="banner" id="top">
+<header id="top">
   <div class="container container--flex--wrap--mobile">
     <a class="logo" href="{% url 'homepage' %}">Django</a>
     <p class="meta">The web framework for perfectionists with deadlines.</p>
@@ -9,7 +9,8 @@
       <i class="icon icon-reorder"></i>
       <span class="visuallyhidden">Menu</span>
     </button>
-    <div role="navigation">
+    <nav aria-labelledby="navigation-header">
+      <span id="navigation-header" class="visuallyhidden">Main navigation</span>
       <ul>
         <li{% if 'start' in request.path %} class="active"{% endif %}>
           <a href="{% url 'overview' %}">Overview</a>
@@ -42,6 +43,6 @@
           {% include "includes/toggle_theme.html" %}
         </li>
       </ul>
-    </div>
+    </nav>
   </div>
-</div>
+</header>

--- a/djangoproject/templates/overview.html
+++ b/djangoproject/templates/overview.html
@@ -6,7 +6,6 @@
 {% block og_title %}{% translate "Django overview" %}{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">{% translate "Django Overview" %}</h1>
   <p>
     {% blocktranslate trimmed %}
       <em>Django</em> was invented to meet fast-moving <em>newsroom deadlines</em>, while satisfying the tough

--- a/djangoproject/templates/registration/base.html
+++ b/djangoproject/templates/registration/base.html
@@ -1,4 +1,4 @@
 {% extends "base_2col.html" %}
 {% load i18n %}
 {% block sectionid %}community{% endblock %}
-{% block header %}<h1>{% translate "Accounts" %}</h1>{% endblock %}
+{% block header %}<p>{% translate "Accounts" %}</p>{% endblock %}

--- a/djangoproject/templates/registration/login.html
+++ b/djangoproject/templates/registration/login.html
@@ -38,8 +38,8 @@
 {% endblock %}
 
 {% block content-related %}
-    <h1 class="visuallyhidden">{% translate "Help" %}</h1>
     <div role="complementary">
+        <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
         {% url 'registration_register' as register_url %}
         <p>
             {% blocktranslate trimmed %}

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -55,8 +55,8 @@
 {% endblock %}
 
 {% block content-related %}
-  <h1 class="visuallyhidden">{% translate "Help" %}</h1>
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Help" %}</h2>
     <p>
       {% blocktranslate trimmed %}
         Fill out the form to the right (all fields are required), and your

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -13,7 +13,7 @@
 {% block og_image_height %}480{% endblock %}
 
 {% block header %}
-  <h1>Download</h1>
+  <p>Download</p>
 {% endblock %}
 
 {% block content %}
@@ -259,12 +259,12 @@
 
 {% block content-related %}
 
-  <h1 class="visuallyhidden">Additional information</h1>
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">Additional Information</h2>
 
     {% if corporate_members %}
       <div class="corporate-members">
-        <h2>Diamond and Platinum Members</h2>
+        <h3>Diamond and Platinum Members</h3>
         {% for obj in corporate_members %}
           <div class="clearfix">
             <div class="member-logo">
@@ -287,7 +287,7 @@
 
     {% donation_snippet %}
 
-    <h2>For the impatient:</h2>
+    <h3>For the impatient:</h3>
     <ul>
       <li>Latest release:
         <a href="{% url 'download-redirect' current.version 'tarball' %}">
@@ -308,11 +308,11 @@
       {% endif %}
     </ul>
 
-    <h2>Which version is better?</h2>
+    <h3>Which version is better?</h3>
     <p>We improve Django almost every day and are pretty good about keeping the code stable. Thus, using the latest development code is a safe and easy way to get access to new features as they’re added. If you choose to follow the development version, keep in mind that there will occasionally be backwards-incompatible changes. You’ll want to pay close attention to the commits by watching <a href="https://github.com/django/django">Django on GitHub</a> or subscribing to <a href="https://groups.google.com/group/django-updates">django-updates</a>.</p>
 
     <p>If you’re just looking for a stable deployment target and don’t mind waiting for the next release, you’ll want to stick with the latest official release (which will always include detailed notes on any changes you’ll need to make while upgrading).</p>
-    <h2>Previous releases</h2>
+    <h3>Previous releases</h3>
     <ul>
       <li>Django {{ previous.version }}{% if previous.is_lts %} (LTS){% endif %}:
         <a href="{% url 'download-redirect' previous.version 'tarball' %}">
@@ -332,7 +332,7 @@
       {% endif %}
     </ul>
 
-    <h2>Unsupported previous releases (no longer receive security updates or bug fixes)</h2>
+    <h3>Unsupported previous releases (no longer receive security updates or bug fixes)</h3>
     <ul>
       {% for release in unsupported %}
         <li>Django {{ release.version }}:

--- a/djangoproject/templates/start.html
+++ b/djangoproject/templates/start.html
@@ -7,7 +7,6 @@
 {% block og_description %}{% translate "It's quick & easy to get up and running with Django" %}{% endblock %}
 
 {% block header %}
-  <h1 class="visuallyhidden">{% translate "Get started" %}</h1>
   <div class="layout-2col">
     <div class="col two-third">
       <p>{% translate "It’s <em>quick &amp; easy</em> to get up and running with <em>Django</em>." %}</p>

--- a/djangoproject/templates/styleguide.html
+++ b/djangoproject/templates/styleguide.html
@@ -3,9 +3,7 @@
 {% block title %}Django Web Styleguide{% endblock %}
 {% block body_class %}styleguide{% endblock %}
 
-{% block header %}
-  <h1>Style Guide</h1>
-{% endblock %}
+{% block header %}<p>Style Guide</p>{% endblock %}
 
 {% block content %}
 
@@ -413,9 +411,8 @@
 {% endblock %}
 
 {% block content-related %} {# Always include <h1> label and <div> with aria role. #}
-  <h1 class="visuallyhidden">Additional Information</h1>
   <div role="complementary">
-    <h2>Contents</h2>
+    <h2 id="aside-header">Contents</h2>
     <ul class="list-outline">
       <li><a class="reference internal" href="#">Django Web Style Guide</a>
         <ul>

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -3,6 +3,7 @@ from io import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase
+from django.urls import NoReverseMatch, get_resolver
 from django_hosts.resolvers import reverse
 
 from docs.models import DocumentRelease, Release
@@ -131,3 +132,35 @@ class PendingMigrationsTests(TestCase):
             )
         except SystemExit:  # pragma: no cover
             raise AssertionError("Pending migrations:\n" + out.getvalue()) from None
+
+
+class Header1Tests(TestCase):
+    def extract_patterns(self, patterns, prefix="", urls=None):
+        urls = urls or []
+        for pattern in patterns:
+            if hasattr(pattern, "url_patterns"):
+                self.extract_patterns(
+                    pattern.url_patterns, prefix + pattern.pattern.regex.pattern
+                )
+            elif hasattr(pattern, "pattern") and pattern.name:
+                try:
+                    urls.append(reverse(pattern.name))
+                except NoReverseMatch:
+                    pass  # Ignore URLs that require arguments.
+        return urls
+
+    def test_single_h1_per_page(self):
+        excluded_urls = [
+            "rss/",
+            "styleguide/",  # Has multiple <h1> examples.
+            "admin/",  # Admin templates are out of our control.
+            "reset/done/",  # Uses an admin template.
+        ]
+        resolver = get_resolver()
+        urls = self.extract_patterns(resolver.url_patterns)
+        for url in urls:
+            if all(url_substring not in url for url_substring in excluded_urls):
+                with self.subTest(url=url):
+                    response = self.client.get(url)
+                    self.assertEqual(response.status_code, 200)
+                    self.assertContains(response, "<h1", count=1)

--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block header %}
-  <h1><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></h1>
+  <p><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></p>
   {% search_form %}
 {% endblock %}
 

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -115,103 +115,112 @@
   </div>
 
   {% block body %}
-    <div id="docs-content">
+    <article id="docs-content">
       {{ doc.body|safe }}
-    </div>
+    </article>
   {% endblock body %}
 
   {% if doc.prev or doc.next %}
-    <div class="browse-horizontal">
+    <nav class="browse-horizontal" aria-labelledby="browse-horizontal-header">
+      <span id="browse-horizontal-header" class="visuallyhidden">{% translate "Previous page and next page" %}</span>
       {% if doc.prev %}
         <div class="left"><a rel="prev" href="{{ doc.prev.link }}"><i class="icon icon-chevron-left"></i> {{ doc.prev.title|safe }}</a></div>
       {% endif %}
       {% if doc.next %}
         <div class="right"><a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }} <i class="icon icon-chevron-right"></i></a></div>
       {% endif %}
-    </div>
+    </nav>
   {% endif %}
 
 {% endblock content %}
 
 
 {% block content-related %}
-  <h1 class="visuallyhidden">{% trans "Additional Information" %}</h1>
   <div role="complementary">
+    <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
 
     {% donation_snippet %}
 
     {% block toc-wrapper %}
-      <h2>{% trans "Contents" %}</h2>
+      <h3>{% trans "Contents" %}</h3>
       {% block toc %}
         {{ doc.toc|safe }}
       {% endblock toc %}
     {% endblock toc-wrapper %}
 
     {% block browse-wrapper %}
-      <h2>{% trans "Browse" %}</h2>
-      <ul>
-        {% block browse %}
-          {% if doc.prev %}
-            <li>{% trans "Prev:" %} <a rel="prev" href="{{ doc.prev.link }}">{{ doc.prev.title|safe }}</a></li>
-          {% endif %}
-          {% if doc.next %}
-            <li>{% trans "Next:" %} <a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }}</a></li>
-          {% endif %}
-          <li><a href="{% url 'document-detail' lang=lang version=version url="contents" host 'docs' %}">{% trans "Table of contents" %}</a></li>
-          {% for doc, title, accesskey, shorttitle in env.rellinks %}
-            <li><a href="{% url 'document-detail' lang=lang version=version url=doc host 'docs' %}">{{ title }}</a></li>
-          {% endfor %}
-        {% endblock browse %}
-      </ul>
+      <nav aria-labelledby="browse-header">
+        <h3 id="browse-header">{% trans "Browse" %}</h3>
+        <ul>
+          {% block browse %}
+            {% if doc.prev %}
+              <li>{% trans "Prev:" %} <a rel="prev" href="{{ doc.prev.link }}">{{ doc.prev.title|safe }}</a></li>
+            {% endif %}
+            {% if doc.next %}
+              <li>{% trans "Next:" %} <a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }}</a></li>
+            {% endif %}
+            <li><a href="{% url 'document-detail' lang=lang version=version url="contents" host 'docs' %}">{% trans "Table of contents" %}</a></li>
+            {% for doc, title, accesskey, shorttitle in env.rellinks %}
+              <li><a href="{% url 'document-detail' lang=lang version=version url=doc host 'docs' %}">{{ title }}</a></li>
+            {% endfor %}
+          {% endblock browse %}
+        </ul>
+      </nav>
     {% endblock browse-wrapper %}
 
     {% block breadcrumbs-wrapper %}
-      <h2>{% trans "You are here:" %}</h2>
-      <ul>
-        <li>
-          <a href="{% url 'document-index' lang=lang version=version host 'docs' %}">{% blocktrans %}Django {{ version }} documentation{% endblocktrans %}</a>
-          {% for p in doc.parents %}
-            <ul><li><a href="{{ p.link }}">{{ p.title|safe }}</a>
-          {% endfor %}
-          <ul><li>{% block current-page-title %}{{ doc.title|safe }}{% endblock current-page-title %}</li></ul>
-          {% for p in doc.parents %}</li></ul>{% endfor %}
-        </li>
-      </ul>
+      <nav aria-labelledby="breadcrumbs-header">
+        <h3 id="breadcrumbs-header">{% trans "You are here:" %}</h3>
+        <ul>
+          <li>
+            <a href="{% url 'document-index' lang=lang version=version host 'docs' %}">{% blocktrans %}Django {{ version }} documentation{% endblocktrans %}</a>
+            {% for p in doc.parents %}
+              <ul><li><a href="{{ p.link }}">{{ p.title|safe }}</a>
+            {% endfor %}
+            <ul><li>{% block current-page-title %}{{ doc.title|safe }}{% endblock current-page-title %}</li></ul>
+            {% for p in doc.parents %}</li></ul>{% endfor %}
+          </li>
+        </ul>
+      </nav>
     {% endblock breadcrumbs-wrapper %}
 
     {% block help-wrapper %}
-      <h2 id="getting-help-sidebar">{% trans "Getting help" %}</h2>
-      <dl class="list-links">
-        <dt><a href="{% url 'document-detail' lang=lang version=version url="faq" host 'docs' %}">{% trans "FAQ" %}</a></dt>
-        <dd>{% blocktrans %}Try the FAQ — it's got answers to many common questions.{% endblocktrans %}</dd>
+      <section aria-labelledby="getting-help-sidebar">
+        <h3 id="getting-help-sidebar">{% trans "Getting help" %}</h3>
+        <dl class="list-links">
+          <dt><a href="{% url 'document-detail' lang=lang version=version url="faq" host 'docs' %}">{% trans "FAQ" %}</a></dt>
+          <dd>{% blocktrans %}Try the FAQ — it's got answers to many common questions.{% endblocktrans %}</dd>
 
-        <dt><a href="/en/stable/genindex/">{% trans "Index" %}</a>, <a href="/en/stable/py-modindex/">{% trans "Module Index" %}</a>, or <a href="/en/stable/contents/">{% trans "Table of Contents" %}</a></dt>
-        <dd>{% blocktrans %}Handy when looking for specific information.{% endblocktrans %}</dd>
+          <dt><a href="/en/stable/genindex/">{% trans "Index" %}</a>, <a href="/en/stable/py-modindex/">{% trans "Module Index" %}</a>, or <a href="/en/stable/contents/">{% trans "Table of Contents" %}</a></dt>
+          <dd>{% blocktrans %}Handy when looking for specific information.{% endblocktrans %}</dd>
 
-        <dt><a href="https://chat.djangoproject.com">{% trans "Django Discord Server" %}</a></dt>
-        <dd>{% blocktrans %}Join the Django Discord Community.{% endblocktrans %}</dd>
+          <dt><a href="https://chat.djangoproject.com">{% trans "Django Discord Server" %}</a></dt>
+          <dd>{% blocktrans %}Join the Django Discord Community.{% endblocktrans %}</dd>
 
-        <dt><a href="https://forum.djangoproject.com/">{% trans "Official Django Forum" %}</a></dt>
-        <dd>{% blocktrans %}Join the community on the Django Forum.{% endblocktrans %}</dd>
+          <dt><a href="https://forum.djangoproject.com/">{% trans "Official Django Forum" %}</a></dt>
+          <dd>{% blocktrans %}Join the community on the Django Forum.{% endblocktrans %}</dd>
 
-        <dt><a href="https://code.djangoproject.com/">{% trans "Ticket tracker" %}</a></dt>
-        <dd>{% blocktrans %}Report bugs with Django or Django documentation in our ticket tracker.{% endblocktrans %}</dd>
-      </dl>
+          <dt><a href="https://code.djangoproject.com/">{% trans "Ticket tracker" %}</a></dt>
+          <dd>{% blocktrans %}Report bugs with Django or Django documentation in our ticket tracker.{% endblocktrans %}</dd>
+        </dl>
+      </section>
     {% endblock help-wrapper %}
 
     {% block links-wrapper %}
-      <h2>{% trans "Download:" %}</h2>
-      <p>
-        {% if version == "dev" %}{% trans "Offline (development version):" %}
-        {% else %}{% blocktrans %}Offline (Django {{ version }}):{% endblocktrans %}{% endif %}
-        <a href="{{ MEDIA_URL }}docs/django-docs-{{ version }}-{{ lang }}.zip">HTML</a> |
-        <a href="https://media.readthedocs.org/pdf/django/{{ rtd_version }}/django.pdf">PDF</a> |
-        <a href="https://media.readthedocs.org/epub/django/{{ rtd_version }}/django.epub">ePub</a>
-        <br>
-        <span class="quiet">
-          {% blocktrans %}Provided by <a href="https://readthedocs.org/">Read the Docs</a>.{% endblocktrans %}
-        </span>
-      </p>
+      <section aria-labelledby="links-wrapper-header">
+        <h3 id="links-wrapper-header">{% trans "Download:" %}</h3>
+        <p>
+          {% if version == "dev" %}{% trans "Offline (development version):" %}
+          {% else %}{% blocktrans %}Offline (Django {{ version }}):{% endblocktrans %}{% endif %}
+          <a href="{{ MEDIA_URL }}docs/django-docs-{{ version }}-{{ lang }}.zip">HTML</a> |
+          <a href="https://media.readthedocs.org/pdf/django/{{ rtd_version }}/django.pdf">PDF</a> |
+          <a href="https://media.readthedocs.org/epub/django/{{ rtd_version }}/django.epub">ePub</a>
+          <br>
+          <span class="quiet">
+            {% blocktrans %}Provided by <a href="https://readthedocs.org/">Read the Docs</a>.{% endblocktrans %}
+          </span>
+        </p>
+      </section>
     {% endblock links-wrapper %}
   </div>
 {% endblock content-related %}

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -193,7 +193,7 @@ class CorporateMembersTestCase(TestCase):
 
         response = self.client.get(reverse("download"))
 
-        self.assertContains(response, "<h2>Diamond and Platinum Members</h2>")
+        self.assertContains(response, "<h3>Diamond and Platinum Members</h3>")
         member_link = (
             lambda m: f'<a href="{m.url}" title="{m.display_name}">{m.description}</a>'
         )
@@ -214,7 +214,7 @@ class CorporateMembersTestCase(TestCase):
 
         response = self.client.get(reverse("download"))
 
-        self.assertNotContains(response, "<h2>Diamond and Platinum Members</h2>")
+        self.assertNotContains(response, "<h3>Diamond and Platinum Members</h3>")
         for member in members:
             self.assertNotContains(response, member.display_name)
             self.assertNotContains(response, member.url)


### PR DESCRIPTION
Fixes https://github.com/django/djangoproject.com/issues/1956 and fixes https://github.com/django/djangoproject.com/issues/1411

This roughly implements the following landmark structure as described in [this comment](https://github.com/django/djangoproject.com/issues/1411#issuecomment-2676972984):

![diagram of docs page with highlighted sections for html landmarks](https://github.com/user-attachments/assets/8a714805-5d39-4b1f-918d-d7edc165c95b)


Here are some screen reader recordings of a couple of tests:

This shows navigating the docs page by headers and that there is only one header level 1:

https://github.com/user-attachments/assets/3fdacb16-54f4-4da3-a801-df48305547b7

This shows navigating the docs page by landmarks:

https://github.com/user-attachments/assets/68f6cdfc-8c38-4b1a-bead-6f38742867b7

