### PR TITLE
Use labels instead of placeholders on contact form

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -17,21 +17,20 @@ logger = logging.getLogger(__name__)
 class BaseContactForm(ContactForm):
     message_subject = forms.CharField(
         max_length=100,
-        widget=forms.TextInput(
-            attrs={"class": "required", "placeholder": _("Message subject")}
-        ),
+        widget=forms.TextInput(attrs={"class": "required"}),
         label=_("Message subject"),
     )
     email = forms.EmailField(
-        widget=forms.TextInput(attrs={"class": "required", "placeholder": _("E-mail")})
+        widget=forms.TextInput(attrs={"class": "required"}),
+        label=_("E-mail"),
     )
     name = forms.CharField(
-        widget=forms.TextInput(attrs={"class": "required", "placeholder": _("Name")})
+        widget=forms.TextInput(attrs={"class": "required"}),
+        label=_("Name"),
     )
     body = forms.CharField(
-        widget=forms.Textarea(
-            attrs={"class": "required", "placeholder": _("Your message")}
-        )
+        widget=forms.Textarea(attrs={"class": "required"}),
+        label=_("Your message"),
     )
     captcha = ReCaptchaField(widget=ReCaptchaV3)
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1334,6 +1334,17 @@ a.cta {
     }
 }
 
+label[for] {
+  font-weight: bold;
+}
+
+.errorlist {
+  color: var(--error-fg);
+  background-color: var(--error-light-l10);
+  border-radius: .3em;
+  margin: 10px 0;
+}
+
 .callout-right {
     @include respond-min(768px) {
         float: right;

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -31,27 +31,19 @@
   </p>
   <form action="." method="post" accept-charset="utf-8" class="form-input">
     {% csrf_token %}
-    <p>
-      {{ form.name.label_tag }}
-      {% if form.name.errors %}<p class="errors">{{ form.name.errors.as_text }}</p>{% endif %}
-      {{ form.name }}
-    </p>
-    <p class="form-email">
-      {{ form.email.label_tag }}
-      {% if form.email.errors %}<p class="errors">{{ form.email.errors.as_text }}</p>{% endif %}
-      {{ form.email }}
-    </p>
-    <p>
-      {{ form.message_subject.label_tag }}
-      {% if form.message_subject.errors %}<p class="errors">{{ form.message_subject.errors.as_text }}</p>{% endif %}
-      {{ form.message_subject }}
-    </p>
-    <p>
-      {{ form.body.label_tag }}
-      {% if form.body.errors %}<p class="errors">{{ form.body.errors.as_text }}</p>{% endif %}
-      {{ form.body }}
-    </p>
-    <p>{{ form.captcha }}</p>
+    <div>
+      {{ form.name.as_field_group }}
+    </div>
+    <div>
+      {{ form.email.as_field_group }}
+    </div>
+    <div>
+      {{ form.message_subject.as_field_group }}
+    </div>
+    <div>
+      {{ form.body.as_field_group }}
+    </div>
+    {{ form.captcha }}
     <p class="submit"><input type="submit" class="cta" value="{% translate "Send &rarr;" %}"></p>
   </form>
 {% endblock %}

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -32,22 +32,22 @@
   <form action="." method="post" accept-charset="utf-8" class="form-input">
     {% csrf_token %}
     <p>
-      <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+      {{ form.name.label_tag }}
       {% if form.name.errors %}<p class="errors">{{ form.name.errors.as_text }}</p>{% endif %}
       {{ form.name }}
     </p>
     <p class="form-email">
-      <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
+      {{ form.email.label_tag }}
       {% if form.email.errors %}<p class="errors">{{ form.email.errors.as_text }}</p>{% endif %}
       {{ form.email }}
     </p>
     <p>
-      <label for="{{ form.message_subject.id_for_label }}">{{ form.message_subject.label }}</label>
+      {{ form.message_subject.label_tag }}
       {% if form.message_subject.errors %}<p class="errors">{{ form.message_subject.errors.as_text }}</p>{% endif %}
       {{ form.message_subject }}
     </p>
     <p>
-      <label for="{{ form.body.id_for_label }}">{{ form.body.label }}</label>
+      {{ form.body.label_tag }}
       {% if form.body.errors %}<p class="errors">{{ form.body.errors.as_text }}</p>{% endif %}
       {{ form.body }}
     </p>

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -32,18 +32,22 @@
   <form action="." method="post" accept-charset="utf-8" class="form-input">
     {% csrf_token %}
     <p>
+      <label for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
       {% if form.name.errors %}<p class="errors">{{ form.name.errors.as_text }}</p>{% endif %}
       {{ form.name }}
     </p>
     <p class="form-email">
+      <label for="{{ form.email.id_for_label }}">{{ form.email.label }}</label>
       {% if form.email.errors %}<p class="errors">{{ form.email.errors.as_text }}</p>{% endif %}
       {{ form.email }}
     </p>
     <p>
+      <label for="{{ form.message_subject.id_for_label }}">{{ form.message_subject.label }}</label>
       {% if form.message_subject.errors %}<p class="errors">{{ form.message_subject.errors.as_text }}</p>{% endif %}
       {{ form.message_subject }}
     </p>
     <p>
+      <label for="{{ form.body.id_for_label }}">{{ form.body.label }}</label>
       {% if form.body.errors %}<p class="errors">{{ form.body.errors.as_text }}</p>{% endif %}
       {{ form.body }}
     </p>


### PR DESCRIPTION
This PR to add the bare minimum of accessibility on the form to contact the DSF.

Basically, display labels in dedicated `label`s instead of using the `placeholder` attribute.

That helps:

- users of screenreaders who rely on "accessible labels" for knowing what is expected;
- users with some attention or cognition disorders who need to *see* what is expected while they are typing content in the field.

When I'll have the whole "translation" part figured out I will try to fix the send button label (`"Send &rarr;"`). Ideally I would like to have the `&rarr;` in an span with aria-hidden=true because it is decorative.

![Screenshot 2025-04-26 at 11-59-07 Contact the Django Software Foundation Django](https://github.com/user-attachments/assets/d5d979c2-516f-49f2-9f61-2058e9a62ad4)
