### PR TITLE
[docs] Fixed stable symlink not updating when changed

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -369,7 +369,9 @@ class Command(BaseCommand):
         """
         stable = built_dir / "stable"
         target = built_dir / release.version
-        stable.symlink_to(target, target_is_directory=True)
+        if stable.resolve() != target:  # Symlink is either missing or has changed
+            stable.unlink(missing_ok=True)
+            stable.symlink_to(target, target_is_directory=True)
 
 
 def gen_decoded_documents(directory):


### PR DESCRIPTION
This was the cause of #2027 (which I resolved by changing the symlink manually at the time).

With this change the manual update is not needed anymore and the `stable` symlink will be updated automatically (as intended) when a new major version of Django is released.