### PR TITLE
Fix search results count mismatch bug

### DIFF
--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -18,21 +18,35 @@
         <a{% if active_category == category %} aria-current="page"{% else %} href="{% querystring category=category.value page=None %}"{% endif %}>{{ category.label }}</a>
       {% endfor %}
     </search>
-    <h2>
-      {% if release.is_dev %}
-        {% blocktranslate count num_results=paginator.count trimmed %}
-          Only 1 result for <em>{{ query }}</em> in the development version
-        {% plural %}
-          {{ num_results }} results for <em>{{ query }}</em> in the development version
-        {% endblocktranslate %}
-      {% else %}
-        {% blocktranslate count num_results=paginator.count trimmed %}
-          Only 1 result for <em>{{ query }}</em> in version {{ version }}
-        {% plural %}
-          {{ num_results }} results for <em>{{ query }}</em> in version {{ version }}
-        {% endblocktranslate %}
-      {% endif %}
-    </h2>
+    {% if paginator.count > 0 %}
+      <h2>
+        {% if release.is_dev %}
+          {% blocktranslate count num_results=paginator.count trimmed %}
+            Only 1 result for <em>{{ query }}</em> in the development version
+          {% plural %}
+            {{ num_results }} results for <em>{{ query }}</em> in the development version
+          {% endblocktranslate %}
+        {% else %}
+          {% blocktranslate count num_results=paginator.count trimmed %}
+            Only 1 result for <em>{{ query }}</em> in version {{ version }}
+          {% plural %}
+            {{ num_results }} results for <em>{{ query }}</em> in version {{ version }}
+          {% endblocktranslate %}
+        {% endif %}
+      </h2>
+    {% else %}
+      <h2>
+        {% if release.is_dev %}
+          {% blocktranslate trimmed %}
+            No results for <em>{{ query }}</em> in the development version
+          {% endblocktranslate %}
+        {% else %}
+          {% blocktranslate trimmed %}
+            No results for <em>{{ query }}</em> in version {{ version }}
+          {% endblocktranslate %}
+        {% endif %}
+      </h2>
+    {% endif %}
   {% else %}
     <h2>{% translate "No search query given" %}</h2>
   {% endif %}

--- a/docs/views.py
+++ b/docs/views.py
@@ -168,6 +168,11 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                 q, release, document_category=doc_category
             )
 
+            # Force queryset evaluation to prevent race conditions between
+            # paginator.count and page.object_list accessing the database
+            # at different times with potentially different transaction states
+            results = list(results)
+
             page_number = request.GET.get("page") or 1
             paginator = Paginator(results, per_page=per_page, orphans=orphans)
 


### PR DESCRIPTION
## Problem
Search results occasionally showed a count header (e.g., "1 result") but displayed an empty list due to a race condition in Django ORM lazy evaluation.

## Root Cause
Race condition in Django ORM lazy evaluation with paginator:
- Paginator's `paginator.count` runs `SELECT COUNT(*)` at time T1
- Paginator's `page.object_list` runs `SELECT * LIMIT` at time T2
- Database state could change between T1 and T2, causing mismatched results

## Solution
- **Backend**: Force queryset evaluation with `results = list(results)` **before** passing to `Paginator`, ensuring both `paginator.count` and `page.object_list` see the same evaluated data
- **Template**: Add `{% if paginator.count > 0 %}` check to show "No results" message when count is 0

## Files Changed
- `docs/views.py`
- `docs/templates/docs/search_results.html`

Fixes https://github.com/django/djangoproject.com/issues/2264