### PR TITLE
Update the community ecosystem page

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -5,7 +5,7 @@
 
   <h1 id="community-ecosystem">
     Community Ecosystem
-    <a class="headerlink" href="#community-ecosystem" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#community-ecosystem" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h1>
 
   <p>
@@ -14,12 +14,12 @@
 
   <h2 id="resources">
     Resources
-    <a class="headerlink" href="#resources" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#resources" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h2>
 
   <h3 id="collections">
     Collections
-    <a class="headerlink" href="#collections" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#collections" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -34,7 +34,7 @@
 
   <h3 id="package-communities">
     Package Communities
-    <a class="headerlink" href="#package-communities" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#package-communities" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -49,7 +49,7 @@
 
   <h3 id="external-communities">
     External Communities
-    <a class="headerlink" href="#external-communities" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#external-communities" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -64,7 +64,7 @@
 
   <h3 id="newsletters">
     Newsletters
-    <a class="headerlink" href="#newsletters" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#newsletters" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -75,7 +75,7 @@
 
   <h3 id="podcasts">
     Podcasts
-    <a class="headerlink" href="#podcasts" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#podcasts" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -94,7 +94,7 @@
 
   <h3 id="conference-talks-videos">
     Conference Talks &amp; Videos
-    <a class="headerlink" href="#conference-talks-videos" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#conference-talks-videos" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -113,7 +113,7 @@
 
   <h3 id="additional-documentation">
     Additional Documentation
-    <a class="headerlink" href="#additional-documentation" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#additional-documentation" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -134,7 +134,7 @@
 
   <h3 id="tutorials">
     Tutorials
-    <a class="headerlink" href="#tutorials" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#tutorials" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -145,7 +145,7 @@
 
   <h3 id="miscellaneous">
     Miscellaneous
-    <a class="headerlink" href="#miscellaneous" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#miscellaneous" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -162,7 +162,7 @@
 
   <h2 id="community-packages">
     Community Packages
-    <a class="headerlink" href="#community-packages" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#community-packages" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h2>
 
   <p>We could never list everything, but here are some incredibly useful and well-supported packages that the Django
@@ -171,7 +171,7 @@
 
   <h3 id="exploratory-packages">
     Exploratory Packages
-    <a class="headerlink" href="#exploratory-packages" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#exploratory-packages" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <p>
     These packages might be included in Django in the near future. Please try them out and give feedback!
@@ -198,7 +198,7 @@
 
   <h3 id="debugging-development-tools">
     Debugging &amp; Development Tools
-    <a class="headerlink" href="#debugging-development-tools" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#debugging-development-tools" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -217,7 +217,7 @@
 
   <h3 id="storage-static-files">
     Storage &amp; Static Files
-    <a class="headerlink" href="#storage-static-files" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#storage-static-files" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -232,7 +232,7 @@
 
   <h3 id="api-development">
     API Development
-    <a class="headerlink" href="#api-development" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#api-development" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -247,7 +247,7 @@
 
   <h3 id="cms">
     Content Management Systems (CMS)
-    <a class="headerlink" href="#cms" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#cms" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -267,7 +267,7 @@
 
   <h3 id="authentication-authorization">
     Authentication &amp; Authorization
-    <a class="headerlink" href="#authentication-authorization" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#authentication-authorization" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -300,7 +300,7 @@
 
   <h3 id="forms-views">
     Forms &amp; Views
-    <a class="headerlink" href="#forms-views" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#forms-views" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -315,7 +315,7 @@
 
   <h3 id="templates">
     Templates
-    <a class="headerlink" href="#templates" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#templates" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -326,7 +326,7 @@
 
   <h3 id="environment-configuration">
     Environment Configuration
-    <a class="headerlink" href="#environment-configuration" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#environment-configuration" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -344,7 +344,7 @@
 
   <h3 id="security-middleware">
     Security &amp; Middleware
-    <a class="headerlink" href="#security-middleware" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#security-middleware" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -361,7 +361,7 @@
 
   <h3 id="testing-fixtures">
     Testing &amp; Fixtures
-    <a class="headerlink" href="#testing-fixtures" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#testing-fixtures" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -380,7 +380,7 @@
 
   <h3 id="admin">
     Admin Interface Enhancements
-    <a class="headerlink" href="#admin" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#admin" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -395,7 +395,7 @@
 
   <h3 id="internationalization-localization">
     Internationalization &amp; Localization
-    <a class="headerlink" href="#internationalization-localization" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#internationalization-localization" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -416,7 +416,7 @@
 
   <h3 id="email-notifications">
     Email &amp; Notifications
-    <a class="headerlink" href="#email-notifications" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#email-notifications" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>
@@ -431,7 +431,7 @@
 
   <h3 id="utilities-miscellaneous">
     Utilities &amp; Miscellaneous
-    <a class="headerlink" href="#utilities-miscellaneous" title="Link to this heading">¶</a>
+    <a class="headerlink" href="#utilities-miscellaneous" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>


### PR DESCRIPTION
Update the community ecosystem page with an eye toward:

- cleaning up some of the copy
- splitting up the resource section to have sub-headings for better organization
- adding a table of contents or quick links to go to a particular section since the page is long
- making it clear that sub-headings can be linked to
- adding visual interest to the page

Based on this original analysis of the page: https://docs.google.com/document/d/1h3IAMafx5K30DdRQYx8OiiSwbpiqQlJC3uP2oP6et9Q/edit?tab=t.0#heading=h.la6v9fpeqmn.