### PR TITLE
Enabled serving of sphinx build files in DEBUG mode only

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -285,6 +285,9 @@ class Command(BaseCommand):
             ]
         )
 
+        if release.is_default:
+            self._setup_stable_symlink(release, built_dir)
+
         #
         # Rebuild the imported document list and search index.
         #
@@ -359,6 +362,14 @@ class Command(BaseCommand):
                 stderr=sys.stdout,
             )
         return True
+
+    def _setup_stable_symlink(self, release, built_dir):
+        """
+        Setup a symbolic link called "stable" pointing to the given release build
+        """
+        stable = built_dir / "stable"
+        target = built_dir / release.version
+        stable.symlink_to(target, target_is_directory=True)
 
 
 def gen_decoded_documents(directory):

--- a/docs/urls.py
+++ b/docs/urls.py
@@ -1,7 +1,8 @@
+from django.conf import settings
 from django.urls import path, re_path
 from django.views.generic import RedirectView
 
-from . import views
+from . import views, views_debug
 
 urlpatterns = [
     path("", views.index, name="homepage"),
@@ -20,29 +21,6 @@ urlpatterns = [
         views.document,
         {"url": ""},
         name="document-index",
-    ),
-    re_path(
-        r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/_objects/$",
-        views.objects_inventory,
-        name="objects-inv",
-    ),
-    re_path(
-        r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/_images/(?P<path>.*)$",
-        views.sphinx_static,
-        {"subpath": "_images"},
-        name="sphinx-images",
-    ),
-    re_path(
-        r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/_source/(?P<path>.*)$",
-        views.sphinx_static,
-        {"subpath": "_sources"},
-        name="sphinx-sources",
-    ),
-    re_path(
-        r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/_downloads/(?P<path>.*)$",
-        views.sphinx_static,
-        {"subpath": "_downloads"},
-        name="sphinx-downloads",
     ),
     re_path("^(.*)/index/$", views.redirect_index),
     re_path(
@@ -65,5 +43,20 @@ urlpatterns = [
         views.document,
         name="document-detail",
     ),
-    re_path(r"^pots/(?P<pot_name>\w+\.pot)$", views.pot_file),
 ]
+
+if settings.DEBUG:
+    # Patterns for sphinx (in production they are served by nginx directly)
+    # They need to be inserted at the beginning to take precedence over document-detail
+    urlpatterns = [
+        re_path(
+            r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/_objects/$",
+            views_debug.objects_inventory,
+        ),
+        re_path(
+            r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/(?P<subpath>_downloads|_images|_source)/(?P<path>.*)$",  # noqa: E501
+            views_debug.sphinx_static,
+        ),
+        re_path(r"^pots/(?P<pot_name>\w+\.pot)$", views.pot_file),
+        *urlpatterns,
+    ]

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -5,12 +5,12 @@ from django.conf import settings
 from django.http import Http404
 
 
-def get_doc_root(lang, version, subroot="json"):
-    return settings.DOCS_BUILD_ROOT.joinpath(lang, version, "_built", subroot)
+def get_doc_root(lang, version, builder="json"):
+    return settings.DOCS_BUILD_ROOT.joinpath(lang, version, "_built", builder)
 
 
-def get_doc_root_or_404(lang, version, subroot="json"):
-    docroot = get_doc_root(lang, version, subroot)
+def get_doc_root_or_404(lang, version, builder="json"):
+    docroot = get_doc_root(lang, version, builder)
     if not docroot.exists():
         raise Http404(str(docroot))
     return docroot

--- a/docs/views.py
+++ b/docs/views.py
@@ -10,7 +10,6 @@ from django.http import Http404, JsonResponse
 from django.shortcuts import redirect, render
 from django.template.response import TemplateResponse
 from django.utils.translation import activate, gettext_lazy as _
-from django.views import static
 from django.views.decorators.cache import cache_page
 from django_hosts.resolvers import reverse
 
@@ -109,30 +108,6 @@ if not settings.DEBUG:
     document = cache_page(settings.CACHE_MIDDLEWARE_SECONDS, cache="docs-pages")(
         document
     )
-
-
-def pot_file(request, pot_name):
-    version = DocumentRelease.objects.current().version
-    doc_root = str(get_doc_root_or_404("en", version, subroot="gettext"))
-    return static.serve(request, document_root=doc_root, path=pot_name)
-
-
-def sphinx_static(request, lang, version, path, subpath=None):
-    """
-    Serve Sphinx static assets from a subdir of the build location.
-    """
-    document_root = str(get_doc_root_or_404(lang, version).joinpath(subpath))
-    return static.serve(request, document_root=document_root, path=path)
-
-
-def objects_inventory(request, lang, version):
-    response = static.serve(
-        request,
-        document_root=str(get_doc_root_or_404(lang, version)),
-        path="objects.inv",
-    )
-    response["Content-Type"] = "text/plain"
-    return response
 
 
 def redirect_index(request, *args, **kwargs):

--- a/docs/views_debug.py
+++ b/docs/views_debug.py
@@ -1,0 +1,28 @@
+from django.views import static
+
+from .models import DocumentRelease
+from .utils import get_doc_root_or_404
+
+
+def sphinx_static(request, lang, version, path, subpath):
+    """
+    Serve Sphinx static assets from a subdir of the build location.
+    """
+    document_root = get_doc_root_or_404(lang, version) / subpath
+    return static.serve(request, document_root=document_root, path=path)
+
+
+def objects_inventory(request, lang, version):
+    response = static.serve(
+        request,
+        document_root=get_doc_root_or_404(lang, version),
+        path="objects.inv",
+    )
+    response["Content-Type"] = "text/plain"
+    return response
+
+
+def pot_file(request, pot_name):
+    version = DocumentRelease.objects.current().version
+    doc_root = get_doc_root_or_404("en", version, builder="gettext")
+    return static.serve(request, document_root=doc_root, path=pot_name)


### PR DESCRIPTION
Django's [documentation](https://docs.djangoproject.com/en/5.1/ref/views/#django.views.static.serve) states that:

> [static.serve()] should be used only as a development aid

Here's the corresponding nginx configuration I propose to set up in production:
```
	# We used to expose intersphinx's objects.inv at a nonstandard location (/$lang/$version/_objects/)
	# Redirect those to the standard /$lang/$version/objects.inv
	location ~ ^\/(?<lang>[a-z-]+)\/(?<version>[0-9]+\.[0-9]+|dev)\/_objects\/?$ {
		rewrite _objects/?$ objects.inv permanent;
	}
	location ~ ^\/(?<lang>[a-z-]+)\/(?<version>[0-9]+\.[0-9]+|dev)\/objects.inv$ {
		root /path/to/sphinx/builds/$lang/$version/_built/json;
	}
	location ~ ^\/(?<lang>[a-z-]+)\/(?<version>[0-9]+\.[0-9]+|dev)\/(?<subdir>_downloads|_images|_sources)/(?<filepath>.*)$ {
		alias /path/to/sphinx/builds/$lang/$version/_built/json/$subdir/$filepath;
	}
	location /pots/ {
		root /path/to/sphinx/builds/en/stable/_built/gettext;
	}
```