### PR TITLE
Added Fellow call for applicant banner.

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -49,6 +49,7 @@
 
     <a href="#main-content" class="skip-link">Skip to main content</a>
     {% include "includes/header.html" %}
+    {% block banner %}{% endblock %}
 
     <section class="copy-banner">
       <div class="container {% block header-classes %}{% endblock %}">

--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -5,6 +5,14 @@
 {% block body_class %}homepage{% endblock %}
 {% block layout_class %}column-container sidebar-right{% endblock %}
 
+{% block banner %}
+  <section class="copy-banner" style="background: #44B78B; padding: 4px;">
+    <div class="container">
+      <p><a href="https://www.djangoproject.com/weblog/2025/jun/09/django-fellow-applicants-2025/">DSF calls for applicants for a Django Fellow, deadline July 1!</a></p>
+    </div>
+  </section>
+{% endblock %}
+
 {% block header %}
   <p>
     <em>{% translate "Django makes it easier to build better web apps more quickly and with less code." %}</em>

--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -10,7 +10,15 @@
 {% endblock %}
 
 {% block header %}
-  <p><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></p>
+  {% comment %}
+    <p><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></p>
+  {% endcomment %}
+  <p>
+    <a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a> &ndash;
+    <a href="https://www.djangoproject.com/weblog/2025/jun/09/django-fellow-applicants-2025/">
+      DSF calls for applicants for a Django Fellow, deadline July 1!
+    </a>
+  </p>
   {% search_form %}
 {% endblock %}
 


### PR DESCRIPTION
Homepage:

![image](https://github.com/user-attachments/assets/fe0aa393-a2c8-4fab-ae3b-3e49a2549780)


Documentation:

![Screenshot from 2025-06-11 11-24-06](https://github.com/user-attachments/assets/8d67d58d-9424-47fe-b4cd-381e104f5c9f)

------

Note that we can put it in more places but I think this is a reasonable start
This idea came from @knyghty when I mentioned that blog articles can get "lost" if we have several posts
