### PR TITLE
Changed GH action to publish images from the preview branch too

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Create and publish a Docker image
 
 on:
     push:
-        branches: ["main"]
+        branches: ["main", "preview"]
 
 env:
     REGISTRY: ghcr.io
@@ -31,9 +31,9 @@ jobs:
               uses: docker/metadata-action@v5
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                  flavor: |
-                      latest=true
                   tags: |
+                      # set latest tag for main branch only
+                      type=raw,value=latest,enable={{is_default_branch}}
                       type=ref,event=branch
                       type=sha
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   tags: |
                       # set latest tag for main branch only
-                      type=raw,value=latest,enable={{is_default_branch}}
+                      type=raw,value=latest,enable=main
                       type=ref,event=branch
                       type=sha
 


### PR DESCRIPTION
I believe this is all that's needed in order to start publishing a `preview` tag to the docker registry used for deployment.

Here's some documentation about the strange `{{is_default_branch}}` condition: https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag.

I removed the `flavor: latest=true` to avoid tagging a preview image with `latest`.

Refs #1922