### PR TITLE
Fixed escaping of alt text in ContentFormat.img()

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -1,4 +1,3 @@
-import re
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -25,25 +24,10 @@ BLOG_DOCUTILS_SETTINGS = {
 }
 BLOG_DOCUTILS_SETTINGS.update(getattr(settings, "BLOG_DOCUTILS_SETTINGS", {}))
 
-# List copied from:
-# https://github.com/Python-Markdown/markdown/blob/3.8/markdown/core.py#L112
-_MD_ESCAPE_CHARS = "\\`*_{}[]>()#+-.!"
-_MD_ESCAPE_REGEX = re.compile(f"[{re.escape(_MD_ESCAPE_CHARS)}]")
-
 
 def _md_slugify(value, separator):
     # matches the `id_prefix` setting of BLOG_DOCUTILS_SETTINGS
     return "s" + separator + _md_title_slugify(value, separator)
-
-
-def _md_escape(s):
-    # Add a backslash \ before any reserved characters
-    return _MD_ESCAPE_REGEX.sub(r"\\\g<0>", s)
-
-
-def _rst_escape(s):
-    # New lines mess up rst, it's easier to replace them with spaces.
-    return s.replace("\n", " ")
 
 
 class EntryQuerySet(models.QuerySet):
@@ -89,9 +73,9 @@ class ContentFormat(models.TextChoices):
         """
         CF = type(self)
         return {
-            CF.REST: f".. image:: {url}\n   :alt: {_rst_escape(alt_text)}",
+            CF.REST: f".. image:: {url}\n   :alt: {alt_text}",
             CF.HTML: format_html('<img src="{}" alt="{}">', url, alt_text),
-            CF.MARKDOWN: f"![{_md_escape(alt_text)}]({url})",
+            CF.MARKDOWN: f"![{alt_text}]({url})",
         }[self]
 
 

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -326,7 +326,6 @@ class ImageUploadTestCase(TestCase):
             (ContentFormat.REST, "test-", '<img src="." alt="test-">'),
             (ContentFormat.REST, "test.", '<img src="." alt="test.">'),
             (ContentFormat.REST, "test!", '<img src="." alt="test!">'),
-            (ContentFormat.REST, "te\nst", '<img src="." alt="te st">'),
         ]
         for cf, alt_text, expected in testdata:
             # RST doesn't like an empty src, so we use . instead

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -297,3 +297,44 @@ class ImageUploadTestCase(TestCase):
             r"http://www\.djangoproject\.localhost:8000"
             r"/m/blog/images/2005/07/test(_\w+)?\.png",
         )
+
+    def test_alt_text_html_escape(self):
+        testdata = [
+            (ContentFormat.HTML, 'te"st', '<img src="." alt="te&quot;st">'),
+            (ContentFormat.HTML, "te<st>", '<img src="." alt="te&lt;st&gt;">'),
+            (ContentFormat.MARKDOWN, 'te"st', '<img src="." alt="te&quot;st">'),
+            (ContentFormat.MARKDOWN, "te[st]", '<img src="." alt="te[st]">'),
+            (ContentFormat.MARKDOWN, "te{st}", '<img src="." alt="te{st}">'),
+            (ContentFormat.MARKDOWN, "te<st>", '<img src="." alt="te&lt;st&gt;">'),
+            (ContentFormat.MARKDOWN, "test*", '<img src="." alt="test*">'),
+            (ContentFormat.MARKDOWN, "test_", '<img src="." alt="test_">'),
+            (ContentFormat.MARKDOWN, "test`", '<img src="." alt="test`">'),
+            (ContentFormat.MARKDOWN, "test+", '<img src="." alt="test+">'),
+            (ContentFormat.MARKDOWN, "test-", '<img src="." alt="test-">'),
+            (ContentFormat.MARKDOWN, "test.", '<img src="." alt="test.">'),
+            (ContentFormat.MARKDOWN, "test!", '<img src="." alt="test!">'),
+            (ContentFormat.MARKDOWN, "te\nst", '<img src="." alt="te\nst">'),
+            (ContentFormat.REST, 'te"st', '<img src="." alt="te&quot;st">'),
+            (ContentFormat.REST, "te[st]", '<img src="." alt="te[st]">'),
+            (ContentFormat.REST, "te{st}", '<img src="." alt="te{st}">'),
+            (ContentFormat.REST, "te<st>", '<img src="." alt="te&lt;st&gt;">'),
+            (ContentFormat.REST, "te:st", '<img src="." alt="te:st">'),
+            (ContentFormat.REST, "test*", '<img src="." alt="test*">'),
+            (ContentFormat.REST, "test_", '<img src="." alt="test_">'),
+            (ContentFormat.REST, "test`", '<img src="." alt="test`">'),
+            (ContentFormat.REST, "test+", '<img src="." alt="test+">'),
+            (ContentFormat.REST, "test-", '<img src="." alt="test-">'),
+            (ContentFormat.REST, "test.", '<img src="." alt="test.">'),
+            (ContentFormat.REST, "test!", '<img src="." alt="test!">'),
+            (ContentFormat.REST, "te\nst", '<img src="." alt="te st">'),
+        ]
+        for cf, alt_text, expected in testdata:
+            # RST doesn't like an empty src, so we use . instead
+            img_tag = cf.img(url=".", alt_text=alt_text)
+            if cf is ContentFormat.MARKDOWN:
+                expected = f"<p>{expected}</p>"
+            with self.subTest(cf=cf, alt_text=alt_text):
+                self.assertHTMLEqual(
+                    ContentFormat.to_html(cf, img_tag),
+                    expected,
+                )


### PR DESCRIPTION
This should fix #2035 and also address escaping issues in the other formats (markdown and restructured text).