### PR TITLE
Add top `CorporateMember`s to `docs` sidebar

### DIFF
--- a/djangoproject/templates/fundraising/includes/top_corporate_members.html
+++ b/djangoproject/templates/fundraising/includes/top_corporate_members.html
@@ -1,0 +1,22 @@
+{% if members %}
+  <div class="corporate-members">
+    <h3>Diamond and Platinum Members</h3>
+    {% for obj in members %}
+      <div class="clearfix">
+        <div class="member-logo">
+          <a href="{{ obj.url }}" title="{{ obj.display_name }}">
+            <img src="{{ obj.thumbnail.url }}" alt="{{ obj.display_name }}" />
+          </a>
+        </div>
+        <div class="small-cta">
+          <ul class="list-links-small">
+            <li><strong>{{ obj.display_name }}</strong></li>
+            <li><a href="{{ obj.url }}" title="{{ obj.display_name }}">
+              {{ obj.description }}
+            </a></li>
+          </ul>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -273,28 +273,7 @@
   <div role="complementary">
     <h2 class="visuallyhidden" id="aside-header">Additional Information</h2>
 
-    {% if corporate_members %}
-      <div class="corporate-members">
-        <h3>Diamond and Platinum Members</h3>
-        {% for obj in corporate_members %}
-          <div class="clearfix">
-            <div class="member-logo">
-              <a href="{{ obj.url }}" title="{{ obj.display_name }}">
-                <img src="{{ obj.thumbnail.url }}" alt="{{ obj.display_name }}" />
-              </a>
-            </div>
-            <div class="small-cta">
-              <ul class="list-links-small">
-                <li><strong>{{ obj.display_name }}</strong></li>
-                <li><a href="{{ obj.url }}" title="{{ obj.display_name }}">
-                  {{ obj.description }}
-                </a></li>
-              </ul>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
+    {% top_corporate_members %}
 
     {% donation_snippet %}
 

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -222,5 +222,7 @@
         </p>
       </section>
     {% endblock links-wrapper %}
+
+    {% top_corporate_members %}
   </div>
 {% endblock content-related %}

--- a/fundraising/templatetags/fundraising_extras.py
+++ b/fundraising/templatetags/fundraising_extras.py
@@ -111,3 +111,10 @@ def display_django_heroes():
         "display_logo_amount": int(LEADERSHIP_LEVEL_AMOUNT),
         "corporate_membership_amounts": CORPORATE_MEMBERSHIP_AMOUNTS,
     }
+
+
+@register.inclusion_tag("fundraising/includes/top_corporate_members.html")
+def top_corporate_members():
+    members = CorporateMember.objects.by_membership_level()
+
+    return {"members": members["diamond"] + members["platinum"]}

--- a/releases/views.py
+++ b/releases/views.py
@@ -1,8 +1,6 @@
 from django.http import Http404, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
 
-from members.models import CorporateMember
-
 from .models import Release
 
 
@@ -23,17 +21,12 @@ def index(request):
     # Get the list of earlier releases.
     unsupported = Release.objects.unsupported()
 
-    corporate_members = CorporateMember.objects.by_membership_level()
-
     context = {
         "current": current,
         "previous": previous,
         "lts": lts,
         "unsupported": unsupported,
         "preview": preview,
-        "corporate_members": (
-            corporate_members["diamond"] + corporate_members["platinum"]
-        ),
     }
     return render(request, "releases/download.html", context)
 


### PR DESCRIPTION
This was requested by the fundraising working group.

I abstracted the top `CorporateMember` display from the `releases` app sidebar into a new inclusion tag called `top_corporate_members` and included it in its original place as well as in the `docs` sidebar as requested.

Uploaded images for `CorporateMember`s may not display in local development environments do to the way media files paths work with subdomains.