### PR TITLE
Fix error 404 on foundations urls when coming from other subdomain

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -1,3 +1,5 @@
+{% load hosts %}
+
 <footer>
   <div class="subfooter">
     <div class="container">
@@ -59,9 +61,9 @@
           <h3>Support Us</h3>
           <ul>
             <li><a href="{% url "fundraising:index" %}">Sponsor Django</a></li>
-            <li><a href="/foundation/corporate-membership/">Corporate membership</a></li>
+            <li><a href="{% host_url "homepage" host "www" %}foundation/corporate-membership/">Corporate membership</a></li>
             <li><a href="https://django.threadless.com/" target="_blank">Official merchandise store</a></li>
-            <li><a href="/foundation/donate/#benevity-giving">Benevity Workplace Giving Program</a></li>
+            <li><a href="{% host_url "homepage" host "www" %}foundation/donate/#benevity-giving">Benevity Workplace Giving Program</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
The website displays a 404 page when clicking the `Corporate membership` and `Benevity Workplace Giving Program` in the footer if coming from the `docs` or `dashboard` subdomains.

To fix this issue, the host `www` was specified by utilizing the `host_url` template tag from the django-hosts.

This fixes Issue #2139.