### PR TITLE
Fix the link for django-browser-reload

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -96,7 +96,7 @@
   <h3>Debugging & Development Tools</h3>
   <ul>
     <li><a href="https://github.com/jazzband/django-debug-toolbar">Django Debug Toolbar</a> &mdash; A configurable set of panels that display various debug information about the current request/response.</li>
-    <li><a href="https://github.com/django-browser-reload/django-browser-reload">django-browser-reload</a> &mdash; Enables automatic browser reloading during development when code changes are detected.</li>
+    <li><a href="https://github.com/adamchainz/django-browser-reload">django-browser-reload</a> &mdash; Enables automatic browser reloading during development when code changes are detected.</li>
     <li><a href="https://github.com/django-extensions/django-extensions">Django Extensions</a> &mdash; A collection of custom extensions for Django, including management commands, model field types, and more.</li>
   </ul>
 


### PR DESCRIPTION
The current link yields a 404. I sourced the corrected URL from the [PyPI entry](https://pypi.org/project/django-browser-reload/) for the package.