### PR TITLE
Fix horizontal scroll on mobile search filters

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2667,7 +2667,7 @@ search.filters {
     // Tablet/Mobile: Show hybrid (All + selected + More dropdown)
     .filter-tabs-responsive {
       display: none; // Hide on desktop
-      
+
       @media (max-width: 1024px) {
         display: flex;
         gap: 10px;
@@ -2714,7 +2714,7 @@ search.filters {
 
       &[aria-expanded="true"] {
         color: var(--body-fg);
-        
+
         .filter-more-icon {
           transform: rotate(180deg);
         }
@@ -2789,7 +2789,7 @@ search.filters {
         box-shadow: none !important;
 
         // Remove underline from all child elements
-        *, 
+        *,
         .filter-checkmark {
           text-decoration: none !important;
           text-decoration-line: none !important;
@@ -2810,7 +2810,7 @@ search.filters {
           text-underline-offset: 0 !important;
           transform: none !important;
           outline: none !important;
-          
+
           // Add subtle left border on hover
           &::before {
             content: "";
@@ -2835,7 +2835,7 @@ search.filters {
           color: var(--body-fg) !important;
           border: none !important;
           border-bottom: none !important;
-          
+
           &:hover {
             background-color: rgba(0, 0, 0, 0.12) !important;
             border: none !important;

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -13,7 +13,7 @@
   {% if query %}
     <search class="filters">
       <span id="search-filters" class="visually-hidden">{% translate "Filter the current search results by documentation category" %}</span>
-      
+
       {# Desktop: All horizontal tabs #}
       <div class="filter-tabs filter-tabs-desktop">
         <a{% if not active_category %} aria-current="page"{% else %} href="{% querystring category=None page=None %}"{% endif %}>{% translate "All" context "all documentation categories" %}</a>
@@ -21,11 +21,11 @@
           <a{% if active_category == category %} aria-current="page"{% else %} href="{% querystring category=category.value page=None %}"{% endif %}>{{ category.label }}</a>
         {% endfor %}
       </div>
-      
+
       {# Tablet/Mobile: Show "All" + "More" dropdown (selected shown in dropdown) #}
       <div class="filter-tabs filter-tabs-responsive">
         <a{% if not active_category %} aria-current="page"{% else %} href="{% querystring category=None page=None %}"{% endif %}>{% translate "All" context "all documentation categories" %}</a>
-        
+
         <div class="filter-more-dropdown">
           <button type="button" class="filter-more-button" aria-expanded="false" aria-haspopup="true">
             {% if active_category %}
@@ -141,7 +141,7 @@
     (function() {
       const moreButton = document.querySelector('.filter-more-button');
       const moreMenu = document.querySelector('.filter-more-menu');
-      
+
       if (moreButton && moreMenu) {
         // Toggle dropdown on button click
         moreButton.addEventListener('click', function(e) {
@@ -150,7 +150,7 @@
           moreButton.setAttribute('aria-expanded', !isExpanded);
           moreMenu.hidden = isExpanded;
         });
-        
+
         // Close dropdown when clicking outside
         document.addEventListener('click', function(e) {
           if (!moreButton.contains(e.target) && !moreMenu.contains(e.target)) {
@@ -158,7 +158,7 @@
             moreMenu.hidden = true;
           }
         });
-        
+
         // Close dropdown on escape key
         document.addEventListener('keydown', function(e) {
           if (e.key === 'Escape' && moreButton.getAttribute('aria-expanded') === 'true') {


### PR DESCRIPTION
Problem
Filter tabs on the search results page require horizontal scrolling on mobile devices, creating a poor user experience.

Solution
Implement responsive design with:

Desktop (>768px): Horizontal tabs (unchanged)
Mobile (≤768px): Dropdown menu
Both UIs exist in HTML; CSS media queries control visibility.

Changes
docs/templates/docs/search_results.html: Add filter-tabs div and filter-dropdown select
djangoproject/scss/_style.scss: Add responsive styles with @media queries

Benefits
No horizontal scrolling on mobile
Touch-friendly dropdown interface
Maintains accessibility (ARIA labels, keyboard navigation)
Desktop experience unchanged

Fixes https://github.com/django/djangoproject.com/issues/2266