### PR TITLE
Remove unnecessary limitation for allowed hosts in development environments

### DIFF
--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -1,11 +1,6 @@
 from .common import *  # noqa
 
-ALLOWED_HOSTS = [
-    "www.djangoproject.localhost",
-    "djangoproject.localhost",
-    "docs.djangoproject.localhost",
-    "dashboard.djangoproject.localhost",
-] + SECRETS.get("allowed_hosts", [])
+ALLOWED_HOSTS = ["*"]
 
 LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
 

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -13,8 +13,6 @@ DATABASES = {
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
-ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]
-
 LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
 
 # django-hosts settings


### PR DESCRIPTION
My original goal was to resolve the issue with the Docker setup and `0.0.0.0`.

<img width="2102" height="836" alt="CleanShot 2025-07-27 at 00 26 08@2x" src="https://github.com/user-attachments/assets/3c230639-1d40-4bcc-a069-f285f2da54dc" />

But after a quick investigation, I couldn't find a case where we need to keep a whitelist of hosts for development purposes. Because the setting wasn't providing any benefit but adding complexity, I used this as as a small refactoring opportunity. Please let me know if there is any case that we need to limit the allowed hosts in non-prod environments. 

If we actually need this limitation, I'll ask for lists of allowed hosts for dev and docker envs. It seems the dev is missing `0.0.0.0`, and docker doesn't have any of the entries the dev has - which makes me think both settings need to be revamped.