### PR TITLE
 Update Former Fellows heading

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -302,7 +302,7 @@
         {% endblocktranslate %}
       </p>
 
-      <p>{% translate "Former Django Fellows:" %}</p>
+      <h3>{% translate "Former Django Fellows:" %}</h3>
 
       <p>
         {% blocktranslate trimmed %}


### PR DESCRIPTION
### Summary
- Update "Former Django Fellows:" from a p tag to an h3 tag for consistent heading structure.

### Motivation
Keeps the fellows list up to date and improves semantic HTML.

### Related
Follow-up to #2224
