### PR TITLE
Add link to latest documentation in version warning banner

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -38,7 +38,10 @@
   {% if release.is_dev %}
     {% if "internals" not in docurl %}{# The dev version is canonical for internals/. #}
       <div id="dev-warning" class="doc-floating-warning">
-        {% trans "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
+      {% blocktrans trimmed %}
+      This document is for Django's development version, which can be significantly different from previous releases.
+        <a href="https://docs.djangoproject.com/en/stable/" style="font-weight : bold; text-decoration: underline;"> Click here for the stable version </a>
+        {% endblocktrans %}
       </div>
     {% endif %}
   {% elif release.is_preview %}


### PR DESCRIPTION
Ticket: [#2904]

Before (Current Behavior)
The warning banner at the top of the documentation pages only notifies the user that they’re viewing an outdated version, without offering a direct link to the latest version.

After (Proposed Enhancement)
The warning banner now includes a clickable link that takes the user directly to the latest documentation version, providing:

Better user experience by reducing friction.

A simple, visible, and actionable way to access the updated docs.

 Implementation Notes
Updated docs.html to include an anchor tag in the warning banner.

Used Django template syntax to dynamically resolve the correct "latest" version link.


![Screenshot From 2025-06-18 14-29-55](https://github.com/user-attachments/assets/4e79bf85-dc99-48e8-8a50-2a661295a273)
