### PR TITLE
Updated social media links

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -47,8 +47,10 @@
           <h3>Follow Us</h3>
           <ul>
             <li><a href="https://github.com/django">GitHub</a></li>
-            <li><a href="https://twitter.com/djangoproject">Twitter</a></li>
+            <li><a href="https://x.com/djangoproject">X</a></li>
             <li><a href="https://fosstodon.org/@django" rel="me">Fediverse (Mastodon)</a></li>
+            <li><a href="https://bsky.app/profile/djangoproject.com">Bluesky</a></li>
+            <li><a href="https://www.linkedin.com/company/django-software-foundation">LinkedIn</a></li>
             <li><a href="{% url 'weblog-feed' %}">News RSS</a></li>
           </ul>
         </div>


### PR DESCRIPTION
This was requested by the fundraising working group.

Before:

<img width="203" height="206" alt="image" src="https://github.com/user-attachments/assets/b296ae82-ef69-4bb7-ad1a-974d61d91195" />

After:

<img width="194" height="270" alt="image" src="https://github.com/user-attachments/assets/5338c0d4-9974-47a9-943c-b5cfb421f5b6" />
