### PR TITLE
Added 2025 PyCharm banner

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -57,21 +57,18 @@
       </div>
     </section>
 
-    {% comment %}
-    Replace the div#billboard below with banner using the skeleton here to
-    add a site banner for surveys/promotions/etc
-
-    <div id="billboard">{% block billboard %}
-      <div class="banner">
-        <p> Banner content goes here </p>
-      </div>
-        {% endblock %}
+    <div id="billboard">
+      {% block billboard %}
+        <div class="banner">
+          <p>
+            <a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&utm_content=django25&utm_medium=referral&utm_source=dsf-banner">
+              Until November 9, 2025, <em>get PyCharm for 30% off</em>.
+              All money goes to the <em>Django Software Foundation</em>!
+            </a>
+          </p>
+        </div>
+      {% endblock %}
     </div>
-    The CSS targets the `#billboard` selector and expects nested `div and `p` elements.
-    elements.
-    {% endcomment %}
-
-    <div id="billboard">{% block billboard %}{% endblock %}</div>
 
     <div class="container {% block layout_class %}{% endblock %}">
       <main id="main-content">


### PR DESCRIPTION
I've used the existing `#billboard` element which was meant for this kind of banner. It has the advantage of keeping the changes to a single file (as opposed to the previous approach which changed 4 base templates).

<details><summary>Screenshot of documentation homepage</summary>

<img width="1154" height="511" alt="Screenshot 2025-10-21 at 21-08-52 Django documentation Django documentation Django" src="https://github.com/user-attachments/assets/fcbfbac1-1370-4bdf-ad01-0af7ccdf2540" />


</details> 