### PR TITLE
Clean tox config

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: pre-commit
+
+on:
+    pull_request:
+    push:
+        branches: [main]
+
+jobs:
+    pre-commit:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+            - uses: pre-commit/action@v3.0.1

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,6 @@ compile-scss-debug:
 install:
 	python -m pip install --requirement requirements/dev.txt
 
-isort:
-	python -m isort $(APP_LIST)
-
-isort-check:
-	python -m isort --check $(APP_LIST)
-
 migrations-check:
 	python -m manage makemigrations --check --dry-run
 

--- a/README.rst
+++ b/README.rst
@@ -138,8 +138,7 @@ Then in the root directory (next to the ``manage.py`` file) run::
     tox
 
 Behind the scenes, this will run the usual ``python -m manage test`` management
-command with a preset list of apps that we want to test as well as
-`flake8 <https://flake8.readthedocs.io/>`_ for code quality checks. We
+command with a preset list of apps that we want to test. We
 collect test coverage data as part of that tox run, to show the result
 simply run::
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 -r common.txt
 django-debug-toolbar==5.2.0
-isort==6.0.1
 pre-commit~=4.2.0
 watchdog==6.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =py{312}-{tests,black,isort}
+envlist =py{312}-{tests,black}
 skipsdist = true
 
 [gh-actions]
@@ -11,10 +11,8 @@ allowlist_externals = make
 passenv = DJANGO_SETTINGS_MODULE
 deps =
     tests: -r{toxinidir}/requirements/tests.txt
-    isort: isort
 commands =
     tests: make ci
-    isort: make isort-check
 
 [testenv:black]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =py{312}-{tests,flake8,black,isort}
+envlist =py{312}-{tests,black,isort}
 skipsdist = true
 
 [gh-actions]
@@ -11,11 +11,9 @@ allowlist_externals = make
 passenv = DJANGO_SETTINGS_MODULE
 deps =
     tests: -r{toxinidir}/requirements/tests.txt
-    flake8: flake8
     isort: isort
 commands =
     tests: make ci
-    flake8: flake8
     isort: make isort-check
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =py{312}-{tests,black}
+envlist =py{312}-{tests}
 skipsdist = true
 
 [gh-actions]
@@ -13,10 +13,3 @@ deps =
     tests: -r{toxinidir}/requirements/tests.txt
 commands =
     tests: make ci
-
-[testenv:black]
-basepython = python3
-usedevelop = false
-deps = black
-changedir = {toxinidir}
-commands = black --check --diff .


### PR DESCRIPTION
Relates to #1890

Removes black, flake8, and isort from tox config. All of them are already handled by pre-commit.

About the new action;

I am a bit hesitant about using https://pre-commit.ci/ for pre-commit checks, for several reasons:
* It doesn't allow selecting which Python version to run pre-commit on
* Auto-fix commits create "fix typo" type of small - meaningless commits, which I believe is a bad practice.
* It's an external service that duplicates the functionality of GitHub Actions, but only for pre-commit.
* Has no configuration info in the repository

My vote here would be to disable that integration and continue with the action. I can revert the new action if the consensus is to not change it, but I wanted to include it because the cleaning in the PR makes the CI more dependent on pre-commit.
