### PR TITLE
Include an exploratory packages section to the ecosystem page.

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -93,6 +93,15 @@
 
   <p>We will refresh this list at least yearly to keep up to date.</p>
 
+  <hr />
+  <h3>Exploratory packages needing feedback</h3>
+  <p>These packages are those the Django Software Foundation is exploring their viability and could use feedback from the community.</p>
+  <ul>
+    <li><a href="https://github.com/RealOrangeOne/django-tasks">Django Tasks</a> &mdash; A lightweight task queue for Django applications, suitable for simple background task processing.</li>
+    <li><a href="https://github.com/khanxmetu/django-admin-keyshortcuts">Django Admin with Keyboard Shortcuts</a> &mdash; A Django package that adds keyboard shortcuts to the Django Admin interface for improved accessibility.</li>
+  </ul>
+  <hr />
+
   <h3>Debugging & Development Tools</h3>
   <ul>
     <li><a href="https://github.com/jazzband/django-debug-toolbar">Django Debug Toolbar</a> &mdash; A configurable set of panels that display various debug information about the current request/response.</li>


### PR DESCRIPTION
These may change more frequently. It will contain GSoC or other DEP created third-party packages.

#### Rendered version with the `<hr />`
<img width="1107" height="787" alt="Screenshot from 2025-09-05 16-48-55" src="https://github.com/user-attachments/assets/add7d63c-3573-475e-8ce7-6a85cf97e62e" />
