### PR TITLE
Change fundraising banner to November 11th

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -673,6 +673,9 @@ header {
             line-height: 1.3;
             padding: 1px 0 6px;
         }
+        .underlined {
+          text-decoration: underline;
+        }
     }
 
 

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -62,7 +62,7 @@
         <div class="banner">
           <p>
             <a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&utm_content=django25&utm_medium=referral&utm_source=dsf-banner">
-              Until November 11, 2025, <em><u>get PyCharm for 30% off</u></em>.
+              Until November 11, 2025, <em class="underlined">get PyCharm for 30% off</em>.
               All money goes to the <em>Django Software Foundation</em>!
             </a>
           </p>


### PR DESCRIPTION
This was requested by Catherine to the social media working group. She also requested to add the underline to the text to make it more obvious that it's a link.