### PR TITLE
Ignore venv from message compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
 # copy project
 COPY . .
 
-RUN python -m django compilemessages
+RUN python -m django compilemessages --ignore .venv
 
 # ENTRYPOINT is specified only in the local docker-compose.yml to avoid
 # accidentally running it in deployed environments.


### PR DESCRIPTION
The goal is to exclude 3rd parties from `compilemessages` input

We were having a Docker build issue last week, arising from a faulty .po file in one of our dependencies. We no longer have the issue, but the change here ensures it won't happen again.