### PR TITLE
Simplified cache usage in `accounts` view helper

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,7 +2,7 @@ import hashlib
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django.core.cache import caches
+from django.core.cache import cache
 from django.shortcuts import get_object_or_404, redirect, render
 
 from tracdb import stats as trac_stats
@@ -35,10 +35,9 @@ def edit_profile(request):
 
 
 def get_user_stats(user):
-    c = caches["default"]
     username = user.username.encode("ascii", "ignore")
     key = "user_vital_status:%s" % hashlib.md5(username).hexdigest()
-    info = c.get(key)
+    info = cache.get(key)
     if info is None:
         info = trac_stats.get_user_stats(user.username)
         # Hide any stat with a value = 0 so that we don't accidentally insult
@@ -46,5 +45,5 @@ def get_user_stats(user):
         for k, v in list(info.items()):
             if v.count == 0:
                 info.pop(k)
-        c.set(key, info, 60 * 60)
+        cache.set(key, info, 60 * 60)
     return info


### PR DESCRIPTION
Importing `cache` instead of `caches` uses the default cache: https://docs.djangoproject.com/en/5.2/topics/cache/#django.core.cache.cache

Let me know if the test could be improved. I noticed that the caching behavior wasn't covered.