### PR TITLE
Supported passing alternate database names via environment

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -33,7 +33,7 @@ CACHE_MIDDLEWARE_KEY_PREFIX = "django"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "djangoproject",
+        "NAME": os.getenv("DJANGO_DB_NAME", "djangoproject"),
         "USER": SECRETS.get("db_user", "djangoproject"),
         "HOST": SECRETS.get("db_host", ""),
         "PASSWORD": SECRETS.get("db_password", ""),
@@ -41,7 +41,7 @@ DATABASES = {
     },
     "trac": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "code.djangoproject",
+        "NAME": os.getenv("TRAC_DB_NAME", "code.djangoproject"),
         "USER": SECRETS.get("trac_db_user", "code.djangoproject"),
         "HOST": SECRETS.get("trac_db_host", ""),
         "PASSWORD": SECRETS.get("trac_db_password", ""),

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -2,6 +2,15 @@ from .common import *  # noqa
 
 DOMAIN_NAME = os.getenv("DOMAIN_NAME", "djangoproject.com")
 
+# Protect against accidentally not setting DJANGO_DB_NAME environment variable
+if (
+    DOMAIN_NAME != "djangoproject.com"
+    and DATABASES["default"]["NAME"] == "djangoproject"
+):
+    raise ValueError(
+        f"You must set DJANGO_DB_NAME to the database name for {DOMAIN_NAME}."
+    )
+
 ALLOWED_HOSTS = [
     f"www.{DOMAIN_NAME}",
     DOMAIN_NAME,

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -2,14 +2,8 @@ from .common import *  # noqa
 
 DOMAIN_NAME = os.getenv("DOMAIN_NAME", "djangoproject.com")
 
-# Protect against accidentally not setting DJANGO_DB_NAME environment variable
-if (
-    DOMAIN_NAME != "djangoproject.com"
-    and DATABASES["default"]["NAME"] == "djangoproject"
-):
-    raise ValueError(
-        f"You must set DJANGO_DB_NAME to the database name for {DOMAIN_NAME}."
-    )
+if not os.getenv("DJANGO_DB_NAME"):
+    raise ValueError("You must set DJANGO_DB_NAME in deployed environments.")
 
 ALLOWED_HOSTS = [
     f"www.{DOMAIN_NAME}",


### PR DESCRIPTION
This PR Adds support for an alternate database for the staging/preview domain, https://preview.djangoproject.com/.