### PR TITLE
Fixed styling of buttons leaking to Debug Toolbar

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2822,7 +2822,7 @@ search.filters {
 }
 
 //------------------- Forms
-form {
+form:not(#djDebug form) {
     @include sans-serif;
     @include font-size(16);
 


### PR DESCRIPTION
This isn't a 100% fix, but it takes care of the buttons at least. I guess we could go and spread some `:not(#djDebug *)` all over our CSS, but I'm not sure that's a really sustainable solution (plus it might have a performance cost that could add up).

## Screenshots:

<details>
<summary>Before</summary>

![Screenshot 2025-04-18 at 20-49-34 The web framework for perfectionists with deadlines Django](https://github.com/user-attachments/assets/06531daf-f6db-433b-a389-dd299e971e8e)


</details>

<details>
<summary>After</summary>

![Screenshot 2025-04-18 at 20-48-57 The web framework for perfectionists with deadlines Django](https://github.com/user-attachments/assets/b9537188-f1d9-4124-8c9b-ea1aa1a732b5)


</details>