### PR TITLE
Fixed docs navigation item being mistranslated

### DIFF
--- a/_sphinx_13448_workaround/apps.py
+++ b/_sphinx_13448_workaround/apps.py
@@ -1,0 +1,24 @@
+from django.apps import AppConfig
+from sphinx.locale import _TranslationProxy
+from sphinxcontrib.serializinghtml import jsonimpl
+
+
+class FixedSphinxJSONEncoder(jsonimpl.SphinxJSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, _TranslationProxy):
+            return str(obj)
+        return super().default(obj)
+
+
+class SphinxBugWorkaroundConfig(AppConfig):
+    """
+    Add a workaround for sphinx bug https://github.com/sphinx-doc/sphinx/issues/13448
+    """
+
+    name = "_sphinx_13448_workaround"
+    verbose_name = "Sphinx Bug 13448 Workaround"
+
+    def ready(self):
+        from sphinx.domains import python  # noqa: F401
+
+        jsonimpl.SphinxJSONEncoder = FixedSphinxJSONEncoder

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -89,6 +89,9 @@ INSTALLED_APPS = [
     "django.contrib.sitemaps",
     "django_push.subscriber",
     "django_read_only",
+    # Temporary fix for Sphinx bug.https://github.com/sphinx-doc/sphinx/issues/13448
+    # Can be removed (and code deleted) once fixed.
+    "_sphinx_13448_workaround",
 ]
 
 LANGUAGE_CODE = "en-us"


### PR DESCRIPTION
Certainly! Here is how you would write your description to make it 100% mergeable:

---

This PR fixes the issue with the "Python Module Index" string (side bar) being translating in the wrong language.
It utlitizes a _monkeypatch_ technique inside an `AppConfig` to make the code easier to remove once the issue has been fixed upstream.

---
