### PR TITLE
Update single quoted dosctrings to triple quotes

### DIFF
--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -101,7 +101,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         DocumentRelease.objects.create(lang="en", release=r2, is_default=True)
 
     def test_docs_host_excluded(self):
-        "We get no Content-Language or Vary headers when docs host is excluded"
+        """We get no Content-Language or Vary headers when docs host is excluded"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
             resp = self.client.get("/", headers={"host": self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
@@ -133,7 +133,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         self.assertNotIn("Vary", resp)
 
     def test_docs_host_not_excluded(self):
-        "We still get Content-Language when docs host is not excluded"
+        """We still get Content-Language when docs host is not excluded"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[]):
             resp = self.client.get("/", headers={"host": self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
@@ -141,7 +141,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         self.assertIn("Vary", resp)
 
     def test_www_host(self):
-        "www should still use LocaleMiddleware"
+        """www should still use LocaleMiddleware"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
             resp = self.client.get("/", headers={"host": self.www_host})
         self.assertEqual(resp.status_code, HTTPStatus.OK)
@@ -149,7 +149,7 @@ class ExcludeHostsLocaleMiddlewareTests(TestCase):
         self.assertIn("Vary", resp)
 
     def test_www_host_with_port(self):
-        "www (with a port) should still use LocaleMiddleware"
+        """www (with a port) should still use LocaleMiddleware"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
             resp = self.client.get("/", headers={"host": "%s:8000" % self.www_host})
         self.assertEqual(resp.status_code, HTTPStatus.OK)

--- a/releases/models.py
+++ b/releases/models.py
@@ -20,7 +20,7 @@ from .utils import get_loose_version_tuple
 # about older release candidates. Safe to use Django's copy of get_version()
 # when upgrading this website to use Django 1.10.
 def get_version(version=None):
-    "Return a PEP 386-compliant version number from VERSION."
+    """Return a PEP 386-compliant version number from VERSION."""
     version = get_complete_version(version)
 
     # Now build the two parts of the version number:


### PR DESCRIPTION
This is recommend by PEP257 for both single and multi line docstrings, and detected as a warning by Pycharm's code inspection
- https://peps.python.org/pep-0257/#one-line-docstrings
- https://peps.python.org/pep-0257/#multi-line-docstrings