### PR TITLE
Fixed docker-publish github action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   tags: |
                       # set latest tag for main branch only
-                      type=raw,value=latest,enable=main
+                      type=raw,value=latest,enable={{is_default_branch}}
                       type=ref,event=branch
                       type=sha
 


### PR DESCRIPTION
This was broken in 2e3582e15bae895185e84adc95f26304a279baa1
because I misunderstood the meaning of the `enable` param.
