### PR TITLE
Add link to 'Stable' doc version in the Warning Alert on top

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -47,7 +47,11 @@
     </div>
   {% elif not release.is_supported %}
     <div id="outdated-warning" class="doc-floating-warning">
-      {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
+      {% trans "This document is for an insecure version of Django that is no longer supported. Please click "%}
+      <a href="{% url 'document-detail' lang='en' version='stable' url='intro/install' host 'docs' %}">
+        {% trans "here" %}
+      </a>
+      {% trans " for the latest version."%}
     </div>
   {% endif %}
 {% endblock body_extra %}


### PR DESCRIPTION
Resolves https://github.com/django/djangoproject.com/issues/2094

![CleanShot 2025-06-17 at 16 23 53@2x](https://github.com/user-attachments/assets/32d57d33-c207-4186-9a29-db1ca535234d)

I copied the link from "Installation guide" link on the sidebar, please let me know if we prefer a different target for the link.

![CleanShot 2025-06-17 at 16 28 53@2x](https://github.com/user-attachments/assets/88f37e25-4b12-4bbb-a7b6-ffcb6f6b2ed9)


I'm open to suggestions about wording and styling.