### PR TITLE
Restored serving of spinx _images

### DIFF
--- a/docs/urls.py
+++ b/docs/urls.py
@@ -22,6 +22,11 @@ urlpatterns = [
         {"url": ""},
         name="document-index",
     ),
+    re_path(
+        r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/_images/(?P<path>.*)$",
+        views_debug.sphinx_static,
+        {"subpath": "_images"},
+    ),
     re_path("^(.*)/index/$", views.redirect_index),
     re_path(
         r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/search/$",
@@ -54,7 +59,7 @@ if settings.DEBUG:
             views_debug.objects_inventory,
         ),
         re_path(
-            r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/(?P<subpath>_downloads|_images|_source)/(?P<path>.*)$",  # noqa: E501
+            r"^(?P<lang>[a-z-]+)/(?P<version>[\w.-]+)/(?P<subpath>_downloads|_source)/(?P<path>.*)$",  # noqa: E501
             views_debug.sphinx_static,
         ),
         re_path(r"^pots/(?P<pot_name>\w+\.pot)$", views_debug.pot_file),


### PR DESCRIPTION
This is a partial revert of efc51e848d870d4c7675f6636b9893324ba3bc3f.

Due to an unfortunate conflict in the nginx configuration of the server after the deploying of the commit mentioned above, the _images directory ended up still being served by Django which added a / to the end of the image path, using a permanent HTTP redirection (because of settings.APPEND_SLASH).

The solution (hopefully temporary) is to restore the serving of images by Django while we figure out how to configure
nginx to keep serving the _images and handled the old cached redirections with a trainling slash.
