### PR TITLE
Update the fundraising goal amount from $200,000 to $300,000

### DIFF
--- a/fundraising/models.py
+++ b/fundraising/models.py
@@ -11,7 +11,7 @@ from sorl.thumbnail import ImageField
 
 from djangoproject.thumbnails import LogoThumbnailMixin
 
-GOAL_AMOUNT = Decimal("200000.00")
+GOAL_AMOUNT = Decimal("300000.00")
 GOAL_START_DATE = datetime.date(datetime.datetime.today().year, 1, 1)
 DISPLAY_DONOR_DAYS = 365
 DEFAULT_DONATION_AMOUNT = 50


### PR DESCRIPTION
This is per the fundraising working group’s discussions. The amount is pretty arbitrary, we just know we want more funding this year, so +100k felt like a reasonable place to aim.

The only place this figure is used is on the [fundraising page](https://www.djangoproject.com/fundraising/), to display the absolute goal amount and % towards completion.

---

Note I haven’t tested this change. As far as I can see looking at the code this seems pretty safe to change the figure of.