### PR TITLE
Prevent EOL date from being set on alpha1 releases

### DIFF
--- a/releases/models.py
+++ b/releases/models.py
@@ -318,6 +318,8 @@ class Release(models.Model):
         }
         if self.iteration > 1:
             previous_release_kwargs["iteration"] = self.iteration - 1
+        elif self.status == "a":
+            return
         elif self.status == "b":
             previous_release_kwargs["status"] = "a"
         elif self.status == "c":

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -216,6 +216,7 @@ class ReleaseTestCase(TestCase):
         other_release = Release.objects.create(version="5.1.7", is_active=True)
         today = datetime.date.today()
         cases = [
+            ("5.1.1", "5.2a1"),
             ("5.2a1", "5.2a2"),
             ("5.2a2", "5.2b1"),
             ("5.2b1", "5.2rc1"),
@@ -229,10 +230,14 @@ class ReleaseTestCase(TestCase):
                     is_active=True,
                 )
                 self.assertIsNone(previous_release.eol_date)
-                Release.objects.create(version=next_version, is_active=True)
+                next_release = Release.objects.create(
+                    version=next_version, is_active=True
+                )
                 previous_release.refresh_from_db()
                 other_release.refresh_from_db()
-                self.assertEqual(previous_release.eol_date, today)
+                if next_release.version_tuple[-2:] != ("alpha", 1):
+                    self.assertEqual(previous_release.eol_date, today)
+                self.assertIsNone(next_release.eol_date)
                 self.assertIsNone(other_release.eol_date)
 
 


### PR DESCRIPTION
Noticed by @nessita when creating 6.0a1 today. When setting an alpha1 release `is_active=True`, this logic fires and sets the EOL date to today.