### PR TITLE
:calendar: Update PyCharm promo end date to Nov 11, 2025

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -62,7 +62,7 @@
         <div class="banner">
           <p>
             <a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&utm_content=django25&utm_medium=referral&utm_source=dsf-banner">
-              Until November 9, 2025, <em>get PyCharm for 30% off</em>.
+              Until November 11, 2025, <em>get PyCharm for 30% off</em>.
               All money goes to the <em>Django Software Foundation</em>!
             </a>
           </p>


### PR DESCRIPTION
This is kind of confusing, but our blog post and internal agreements say through Nov 11, 2025 even though PyCharm’s page has the 9th on it.

Please hold off merging until their page has the appropriate dates https://www.jetbrains.com/pycharm/promo/support-django/ 

**Note:** We have might end up extending it back a few days. 