### PR TITLE
Add no-cache headers to draft blog posts

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -1,3 +1,4 @@
+from django.utils.cache import add_never_cache_headers
 from django.views.generic.dates import (
     ArchiveIndexView,
     DateDetailView,
@@ -58,3 +59,9 @@ class BlogDateDetailView(BlogViewMixin, DateDetailView):
             return Entry.objects.all()
         else:
             return super().get_queryset()
+
+    def get(self, request, *args, **kwargs):
+        response = super().get(request, *args, **kwargs)
+        if not self.object.is_published():
+            add_never_cache_headers(response)
+        return response


### PR DESCRIPTION
Fixes #2158.

Add headers to never cache draft blog posts (since we want changes to be reflected immediately).

Note that Django's cache middleware will not cache responses when the Cache-Control header is set to no-cache, no-store, or private, which is our case here for draft blog posts.