### PR TITLE
Add .well-known/security.txt file

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,10 @@
+Policy: https://www.djangoproject.com/security/
+Contact: https://www.djangoproject.com/security/
+Expires: 2026-12-31T00:00:00.000Z
+Encryption: https://keys.openpgp.org/vks/v1/by-fingerprint/AF3516D27D0621171E0CCE25FCB84B8D1D17F80B
+Preferred-Languages: en
+
+# Hello security researcher!
+# We appreciate your help in keeping Django secure.
+# Please report security issues that concern the Django website (djangoproject.com) to ops@djangoproject.com
+# This helps us make sure your report is seen by the right people.

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timedelta
 from http import HTTPStatus
 from io import StringIO
 
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import NoReverseMatch, get_resolver
@@ -164,3 +166,40 @@ class Header1Tests(TestCase):
                     response = self.client.get(url)
                     self.assertEqual(response.status_code, 200)
                     self.assertContains(response, "<h1", count=1)
+
+
+class SecurityTxtFileTests(TestCase):
+    """
+    Tests for the security.txt file.
+    """
+
+    def test_security_txt_not_expired(self):
+        """
+        The security.txt file should not be expired.
+        """
+        FILE_PATH = settings.BASE_DIR / ".well-known" / "security.txt"
+        with open(FILE_PATH) as f:
+            content = f.read()
+            # Read the line that starts with "Expires:", and parse the date.
+            for line in content.splitlines():
+                if line.startswith("Expires:"):
+                    expires = line.strip("Expires: ")
+                    break
+            else:
+                self.fail("No Expires line found in security.txt")
+
+            expires_date = datetime.strptime(
+                expires,
+                "%Y-%m-%dT%H:%M:%S.%fZ",
+            ).date()
+            # We should ideally be two weeks early with updating - active over reactive
+            cutoff = (datetime.now() - timedelta(days=15)).date()
+            self.assertGreater(
+                expires_date,
+                cutoff,
+                "The security.txt file is close to expiring. \
+Please update the 'Expires' line in to confirm the contents are \
+still accurate: {}".format(
+                    FILE_PATH
+                ),
+            )


### PR DESCRIPTION
This is a PR for an action I took as member of the Website working group, see meeting notes here: https://forum.djangoproject.com/t/website-team-meeting-notes/40655

---

I spoke with @bmispelon yesterday during Wagtail Office Hours and he mentioned we can serve static files like this through a nginx rule which are controlled by the ops team. We apparently already do this for other 'static' content files. This has yet to be set up.

I chose to put this in a .well-known folder in the project root for visibility.

Consider the contents of the security.txt file an initial draft and open to discussion.

