### PR TITLE
Add warning for outdated Django versions with link to latest stable r…

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -46,8 +46,11 @@
       {% trans "This document is for a preview release of Django, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
     </div>
   {% elif not release.is_supported %}
+    {% url 'document-detail' lang='en' version='stable' url=docurl host='docs' as latest_url %}
     <div id="outdated-warning" class="doc-floating-warning">
-      {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
+      {% blocktrans with link='<a href="'|add:latest_url|add:'">here</a>'|safe %}
+        This document is for an insecure version of Django that is no longer supported. Please click {{ link }} for the latest version.
+      {% endblocktrans %}
     </div>
   {% endif %}
 {% endblock body_extra %}


### PR DESCRIPTION
This pull request addresses [Issue #2094](https://github.com/django/djangoproject.com/issues/2094) by updating the outdated version warning displayed on unsupported Django documentation pages.

What’s changed:

Replaced the static text warning shown for unsupported Django versions with a message that includes a clickable "here" link.

The link dynamically points to the same page in the latest stable version of the documentation using Django’s {% url %} template tag and docurl.

Used {% blocktrans with %} and |safe to preserve full translation compatibility while safely inserting the <a> element.

New behavior:

This document is for an insecure version of Django that is no longer supported. Please click [here](https://docs.djangoproject.com/en/stable/...) for the latest version.

This improves usability for readers who land on older pages and ensures they can quickly access the correct, supported documentation.