### PR TITLE
Make use of Pathlib's "/"

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -15,7 +15,7 @@ DATA_DIR = (
 )
 
 try:
-    with DATA_DIR.joinpath("conf", "secrets.json").open() as handle:
+    with (DATA_DIR / "conf" / "secrets.json").open() as handle:
         SECRETS = json.load(handle)
 except OSError:
     SECRETS = {
@@ -54,7 +54,7 @@ DATABASE_ROUTERS = ["tracdb.db_router.TracRouter"]
 DEFAULT_FROM_EMAIL = "noreply@djangoproject.com"
 FUNDRAISING_DEFAULT_FROM_EMAIL = "fundraising@djangoproject.com"
 
-FIXTURE_DIRS = [str(PROJECT_PACKAGE.joinpath("fixtures"))]
+FIXTURE_DIRS = [PROJECT_PACKAGE / "fixtures"]
 
 INSTALLED_APPS = [
     "accounts",
@@ -184,7 +184,7 @@ SILENCED_SYSTEM_CHECKS = [
 
 SITE_ID = 1
 
-STATICFILES_DIRS = [str(PROJECT_PACKAGE.joinpath("static"))]
+STATICFILES_DIRS = [PROJECT_PACKAGE / "static"]
 
 STATIC_URL = "/s/"
 
@@ -196,7 +196,7 @@ STATICFILES_FINDERS = (
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [str(PROJECT_PACKAGE.joinpath("templates"))],
+        "DIRS": [PROJECT_PACKAGE / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "builtins": [

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -27,14 +27,14 @@ CSRF_COOKIE_SECURE = False
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-MEDIA_ROOT = str(DATA_DIR.joinpath("media_root"))
+MEDIA_ROOT = DATA_DIR / "media_root"
 
 SESSION_COOKIE_SECURE = False
 
-STATIC_ROOT = str(DATA_DIR.joinpath("static_root"))
+STATIC_ROOT = DATA_DIR / "static_root"
 
 # Docs settings
-DOCS_BUILD_ROOT = DATA_DIR.joinpath("djangodocs")
+DOCS_BUILD_ROOT = DATA_DIR / "djangodocs"
 
 # django-hosts settings
 

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -40,7 +40,7 @@ LOGGING["handlers"]["syslog"] = {
 }
 LOGGING["loggers"]["django.request"]["handlers"].append("syslog")
 
-MEDIA_ROOT = str(DATA_DIR.joinpath("media"))
+MEDIA_ROOT = DATA_DIR / "media"
 
 MEDIA_URL = f"https://media.{DOMAIN_NAME}/"
 
@@ -61,12 +61,12 @@ STORAGES = {
     },
 }
 
-STATIC_ROOT = str(DATA_DIR.joinpath("static"))
+STATIC_ROOT = DATA_DIR / "static"
 
 STATIC_URL = f"https://static.{DOMAIN_NAME}/"
 
 # Docs settings
-DOCS_BUILD_ROOT = DATA_DIR.joinpath("data", "docbuilds")
+DOCS_BUILD_ROOT = DATA_DIR / "data" / "docbuilds"
 
 # django-hosts settings
 

--- a/docs/models.py
+++ b/docs/models.py
@@ -188,10 +188,8 @@ class DocumentRelease(models.Model):
         self.documents.all().delete()
 
         # Read excluded paths from robots.docs.txt.
-        robots_path = settings.BASE_DIR.joinpath(
-            "djangoproject", "static", "robots.docs.txt"
-        )
-        with open(str(robots_path)) as fh:
+        robots_path = settings.BASE_DIR / "djangoproject" / "static" / "robots.docs.txt"
+        with robots_path.open() as fh:
             excluded_paths = [
                 line.strip().split("/")[-1]
                 for line in fh
@@ -472,6 +470,6 @@ class Document(models.Model):
     @cached_property
     def body(self):
         """The document's body"""
-        with open(str(self.full_path)) as fp:
+        with self.full_path.open() as fp:
             doc = json.load(fp)
         return doc["body"]

--- a/docs/tests/test_models.py
+++ b/docs/tests/test_models.py
@@ -570,10 +570,8 @@ class UpdateDocTests(TestCase):
         from robots indexing.
         """
         # Read the first Disallow line of robots.txt.
-        robots_path = settings.BASE_DIR.joinpath(
-            "djangoproject", "static", "robots.docs.txt"
-        )
-        with open(str(robots_path)) as fh:
+        robots_path = settings.BASE_DIR / "djangoproject" / "static" / "robots.docs.txt"
+        with robots_path.open() as fh:
             for line in fh:
                 if line.startswith("Disallow:"):
                     break

--- a/docs/tests/test_templates.py
+++ b/docs/tests/test_templates.py
@@ -31,14 +31,18 @@ class TemplateTagTests(TestCase):
         tmp_docs_build_root = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmp_docs_build_root)
         os.makedirs(
-            tmp_docs_build_root.joinpath(
-                settings.DEFAULT_LANGUAGE_CODE, "1.8", "_built", "json"
-            )
+            tmp_docs_build_root
+            / settings.DEFAULT_LANGUAGE_CODE
+            / "1.8"
+            / "_built"
+            / "json"
         )
         os.makedirs(
-            tmp_docs_build_root.joinpath(
-                settings.DEFAULT_LANGUAGE_CODE, "1.11", "_built", "json"
-            )
+            tmp_docs_build_root
+            / settings.DEFAULT_LANGUAGE_CODE
+            / "1.11"
+            / "_built"
+            / "json"
         )
         with self.settings(DOCS_BUILD_ROOT=tmp_docs_build_root):
             self.assertEqual(get_all_doc_versions({}), ["1.8", "1.11", "dev"])

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -1,12 +1,13 @@
 import re
 import unicodedata
+from pathlib import Path
 
 from django.conf import settings
 from django.http import Http404
 
 
 def get_doc_root(lang, version, builder="json"):
-    return settings.DOCS_BUILD_ROOT.joinpath(lang, version, "_built", builder)
+    return settings.DOCS_BUILD_ROOT / lang / version / "_built" / builder
 
 
 def get_doc_root_or_404(lang, version, builder="json"):
@@ -22,7 +23,7 @@ def get_doc_path(docroot, subpath):
         bits = subpath.strip("/").split("/") + ["index.fjson"]
     except AttributeError:
         bits = []
-    doc = docroot.joinpath(*bits)
+    doc = docroot / Path(*bits)
     try:
         if doc.exists():
             return doc
@@ -30,7 +31,7 @@ def get_doc_path(docroot, subpath):
         pass  # we get here if doc + subpath (without /index.fjson) is a file
 
     bits = bits[:-2] + ["%s.fjson" % bits[-2]]
-    doc = docroot.joinpath(*bits)
+    doc = docroot / Path(*bits)
     if doc.exists():
         return doc
 

--- a/docs/views.py
+++ b/docs/views.py
@@ -81,7 +81,7 @@ def document(request, lang, version, url):
 
     context = {
         "doc": load_json_file(doc_path),
-        "env": load_json_file(docroot.joinpath("globalcontext.json")),
+        "env": load_json_file(docroot / "globalcontext.json"),
         "lang": lang,
         "version": version,
         "canonical_version": canonical_version,
@@ -91,7 +91,7 @@ def document(request, lang, version, url):
         "rtd_version": rtd_version,
         "docurl": url,
         "update_date": datetime.datetime.fromtimestamp(
-            (docroot.joinpath("last_build")).stat().st_mtime
+            (docroot / "last_build").stat().st_mtime
         ),
         "redirect_from": request.GET.get("from", None),
     }

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -262,7 +262,7 @@ class TestWebhooks(ReleaseMixin, TestCase):
         )
 
     def stripe_data(self, filename):
-        file_path = settings.BASE_DIR.joinpath(f"fundraising/test_data/{filename}.json")
+        file_path = settings.BASE_DIR / f"fundraising/test_data/{filename}.json"
         with file_path.open() as f:
             data = json.load(f)
             return stripe.convert_to_stripe_object(data, stripe.api_key, None)


### PR DESCRIPTION
Coming from:
- https://github.com/django/djangoproject.com/pull/2213#discussion_r2376172687

It provides a cleaner experience and it's easier to read, comparing to `.joinpath()`