### PR TITLE
Populate description meta tag in base_weblog template (fix #2250)

### DIFF
--- a/djangoproject/templates/base_weblog.html
+++ b/djangoproject/templates/base_weblog.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load fundraising_extras i18n weblog %}
 {% block layout_class %}sidebar-right{% endblock %}
+{% block description %}{% translate "News & Events" %}{% endblock %}
 {% block title %}{% translate "News &amp; Events" %}{% endblock %}
 
 {% block og_title %}{% translate "News &amp; Events" %}{% endblock %}


### PR DESCRIPTION
Added a description block to base_weblog.html so that the meta description tag is populated for blog pages. This aligns the description with the page title, ensuring better previews on social platforms and search engines.