### PR TITLE
Make secrets.json not being found an explicit error when DJANGOPROJECT_DATA_DIR is set

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -14,15 +14,8 @@ DATA_DIR = (
     Path(os.environ[data_dir_key]) if data_dir_key in os.environ else BASE_DIR.parent
 )
 
-try:
-    with (DATA_DIR / "conf" / "secrets.json").open() as handle:
-        SECRETS = json.load(handle)
-except OSError:
-    SECRETS = {
-        "secret_key": "a",
-        "superfeedr_creds": ["any@email.com", "some_string"],
-    }
-
+with (DATA_DIR / "conf" / "secrets.json").open() as handle:
+    SECRETS = json.load(handle)
 
 # Django settings
 


### PR DESCRIPTION
While helping someone setup the website in their system, they faced an issue in which the `secrets.json` file wasn't found, and they had `DJANGOPROJECT_DATA_DIR` env var set (but the `secrets.json` was on a different directory).

The instructions tell you to have this on your bashrc/zshrc export `DJANGOPROJECT_DATA_DIR=~/.djangoproject`, and if set, expect a `~/.djangoproject/conf/secrets.json`.
In fact there's a fallback for that but only in the env variable is not set, which the instructions never tell you about.

Removing the `DJANGOPROJECT_DATA_DIR` would require coordination with operations to make sure it doesn't break their setup, so for now I'd just make it error explicitly if the `secrets.json` file is not found, which is a good initial step.

I think there's a case in which this breaks an existing working local setup, which requires the following conditions:
1. The env var `DJANGOPROJECT_DATA_DIR` is set to a path that doesn't contain `secrets.json`. Note that the website can work without `DJANGOPROJECT_DATA_DIR` being set at all.
2. The local postgres is set up to use **exactly** the defaults set in `DATABASES`. Any difference will mean it will raise an error when trying to execute Django.