### PR TITLE
Added temporary workaround for incompatibility between django-money and 5.2

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,7 +2,7 @@ Babel==2.17.0
 django-contact-form==5.1.2
 django-countries==7.6.1
 django-hosts==5.1
-django-money==3.5.3
+django-money @ git+https://github.com/gvangool/django-money.git@408ed3ce4d65689a60221f90713313f56cea5724
 django-push @ git+https://github.com/brutasse/django-push.git@22fda99641cfbd2f3075a723d92652a8e38220a5
 django-read-only==1.19.0
 django-recaptcha==4.0.0


### PR DESCRIPTION
I've tested it locally and it resolves the crash in the admin.