### PR TITLE
Use the binary version of psycopg for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # install deb packages
+# PostgreSQL dependencies are needed for dbshell and backup process
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         gettext \
@@ -23,23 +24,14 @@ RUN apt-get update \
     && apt-get distclean
 
 ARG REQ_FILE=requirements/prod.txt
+ARG BUILD_DEPENDENCIES="g++ gcc libc6-dev libpq-dev zlib1g-dev"
 
 # install python dependencies
 COPY ./requirements ./requirements
 RUN apt-get update \
-    && apt-get install --assume-yes --no-install-recommends \
-        g++ \
-        gcc \
-        libc6-dev \
-        libpq-dev \
-        zlib1g-dev \
+    && apt-get install --assume-yes --no-install-recommends ${BUILD_DEPENDENCIES} \
     && python3 -m pip install --no-cache-dir -r ${REQ_FILE} \
-    && apt-get purge --assume-yes --auto-remove \
-        g++ \
-        gcc \
-        libc6-dev \
-        libpq-dev \
-        zlib1g-dev \
+    && apt-get purge --assume-yes --auto-remove ${BUILD_DEPENDENCIES} \
     && apt-get distclean
 
 # copy project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
             dockerfile: Dockerfile
             args:
                 - REQ_FILE=requirements/tests.txt
+                - BUILD_DEPENDENCIES=g++ gcc
         entrypoint: ./docker-entrypoint.dev.sh
         command: python manage.py runserver 0.0.0.0:8000
         volumes:

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,7 +14,6 @@ Jinja2==3.1.6
 libsass==0.23.0
 Markdown==3.9
 Pillow==11.3.0
-psycopg[c]==3.2.9
 Pygments==2.19.2
 pykismet3==0.1.1
 requests==2.32.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 -r common.txt
 django-debug-toolbar==6.0.0
 pre-commit~=4.3.0
+psycopg[binary]==3.2.10
 watchdog==6.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,5 @@
 -r common.txt
 gunicorn==23.0.0
+psycopg[c]==3.2.10
 redis==6.4.0
 sentry-sdk==2.38.0


### PR DESCRIPTION
Replaces `psycopg[c]`  with `psycopg[binary]` for development.

Relates to https://github.com/django/djangoproject.com/issues/2215