### PR TITLE
Updated the Team list page description and added a link within the footer.

### DIFF
--- a/djangoproject/templates/includes/footer.html
+++ b/djangoproject/templates/includes/footer.html
@@ -9,8 +9,7 @@
             <li><a href="{% url 'overview' %}">About Django</a></li>
             {% comment %}<li><a href="{% url 'case_study_index' %}">Case Studies</a></li>{% endcomment %}
             <li><a href="{% url 'start' %}">Getting Started with Django</a></li>
-            <li><a href="{% url 'document-detail' lang='en' version='dev' url="internals/organization" host 'docs' %}">Team
-              Organization</a></li>
+            <li><a href="{% url 'members:teams' %}">Team Organization</a></li>
             <li><a href="{% url 'homepage' %}foundation/">Django Software Foundation</a></li>
             <li><a href="{% url 'code_of_conduct' %}">Code of Conduct</a></li>
             <li><a href="{% url 'diversity' %}">Diversity Statement</a></li>

--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -14,7 +14,21 @@
 {% block content %}
 
   <h2>{% translate "Teams" %}</h2>
-  <p>{% translate "Teams indicate who is actively contributing in certain areas." %}</p>
+  <p>
+    {% blocktranslate trimmed %}
+      The following teams are groups of people who support the Django project
+      and the Django Software Foundation. Apart from the Django Fellows, who
+      are paid contractors, all of these contributors are volunteers.
+      Most teams are distinct, contactable groups with their own set of goals.
+      Some roles are also listed, such as Mergers and Releasers, which are
+      individuals with elevated permissions rather than formal teams. For an
+      overview of how the Django Project is organized and the principles that
+      guide it, see the
+      <a href="https://docs.djangoproject.com/en/dev/internals/organization/#organization-of-the-django-project">
+        organization and principles
+      </a> page.
+    {% endblocktranslate %}
+  </p>
 
   {% for team in teams %}
     <div class="section">


### PR DESCRIPTION
This PR does two things:

- Updates the current team page description
- Replaces the team organization footer link from https://docs.djangoproject.com/en/dev/internals/organization/ to https://www.djangoproject.com/foundation/teams/ (fixes #2226)

I believe that if the description of the Team list page is updated a little, the team list page is more useful than the "Organization of the Django Project" docs. 
Note that the Team list page already has various links to these docs when needed in team descriptions. I added a link to this in the page description also.

I think it is very hard to navigate to the Team list page currently. I currently click on the "Team Organization" footer link and then click "Mergers" (to see the list of mergers) which gets me to the team page.