### PR TITLE
Fixed "connection 'trac' doesn't exist" error running tests via Docker

### DIFF
--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -10,6 +10,15 @@ DATABASES = {
         "PORT": os.environ.get("SQL_PORT"),
     }
 }
+# Trac connection
+DATABASES["trac"] = {
+    "ENGINE": "django.db.backends.postgresql",
+    "NAME": os.environ.get("TRAC_DATABASE", "code.djangoproject"),
+    "USER": os.environ.get("TRAC_USER", "code.djangoproject"),
+    "PASSWORD": os.environ.get("TRAC_PASSWORD", ""),
+    "HOST": os.environ.get("TRAC_HOST", "db"),
+    "PORT": os.environ.get("TRAC_PORT", "5432"),
+}
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -10,6 +10,7 @@ DATABASES = {
         "PORT": os.environ.get("SQL_PORT"),
     }
 }
+
 # Trac connection
 DATABASES["trac"] = {
     "ENGINE": "django.db.backends.postgresql",
@@ -27,4 +28,4 @@ ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]
 LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
 
 # django-hosts settings
-PARENT_HOST = "localhost:8000"
+PARENT_HOST = "djangoproject.localhost:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
             - SQL_PASSWORD=secret
             - SQL_HOST=db
             - SQL_PORT=5432
+            - TRAC_DATABASE=code.djangoproject
+            - TRAC_USER=code.djangoproject
+            - TRAC_PASSWORD=secret
+            - TRAC_HOST=db
+            - TRAC_PORT=5432
+
         depends_on:
             db:
                 condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,5 @@ services:
             interval: 1s
             timeout: 10s
             retries: 10
+        volumes:
+        - ./initdb/tracdb.sql:/docker-entrypoint-initdb.d/tracdb.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,4 +42,4 @@ services:
             timeout: 10s
             retries: 10
         volumes:
-        - ./initdb/tracdb.sql:/docker-entrypoint-initdb.d/tracdb.sql
+            - ./initdb/tracdb.sql:/docker-entrypoint-initdb.d/tracdb.sql

--- a/docker-entrypoint.dev.sh
+++ b/docker-entrypoint.dev.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 python -m manage flush --no-input
-# PGPASSWORD=djangoproject psql --host db --port 5432 --username=code.djangoproject --dbname=code.djangoproject < tracdb/trac.sql
+PGPASSWORD=secret psql --host db --port 5432 --username=code.djangoproject --dbname=code.djangoproject < tracdb/trac.sql
 python -m manage migrate
 make compile-scss # must come before collectstatic
 python -m manage collectstatic --no-input --clear

--- a/initdb/tracdb.sql
+++ b/initdb/tracdb.sql
@@ -1,0 +1,3 @@
+-- Legacy Trac DB
+CREATE USER "code.djangoproject" WITH PASSWORD 'secret' CREATEDB;
+CREATE DATABASE "code.djangoproject" OWNER "code.djangoproject";


### PR DESCRIPTION
Fixes #2193 

This allows for tests and local dev to work via the docker steps without any additional setup steps