### PR TITLE
Check for elements in donate page JavaScript

### DIFF
--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -185,18 +185,29 @@ document.querySelectorAll('.btn-clipboard').forEach(function (el) {
 })();
 
 // Update donate button text on fundraising page based on interval selection
-document
-  .querySelector('#donate #id_interval')
-  .addEventListener('change', function () {
+(function () {
+  const el = document.querySelector('#donate #id_interval');
+
+  if (!el) {
+    return;
+  }
+
+  el.addEventListener('change', function () {
     const text = this.value === 'onetime' ? 'Donate' : `Donate ${this.value}`;
 
     document.getElementById('donate-button').value = text;
   });
+})();
 
 // Manage custom donation amount input on fundraising page
-document
-  .querySelector('#donate #id_amount')
-  .addEventListener('change', function () {
+(function () {
+  const el = document.querySelector('#donate #id_amount');
+
+  if (!el) {
+    return;
+  }
+
+  el.addEventListener('change', function () {
     if (this.value !== 'custom') {
       return;
     }
@@ -216,3 +227,4 @@ document
     input_el.focus();
     input_el.value = '25';
   });
+})();


### PR DESCRIPTION
This patch ensures that `addEventListener` will not be called on `null`, which generates a JavaScript error. This approach already exists in the file.

Thankfully the error is inert since any page it will be thrown on doesn't need the remainder of the code in `djangoproject.js` to be run.