### PR TITLE
Added flatpages-extra

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     "django_hosts",
     "sorl.thumbnail",
     "djmoney",
+    "flatpages_extra",
     "django.contrib.sites",
     "django.contrib.auth",
     "django.contrib.admin",

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -139,6 +139,7 @@ urlpatterns = [
     path("weblog/", include("blog.urls")),
     path("download/", include("releases.urls")),
     path("svntogit/", include("svntogit.urls")),
+    path("flatpagesextra/", include("flatpages_extra.urls")),
     path("", include("legacy.urls")),
 ]
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,7 @@
 Babel==2.17.0
 django-contact-form==5.2.0
 django-countries==7.6.1
+django-flatpages-extra==1.0
 django-hosts==5.1
 django-money==3.5.4
 django-push @ git+https://github.com/brutasse/django-push.git@22fda99641cfbd2f3075a723d92652a8e38220a5


### PR DESCRIPTION
This PR adds `django-flatpages-extra`, which is a package I created after a discussion with @StephanieAG from the fundraising WG on how to make it easier to update flat pages.

As you can tell from the very short PR, the package is a drop-in replacement and is reversible. It adds the following features to the admin:

- The ability to create a revision for a flat page
- preview revisions (including a shareable link for people who don't have an admin account)
- reverting revisions
- better history of changes for flat pages

Initially I was going to develop this as an app in this project, but then realized it might be useful as a 3rd party too. If accepted I would release a 1.0 of the package.

## Screenshots:

<details><summary>Editing content directly is disabled</summary>
<img width="1375" height="661" alt="Screenshot 2025-08-02 at 12-02-50 _accessibility_ -- Django Accessibility Statement! Change flat page Django site admin" src="https://github.com/user-attachments/assets/68e09f60-449f-4398-b33e-3d31c97526f4" />

</details> 

<details><summary>Preview page</summary>
<img width="793" height="736" alt="Screenshot 2025-08-02 at 12-07-34 Django Accessibility Statement! Django" src="https://github.com/user-attachments/assets/3c4a7936-d4d6-4fc3-8252-9cf96a18b07b" />

</details> 

<details><summary>Compare view (diff)</summary>
<img width="943" height="495" alt="Screenshot 2025-08-02 at 12-08-18 Comparing revision with original Django site admin" src="https://github.com/user-attachments/assets/2858b292-1d74-4fba-9e0e-3432d271558e" />

</details> 