### PR TITLE
Automatically generate Django series roadmaps from Release data

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2529,14 +2529,48 @@ dl.data {
     white-space: normal;
 }
 
+table {
+    th {
+        background: var(--sidebar-bg);
+        font-weight: bold;
+        text-align: left;
+    }
+
+    td {
+        border-bottom: 1px solid var(--hairline-color);
+    }
+
+    td,
+    th {
+        padding: 0.5em 1em;
+    }
+}
+
 table.foundation td {
-    border-bottom: 1px solid var(--hairline-color);
     padding: 0 5px;
 }
 
-table.docutils td,
-table.docutils th {
-    border-bottom: 1px solid var(--hairline-color);
+table.django-supported-versions,
+table.django-unsupported-versions {
+    border: 1px solid var(--hairline-color);
+    color: var(--table-color);
+
+    th,
+    td {
+        border-bottom: none;
+        padding: 5px;
+        text-align: center;
+    }
+}
+
+table.django-supported-versions th,
+table.django-supported-versions tr {
+    background-color: var(--secondary-accent);
+}
+
+table.django-unsupported-versions th,
+table.django-unsupported-versions tr {
+    background-color: var(--error-light);
 }
 
 .list-links {
@@ -3418,26 +3452,6 @@ form .footnote {
         display: inline-block;
         margin-left: 1em;
     }
-}
-
-table.django-supported-versions,
-table.django-unsupported-versions {
-    border: 1px solid black;
-    text-align: center;
-    color: var(--table-color);
-
-    th,
-    td {
-        padding: 5px;
-    }
-}
-
-table.django-supported-versions tr {
-    background-color: var(--secondary-accent);
-}
-
-table.django-unsupported-versions tr {
-    background-color: var(--error-light);
 }
 
 /* Corporate membership list page */

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -85,10 +85,10 @@
       <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
-      <td>5.2 LTS</td>
-      <td>{% get_latest_micro_release '5.2' %}</td>
-      <td>December 2025</td>
-      <td>April 2028</td>
+      <td>4.2 LTS</td>
+      <td>{% get_latest_micro_release '4.2' %}</td>
+      <td>December 4, 2023</td>
+      <td>April 2026</td>
     </tr>
     <tr>
       <td>5.1</td>
@@ -97,10 +97,10 @@
       <td>December 2025</td>
     </tr>
     <tr>
-      <td>4.2 LTS</td>
-      <td>{% get_latest_micro_release '4.2' %}</td>
-      <td>December 4, 2023</td>
-      <td>April 2026</td>
+      <td>5.2 LTS</td>
+      <td>{% get_latest_micro_release '5.2' %}</td>
+      <td>December 2025</td>
+      <td>April 2028</td>
     </tr>
   </table>
 
@@ -114,28 +114,28 @@
       <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
-      <td>7.0</td>
-      <td>December 2027</td>
-      <td>August 2028</td>
-      <td>April 2029</td>
+      <td><a href="{% url 'roadmap' '6.0' %}">6.0</a></td>
+      <td>December 2025</td>
+      <td>August 2026</td>
+      <td>April 2027</td>
     </tr>
     <tr>
-      <td>6.2 LTS</td>
+      <td><a href="{% url 'roadmap' '6.1' %}">6.1</a></td>
+      <td>August 2026</td>
+      <td>April 2027</td>
+      <td>December 2027</td>
+    </tr>
+    <tr>
+      <td><a href="{% url 'roadmap' '6.2' %}">6.2 LTS</a></td>
       <td>April 2027</td>
       <td>December 2027</td>
       <td>April 2030</td>
     </tr>
     <tr>
-      <td>6.1</td>
-      <td>August 2026</td>
-      <td>April 2027</td>
+      <td><a href="{% url 'roadmap' '7.0' %}">7.0</a></td>
       <td>December 2027</td>
-    </tr>
-    <tr>
-      <td>6.0</td>
-      <td>December 2025</td>
-      <td>August 2026</td>
-      <td>April 2027</td>
+      <td>August 2028</td>
+      <td>April 2029</td>
     </tr>
   </table>
 

--- a/djangoproject/templates/releases/roadmap.html
+++ b/djangoproject/templates/releases/roadmap.html
@@ -1,0 +1,120 @@
+{% extends "base.html" %}
+{% load date_format %}
+
+{% block sectionid %}roadmap{% endblock %}
+{% block title %}Django {{ series }} Roadmap{% endblock %}
+{% block layout_class %}sidebar-right{% endblock %}
+
+{% block header %}
+  <p>Download</p>
+{% endblock %}
+
+{% block content %}
+  <h1>Django {{ series }} Roadmap</h1>
+  <p>This document details the schedule and roadmap towards Django {{ series }}.</p>
+
+  <section id="what-features-will-be-released">
+    <h2>What features will be in Django {{ series }}?</h2>
+    <p>Whatever gets committed by the alpha feature freeze!</p>
+    <p>Django {{ series }} will be a time-based release. Any features completed and committed
+      to main by the alpha feature freeze deadline noted below will be included. Any
+      that miss the deadline won't.</p>
+    <p>If you have a major feature you'd like to contribute, please introduce yourself
+      on the <a href="https://forum.djangoproject.com/c/internals/5">django-internals forum</a>
+      so you can find a shepherd for your feature.</p>
+    <p>Minor features and bug fixes will be merged as they are completed. If you
+      have submitted a patch, ensure the flags on the Trac ticket are correct so it
+      appears in the "Patches needing review" filter of the
+      <a href="https://dashboard.djangoproject.com/">Django Development Dashboard</a>.
+      Better yet, find someone to review your patch and mark the ticket as
+      "Ready for checkin". Tickets marked "Ready for checkin" are regularly reviewed
+      by mergers.</p>
+  </section>
+
+  <section id="schedule">
+    <h2>Schedule</h2>
+    <p>
+      Major milestones along the way to {{ series }} are scheduled below.
+      See <a href="#process">Process</a> for more details. Dates are subject to change.
+    </p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Milestone</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ releases.a.date|default:"TBD" }}</td>
+            <td>Django {{ series }} alpha; feature freeze.</td>
+          </tr>
+          <tr>
+            <td>{{ releases.b.date|default:"TBD" }}</td>
+            <td>Django {{ series }} beta; non-release blocking bug fix freeze.</td>
+          </tr>
+          <tr>
+            <td>{{ releases.c.date|default:"TBD" }}</td>
+            <td>Django {{ series }} RC 1; translation string freeze.</td>
+          </tr>
+          <tr>
+            <td>{{ releases.f.date|default:"TBD" }}</td>
+            <td>Django {{ series }} final.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section id="process">
+    <h2>Process</h2>
+    <p>Any features not completed by the feature freeze date won't make it into {{ series }}.</p>
+    <p>The release manager will keep the schedule updated and ensure efficient
+      routing of issues and reminders for deadlines.</p>
+
+    <section id="feature-freeze-alpha-1">
+      <h3>Feature freeze / Alpha 1</h3>
+      <p>All major and minor features must be merged by the Alpha 1 deadline. Any
+        features not done by this point will be deferred or dropped. At this time, we
+        will fork <code>stable/{{ series }}.x</code> from <code>main</code>.</p>
+      <p>After the alpha, non-release blocking bug fixes may be backported at the
+        mergers' discretion.</p>
+    </section>
+
+    <section id="beta-1">
+      <h3>Beta 1</h3>
+      <p>Beta 1 marks the end of changes that aren't release blocking bugs. Only release
+        blocking bug fixes will be allowed to be backported after the beta.</p>
+    </section>
+
+    <section id="rc-1">
+      <h3>RC 1</h3>
+      <p>If release blockers are still coming in at the planned release candidate date,
+        we'll release beta 2 to encourage further testing. RC 1 marks the freeze for
+        translation strings; translators will have two weeks to submit updates. Release
+        blocking bug fixes may continue to be backported.</p>
+    </section>
+
+    <section id="final">
+      <h3>Final</h3>
+      <p>Django {{ series }} final will ideally ship two weeks after the last RC. If no major bugs
+        are found by then, {{ series }} final will be issued; otherwise, the timeline will be
+        adjusted as needed.</p>
+    </section>
+
+    <section id="how-to-help">
+      <h3>How you can help</h3>
+      <p>Community effort is key. You can help by:</p>
+      <ul>
+        <li>Reading the <a href="http://docs.djangoproject.com/en/dev/internals/contributing/">guide to contributing</a>
+          and <a href="http://docs.djangoproject.com/en/dev/internals/release-process/">Django's release process</a>.</li>
+        <li>Working on patches and <a href="https://docs.djangoproject.com/en/dev/internals/contributing/triaging-tickets/">triaging tickets</a>.</li>
+        <li>Attending sprints.</li>
+        <li>Testing release snapshots (alphas, betas) against your code and reporting bugs.</li>
+        <li>Providing as many testers as possible to ensure a bug-free release.</li>
+      </ul>
+    </section>
+  </section>
+
+{% endblock %}

--- a/releases/urls.py
+++ b/releases/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, re_path
 
-from .views import index, redirect
+from .views import index, redirect, roadmap
 
 urlpatterns = [
     path("", index, name="download"),
     re_path(
         "^([0-9a-z_.-]+)/(tarball|wheel|checksum)/$", redirect, name="download-redirect"
     ),
+    re_path(r"^(?P<series>\d{1,2}\.[0-2])/roadmap/$", roadmap, name="roadmap"),
 ]

--- a/releases/views.py
+++ b/releases/views.py
@@ -31,6 +31,20 @@ def index(request):
     return render(request, "releases/download.html", context)
 
 
+def roadmap(request, series):
+    major, minor = series.split(".")
+    major = int(major)
+    if major < 2:
+        raise Http404
+
+    releases = Release.objects.filter(major=major, minor=minor, micro=0)
+    context = {
+        "series": series,
+        "releases": {r.status: r for r in releases},
+    }
+    return render(request, "releases/roadmap.html", context)
+
+
 def redirect(request, version, kind):
     release = get_object_or_404(Release, version=version)
 


### PR DESCRIPTION
This branch adds a new view that replaces the Roadmap wiki pages, e.g.:

  * https://code.djangoproject.com/wiki/Version5.2Roadmap
  * https://code.djangoproject.com/wiki/Version6.0Roadmap
  * https://code.djangoproject.com/wiki/Version6.1Roadmap

The wiki pages were almost identical except for version-specific details and target dates. This information is now generated dynamically from the Release model in the database.

The supported and future Roadmap tables were reorganized so they follow a more intuitive timeline (from older to newer versions).