### PR TITLE
Update download.html: Remove Python2 from top

### DIFF
--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -20,7 +20,7 @@
   <h1>How to get Django</h1>
   <p>Django is available open-source under the
     <a href="https://github.com/django/django/blob/main/LICENSE">BSD license</a>.
-    We recommend using the latest version of Python 3.
+    We recommend using the latest version of Python.
     See <a href="{% url 'document-detail' lang='en' version='dev' url='faq/install' host 'docs' %}#what-python-version-can-i-use-with-django">
       the FAQ</a> for the Python versions supported by each version of Django.
     Here’s how to get it:</p>


### PR DESCRIPTION
Those who need Python2 will find the info. No need to show this to all users at the top (my point of view).