### PR TITLE
Fix pre commit in container

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,8 @@ repos:
       rev: v3.7.4
       hooks:
           - id: prettier
+            # https://github.com/rbubley/mirrors-prettier/issues/3
+            language_version: 24.15.0
             exclude_types: [html, json, scss]
             exclude: '(^djangoproject\/static\/js\/lib\/.*$|^checklists\/templates\/.*$)'
 


### PR DESCRIPTION
`docker compose run --rm web python -m pre_commit run --all-files` does not currently work. Here are the changes needed to get it running properly.