### PR TITLE
Removed Coveralls references and configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
             - name: Install dependencies
               run: |
-                  python -m pip install --upgrade pip setuptools coveralls
+                  python -m pip install --upgrade pip setuptools
                   python -m pip install -r requirements/tests.txt
             - name: Set up databases
               run: |
@@ -60,12 +60,3 @@ jobs:
             - name: Run tests
               run: |
                   make ci
-            - name: Coveralls
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COVERALLS_PARALLEL: true
-                  COVERALLS_FLAG_NAME: "${{ env.PYTHON_VERSION }}"
-                  COVERALLS_SERVICE_NAME: github
-                  COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
-                  COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
-              run: coveralls --service=github

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ djangoproject.com source code
 .. image:: https://github.com/django/djangoproject.com/workflows/Tests/badge.svg?branch=main
     :target: https://github.com/django/djangoproject.com/actions
 
-.. image:: https://coveralls.io/repos/django/djangoproject.com/badge.svg?branch=main
-    :target: https://coveralls.io/r/django/djangoproject.com?branch=main
-
 To run locally, you can either:
 
 - Install and run from a virtual environment


### PR DESCRIPTION
After some discussion, the Website WG decided that we no longer want to use Coveralls. A coverage report is generated when running `make ci` locally.

Closes #2172.