### PR TITLE
Improve displaying of images in blog entries

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3576,3 +3576,13 @@ ul.corporate-members li {
         }
     }
 }
+
+.blog {
+    .blog-entry-body {
+        img {
+            max-width: 100%;
+            display: block;
+            margin: auto;
+        }
+    }
+}

--- a/djangoproject/templates/base_weblog.html
+++ b/djangoproject/templates/base_weblog.html
@@ -15,6 +15,8 @@
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url 'weblog-feed' %}" />
 {% endblock %}
 
+{% block body_class %}blog{% endblock %}
+
 {% block content-related %}
   <div role="complementary">
     <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>

--- a/djangoproject/templates/blog/entry_detail.html
+++ b/djangoproject/templates/blog/entry_detail.html
@@ -11,8 +11,10 @@
 {% block content %}
     <h1>{{ object.headline|safe }}</h1>
 
-    <span class="meta">{% blocktranslate trimmed with author=object.author pub_date=object.pub_date|date:"DATE_FORMAT" %}
-        Posted by <strong>{{ author }}</strong> on {{ pub_date }} </span>
-    {% endblocktranslate %}
-        {{ object.body_html|safe }}
+    <span class="meta">
+        {% blocktranslate trimmed with author=object.author pub_date=object.pub_date|date:"DATE_FORMAT" %}
+            Posted by <strong>{{ author }}</strong> on {{ pub_date }}
+        {% endblocktranslate %}
+    </span>
+    {{ object.body_html|safe }}
 {% endblock %}

--- a/djangoproject/templates/blog/entry_detail.html
+++ b/djangoproject/templates/blog/entry_detail.html
@@ -16,5 +16,5 @@
             Posted by <strong>{{ author }}</strong> on {{ pub_date }}
         {% endblocktranslate %}
     </span>
-    {{ object.body_html|safe }}
+    <div class="blog-entry-body">{{ object.body_html|safe }}</div>
 {% endblock %}


### PR DESCRIPTION
This PR adds some CSS classes so that we're able to target images inside blog entries.

Then it adds two rules for images:

1) A `max-width: 100%` which prevents images from bleeding outside of the content
2) A `display: block` combined with `margin-left/right: auto` so that images smaller than the width are centered horizontally.

<details>
<summary>Screenshot before</summary>

![Screenshot 2025-04-09 at 21-19-27 Test image sizing Weblog Django](https://github.com/user-attachments/assets/dfd11970-82b0-40e2-93b2-8e506452e935)


</details>

<details>
<summary>Screenshot after</summary>

![Screenshot 2025-04-09 at 22-08-07 Test image sizing Weblog Django](https://github.com/user-attachments/assets/df67cb3d-de86-4383-a71f-755f85bf2668)


</details>