### PR TITLE
Moved CTA between new features and schedule

### DIFF
--- a/djangoproject/templates/releases/roadmap.html
+++ b/djangoproject/templates/releases/roadmap.html
@@ -31,6 +31,19 @@
       by mergers.</p>
   </section>
 
+  <section id="how-to-help">
+    <h2>How you can help</h2>
+    <p>Community effort is key. You can help by:</p>
+    <ul>
+      <li>Reading the <a href="http://docs.djangoproject.com/en/dev/internals/contributing/">guide to contributing</a>
+        and <a href="http://docs.djangoproject.com/en/dev/internals/release-process/">Django's release process</a>.</li>
+      <li>Working on patches and <a href="https://docs.djangoproject.com/en/dev/internals/contributing/triaging-tickets/">triaging tickets</a>.</li>
+      <li>Attending sprints.</li>
+      <li>Testing release snapshots (alphas, betas) against your code and reporting bugs.</li>
+      <li>Providing as many testers as possible to ensure a bug-free release.</li>
+    </ul>
+  </section>
+
   <section id="schedule">
     <h2>Schedule</h2>
     <p>
@@ -101,19 +114,6 @@
       <p>Django {{ series }} final will ideally ship two weeks after the last RC. If no major bugs
         are found by then, {{ series }} final will be issued; otherwise, the timeline will be
         adjusted as needed.</p>
-    </section>
-
-    <section id="how-to-help">
-      <h3>How you can help</h3>
-      <p>Community effort is key. You can help by:</p>
-      <ul>
-        <li>Reading the <a href="http://docs.djangoproject.com/en/dev/internals/contributing/">guide to contributing</a>
-          and <a href="http://docs.djangoproject.com/en/dev/internals/release-process/">Django's release process</a>.</li>
-        <li>Working on patches and <a href="https://docs.djangoproject.com/en/dev/internals/contributing/triaging-tickets/">triaging tickets</a>.</li>
-        <li>Attending sprints.</li>
-        <li>Testing release snapshots (alphas, betas) against your code and reporting bugs.</li>
-        <li>Providing as many testers as possible to ensure a bug-free release.</li>
-      </ul>
     </section>
   </section>
 


### PR DESCRIPTION
## Changes
- Moved "How you can help" section from bottom (nested under Process) to between "What features" and "Schedule"
- Changed heading from `<h3>` to `<h2>` to match the new top-level section structure
- No content or functionality changes — purely a reorganization for better UX

## New page structure
1. What features will be in Django X.X?
2. **How you can help** ← moved here (more visible)
3. Schedule
4. Process

This change makes the call-to-action more prominent, potentially increasing contributor engagement by reducing the discovery path.

Fixes https://github.com/django/djangoproject.com/issues/2267