### PR TITLE
Added the DSF board meeting link

### DIFF
--- a/djangoproject/templates/foundation/meeting_archive.html
+++ b/djangoproject/templates/foundation/meeting_archive.html
@@ -11,6 +11,11 @@
 {% block content %}
   <h1>{% translate "Meeting minutes archive" %}</h1>
 
+  <div class="alert alert-info">
+    <strong>Note:</strong> DSF board meeting minutes from May 2025 onwards are stored in our public GitHub repository:
+    <a href="https://github.com/django/dsf-minutes" target="_blank" rel="noopener">https://github.com/django/dsf-minutes</a>
+  </div>
+
   <p>{% translate "Select a year to view meeting minutes:" %}</p>
 
   <ul>

--- a/djangoproject/templates/foundation/meeting_archive_month.html
+++ b/djangoproject/templates/foundation/meeting_archive_month.html
@@ -7,6 +7,11 @@
 {% block content %}
   <h1>{% blocktranslate with month=month|date:"F, Y" %}Meeting minutes archive: {{ month }}{% endblocktranslate %}</h1>
 
+  <div class="alert alert-info">
+    <strong>Note:</strong> DSF board meeting minutes from May 2025 onwards are stored in our public GitHub repository:
+    <a href="https://github.com/django/dsf-minutes" target="_blank" rel="noopener">https://github.com/django/dsf-minutes</a>
+  </div>
+
   <ul>
     {% for meeting in object_list %}
       <li><a href="{{ meeting.get_absolute_url }}">{{ meeting }}</a></li>

--- a/djangoproject/templates/foundation/meeting_archive_year.html
+++ b/djangoproject/templates/foundation/meeting_archive_year.html
@@ -7,6 +7,11 @@
 {% block content %}
   <h1>{% blocktranslate with year=year|date:"Y" %}Meeting minutes archive: {{ year }}{% endblocktranslate %}</h1>
 
+  <div class="alert alert-info">
+    <strong>Note:</strong> DSF board meeting minutes from May 2025 onwards are stored in our public GitHub repository:
+    <a href="https://github.com/django/dsf-minutes" target="_blank" rel="noopener">https://github.com/django/dsf-minutes</a>
+  </div>
+
   <ul>
     {% for meeting in object_list %}
       <li><a href="{{ meeting.get_absolute_url }}">{{ meeting }}</a></li>

--- a/djangoproject/templates/foundation/meeting_detail.html
+++ b/djangoproject/templates/foundation/meeting_detail.html
@@ -9,6 +9,11 @@
 
   <h1>{{ meeting }}</h1>
 
+  <div class="alert alert-info">
+    <strong>Note:</strong> DSF board meeting minutes from May 2025 onwards are stored in our public GitHub repository:
+    <a href="https://github.com/django/dsf-minutes" target="_blank" rel="noopener">https://github.com/django/dsf-minutes</a>
+  </div>
+
   <p>
     {% blocktranslate trimmed with name=meeting.leader.account.get_full_name %}
       The meeting was led by {{ name }}.


### PR DESCRIPTION
I have added the note and the link for the new DSF board meeting. I made changes to 4 files which includes **meeting_archive_month.html** , **meeting_archive_year.html** , **meeting_archive.html** and **meeting_detail.html**