### PR TITLE
Fixed translations of results count for languages where 0 is singular rather than plural.

### DIFF
--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -21,13 +21,13 @@
     <h2>
       {% if release.is_dev %}
         {% blocktranslate count num_results=paginator.count trimmed %}
-          Only 1 result for <em>{{ query }}</em> in the development version
+          {{ num_results }} result for <em>{{ query }}</em> in the development version
         {% plural %}
           {{ num_results }} results for <em>{{ query }}</em> in the development version
         {% endblocktranslate %}
       {% else %}
         {% blocktranslate count num_results=paginator.count trimmed %}
-          Only 1 result for <em>{{ query }}</em> in version {{ version }}
+          {{ num_results }} result for <em>{{ query }}</em> in version {{ version }}
         {% plural %}
           {{ num_results }} results for <em>{{ query }}</em> in version {{ version }}
         {% endblocktranslate %}

--- a/docs/tests/test_views.py
+++ b/docs/tests/test_views.py
@@ -106,7 +106,7 @@ class SearchFormTestCase(TestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertContains(
                     response,
-                    "Only 1 result for <em>generic</em> in version 5.1",
+                    "1 result for <em>generic</em> in version 5.1",
                     html=True,
                 )
                 self.assertContains(response, self.active_filter, count=1)
@@ -225,7 +225,7 @@ class SearchFormTestCase(TestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertContains(
                     response,
-                    f"Only 1 result for <em>{query}</em> in version 5.1",
+                    f"1 result for <em>{query}</em> in version 5.1",
                     html=True,
                 )
                 self.assertContains(response, expected_code_links, html=True)


### PR DESCRIPTION
Fixes https://github.com/django/djangoproject.com/issues/2264

Got suspicious when every French 0 term had this issue:
- https://docs.djangoproject.com/fr/5.2/search/?q=rubbish
- https://docs.djangoproject.com/fr/5.2/search/?q=potato

Turns out that 0 things is singular, not plural in French and so 0 results would translate to "Only 1 result" as 0s need the singular translation.

Happy to tweak this however thought best