### PR TITLE
Speed up initial docs generation by setting the git clone depth to 1.

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -358,7 +358,17 @@ class Command(BaseCommand):
                 os.chdir(cwd)
         else:
             subprocess.check_call(
-                ["git", "clone", "--depth", "1", "--branch", branch, repo, str(destdir), quiet],
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    branch,
+                    repo,
+                    str(destdir),
+                    quiet,
+                ],
                 stderr=sys.stdout,
             )
         return True

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -358,7 +358,7 @@ class Command(BaseCommand):
                 os.chdir(cwd)
         else:
             subprocess.check_call(
-                ["git", "clone", "--branch", branch, repo, str(destdir), quiet],
+                ["git", "clone", "--depth", "1", "--branch", branch, repo, str(destdir), quiet],
                 stderr=sys.stdout,
             )
         return True


### PR DESCRIPTION
For the docs generation on a new setup, which is when the .git folder doesn't exist, there's no need to clone the entire repo history. 
Setting the clone depth to 1 and just pulling the last commit, speeds the initial clone process quite a bit.

This shouldn't change anything for existing docs setups.