### PR TITLE
Added banner to differentiate preview.djangoproject.com

### DIFF
--- a/djangoproject/context_processors.py
+++ b/djangoproject/context_processors.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+
+
+def display_preview_banner(request):
+    """
+    Determines if a banner should be displayed to help the website teams
+    distinguish between the preview and production sites. The banner is
+    based on the domain name configured in settings, if any, and will
+    appear on https://*.preview.djangoproject.com/ (but not
+    https://*.djangoproject.com/).
+    """
+    domain_name = getattr(settings, "DOMAIN_NAME", "djangoproject.com")
+    return {
+        "DISPLAY_PREVIEW_BANNER": domain_name != "djangoproject.com",
+    }

--- a/djangoproject/context_processors.py
+++ b/djangoproject/context_processors.py
@@ -7,9 +7,11 @@ def display_preview_banner(request):
     distinguish between the preview and production sites. The banner is
     based on the domain name configured in settings, if any, and will
     appear on https://*.preview.djangoproject.com/ (but not
-    https://*.djangoproject.com/).
+    https://*.djangoproject.com/ nor in local development).
     """
-    domain_name = getattr(settings, "DOMAIN_NAME", "djangoproject.com")
+    production_tld = "djangoproject.com"
+    # Note: DOMAIN_NAME is not defined in local development
+    domain_name = getattr(settings, "DOMAIN_NAME", production_tld)
     return {
-        "DISPLAY_PREVIEW_BANNER": domain_name != "djangoproject.com",
+        "DISPLAY_PREVIEW_BANNER": domain_name != production_tld,
     }

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -209,6 +209,7 @@ TEMPLATES = [
                 "docs.context_processors.docs_version",
                 "releases.context_processors.django_version",
                 "aggregator.context_processors.community_stats",
+                "djangoproject.context_processors.display_preview_banner",
                 "django.template.context_processors.request",
             ],
         },

--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -1,3 +1,6 @@
+{% if DISPLAY_PREVIEW_BANNER %}
+  <div class="copy-banner" style="background: #fff78e; padding: 10px;"></div>
+{% endif %}
 <header id="top">
   <div class="container container--flex--wrap--mobile">
     <a class="logo" href="{% url 'homepage' %}">Django</a>


### PR DESCRIPTION
Adds a subtle yellow banner to the top of the preview site to help differentiate it from production.

Test by adding `DOMAIN_NAME = "anything.djangoproject.com"` to `settings/dev.py`:

<img width="1143" alt="Screenshot 2025-04-26 at 3 59 08 PM" src="https://github.com/user-attachments/assets/f0d8ae0e-d168-4bd7-bc62-44d0b6fc939b" />
