### PR TITLE
Upgrade Python to 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
     pull_request:
 
 env:
-    PYTHON_VERSION: 3.12
+    PYTHON_VERSION: 3.13
 
 jobs:
     tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       rev: v3.21.2
       hooks:
           - id: pyupgrade
-            args: [--py312]
+            args: [--py313]
 
     - repo: https://github.com/adamchainz/django-upgrade
       rev: 1.29.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.12-slim-trixie
+FROM python:3.13-slim-trixie
 
 # set work directory
 WORKDIR /usr/src/app

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ To run locally, you can either:
 Install and run locally from a virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Create a `Python 3.12 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
+#. Create a `Python 3.13 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
 
 #. Install dependencies::
 


### PR DESCRIPTION
Coming from https://github.com/django/djangoproject.com/issues/1890#issuecomment-3167984510

> > If that's okay, I can proceed with 3.13 update and demonstrate why we don't need the matrix anymore.
> 
> Absolutely. It should be a separate PR than removing tox though, the two things might be connected but we should still do them one at a time.

cc @bmispelon 

