### PR TITLE
Added Sphinx clean up global state call.

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -21,6 +21,7 @@ from django.utils.translation import to_locale
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.errors import SphinxError
+from sphinx.testing.util import _clean_up_global_state
 from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 from ...models import DocumentRelease
@@ -233,6 +234,8 @@ class Command(BaseCommand):
                             "extensions": extensions,
                         },
                     ).build()
+                # Clean up global state after building each language.
+                _clean_up_global_state()
             except SphinxError as e:
                 self.stderr.write(
                     "sphinx-build returned an error (release %s, builder %s): %s"

--- a/docs/tests/test_builder.py
+++ b/docs/tests/test_builder.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase
+from sphinx.testing.util import _clean_up_global_state
 
 from ..builder import DomainObject, PythonObjectsJSONHTMLBuilder
 
@@ -61,3 +62,8 @@ class TestPythonObjectsJSONHTMLBuilder(SimpleTestCase):
         self.assertIn("python_objects_search", result)
         self.assertEqual(result["python_objects"], {"ClassA": "module1.ClassA"})
         self.assertEqual(result["python_objects_search"], "ClassA")
+
+
+class TestSphinxAPI(SimpleTestCase):
+    def test_private_sphinx_function_exists(self):
+        _clean_up_global_state()


### PR DESCRIPTION
This is the other function mentioned in the Sphinx issue tracker: https://github.com/sphinx-doc/sphinx/issues/12130

Locally before these changes I had "source" always being Italian, e.g.

![Japanese docs with source in Italian](https://github.com/user-attachments/assets/81a46790-9b36-4aae-8613-164db1b85fa3)


After, we have Japanese with Japanese:
![Japanese docs with source in Japanese](https://github.com/user-attachments/assets/3346836d-e1bb-4d1c-97be-7f2f86425efb)
