### PR TITLE
Fix language switcher on search results pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: all ci clean collectstatics compile-scss compile-scss-debug install run test watch-scss
+
+APP_LIST ?= accounts aggregator blog contact dashboard djangoproject docs foundation fundraising legacy members releases svntogit tracdb
+SCSS = djangoproject/scss
+STATIC = djangoproject/static
+
+ci: compilemessages test
+	@python -m coverage report
+
+compilemessages:
+	python -m manage compilemessages
+
+collectstatics: compile-scss
+	python -m manage collectstatic --noinput
+
+compile-scss:
+	python -m pysassc $(SCSS)/output.scss $(STATIC)/css/output.css --style=compressed
+
+compile-scss-debug:
+	python -m pysassc $(SCSS)/output.scss $(STATIC)/css/output.css --sourcemap
+
+install:
+	python -m pip install --requirement requirements/dev.txt
+
+migrations-check:
+	python -m manage makemigrations --check --dry-run
+
+run:
+	python -m manage runserver 0.0.0.0:8000
+
+test:
+	@python -m coverage run --source=. --module manage test --verbosity 2 $(APP_LIST)
+
+watch-scss:
+	watchmedo shell-command --patterns=*.scss --recursive --command="make compile-scss-debug" $(SCSS)
+
+reset-local-db:
+	python -m manage flush --no-input
+	python -m manage loaddata dev_sites
+	python -m manage loaddata doc_releases
+	python -m manage loaddata dashboard_production_metrics
+	python -m manage update_metrics


### PR DESCRIPTION
## Fix language switcher on search results pages

### Problem
The language switcher appeared on search results pages but had no clickable language options, preventing users from switching languages after performing a search.

### Root Cause
The `search_results` view was missing the `available_languages` context variable that the template requires to render language links.

### Solution
Added `available_languages` to the view context by calling `get_available_languages_by_version()`, matching the implementation in the `document()` view.

Fixes https://github.com/django/djangoproject.com/issues/2263