### PR TITLE
Tavish/issue#2224

### DIFF
--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -302,7 +302,7 @@
         {% endblocktranslate %}
       </p>
 
-<h3>{% translate "Former Django Fellows:" %}</h3>
+<h3>{% translate "Former Django Fellows" %}:</h3>
 
       <p>
         {% blocktranslate trimmed %}

--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -302,7 +302,7 @@
         {% endblocktranslate %}
       </p>
 
-      <p>{% translate "Former Django Fellows:" %}</p>
+<h3>{% translate "Former Django Fellows:" %}</h3>
 
       <p>
         {% blocktranslate trimmed %}


### PR DESCRIPTION
Fixes the translation tag for "Former Django Fellows" by properly closing the string with a quotation mark.

->Before:
<p>{% translate "Former Django Fellows:" %}</p>

->After :
Moves the colon punctuation outside the translation string for better internationalization.
<h3>{% translate "Former Django Fellows" %}:</h3>