### PR TITLE
Update Leaders donation limit text

### DIFF
--- a/djangoproject/templates/fundraising/includes/display_django_heroes.html
+++ b/djangoproject/templates/fundraising/includes/display_django_heroes.html
@@ -65,7 +65,7 @@
   <p>
     {% blocktranslate trimmed with amount=display_logo_amount|intcomma %}
       Leadership-level donors contribute ${{ amount }} or
-      more in a calendar year.
+      more in total donations.
     {% endblocktranslate %}
   </p>
   <div>

--- a/djangoproject/templates/fundraising/includes/display_django_heroes.html
+++ b/djangoproject/templates/fundraising/includes/display_django_heroes.html
@@ -64,8 +64,8 @@
     Leaders (${{ amount }}+){% endblocktranslate %}</h3>
   <p>
     {% blocktranslate trimmed with amount=display_logo_amount|intcomma %}
-      Leadership-level donors contribute ${{ amount }} or
-      more in total donations.
+      Leadership-level donors contribute at least ${{ amount }} 
+      and have donated in the last {{ display_donor_days }} days.
     {% endblocktranslate %}
   </p>
   <div>

--- a/djangoproject/templates/fundraising/includes/display_django_heroes.html
+++ b/djangoproject/templates/fundraising/includes/display_django_heroes.html
@@ -64,7 +64,7 @@
     Leaders (${{ amount }}+){% endblocktranslate %}</h3>
   <p>
     {% blocktranslate trimmed with amount=display_logo_amount|intcomma %}
-      Leadership-level donors contribute at least ${{ amount }} 
+      Leadership-level donors contribute at least ${{ amount }}
       and have donated in the last {{ display_donor_days }} days.
     {% endblocktranslate %}
   </p>


### PR DESCRIPTION
Fixed the contribution description for #1766 

Since the heroes are based on the total donated_amount contributed, not the donations over the past year, the text has to be updated. 
https://github.com/django/djangoproject.com/blob/100d673a8ff0a9072ee0eeebcee4252f396049bf/fundraising/templatetags/fundraising_extras.py#L95-L113

The fundraisers also have to have donated in the past year to show up
https://github.com/django/djangoproject.com/blob/5537f965ece29b766efe17c1d2137c3d2037811c/fundraising/models.py#L25-L35