### PR TITLE
Prevented Sphinx global state interfering with builds.

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -227,7 +227,7 @@ class Command(BaseCommand):
                         # stderr to stdout to be logged (rather than generating an email)
                         warning=sys.stdout,
                         parallel=multiprocessing.cpu_count(),
-                        verbosity=self.verbosity,
+                        verbosity=0,
                         confoverrides={
                             "language": to_locale(release.lang),
                             "extensions": extensions,


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/issues/12130

This mimics how Sphinx is called in `build_main`: https://github.com/sphinx-doc/sphinx/blob/457754b9d936509d695d75e6b251e86100850eca/sphinx/cmd/build.py#L413

I'm not sure if this will fix https://github.com/django/djangoproject.com/issues/1973 but I think it's probably worth doing