### PR TITLE
Fix #2264 :  Fix search results count race condition

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -168,6 +168,11 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                 q, release, document_category=doc_category
             )
 
+            # Force queryset evaluation to prevent race conditions between
+            # paginator.count and page.object_list accessing the database
+            # at different times with potentially different transaction states
+            results = list(results)
+
             page_number = request.GET.get("page") or 1
             paginator = Paginator(results, per_page=per_page, orphans=orphans)
 


### PR DESCRIPTION
## Problem
Search results page shows incorrect count when paginator.count and
page.object_list query the database at different times, causing a
race condition. Header may display 'N results' while showing an
empty list.

## Solution
Convert QuerySet to list immediately after search to force single
database query. Both paginator.count and page.object_list now use
the same data snapshot from memory.

## Changes
- docs/views.py: Add results = list(results) after search query

Fixes https://github.com/django/djangoproject.com/issues/2264