### PR TITLE
Remove redundant if condition from django debug toolbar init

### DIFF
--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -44,25 +44,24 @@ PARENT_HOST = "djangoproject.localhost:8000"
 
 PUSH_SSL_CALLBACK = False
 
-# Enable optional components
+# django-debug-toolbar initialization
+try:
+    import debug_toolbar  # NOQA
+except ImportError:
+    pass
+else:
+    INSTALLED_APPS.append("debug_toolbar")
+    INTERNAL_IPS = ["127.0.0.1"]
+    MIDDLEWARE.insert(
+        MIDDLEWARE.index("django.middleware.common.CommonMiddleware") + 1,
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+    )
+    MIDDLEWARE.insert(
+        MIDDLEWARE.index("debug_toolbar.middleware.DebugToolbarMiddleware") + 1,
+        "djangoproject.middleware.CORSMiddleware",
+    )
 
-if DEBUG:
-    try:
-        import debug_toolbar  # NOQA
-    except ImportError:
-        pass
-    else:
-        INSTALLED_APPS.append("debug_toolbar")
-        INTERNAL_IPS = ["127.0.0.1"]
-        MIDDLEWARE.insert(
-            MIDDLEWARE.index("django.middleware.common.CommonMiddleware") + 1,
-            "debug_toolbar.middleware.DebugToolbarMiddleware",
-        )
-        MIDDLEWARE.insert(
-            MIDDLEWARE.index("debug_toolbar.middleware.DebugToolbarMiddleware") + 1,
-            "djangoproject.middleware.CORSMiddleware",
-        )
-
+# django-recaptcha settings
 SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
     # Default test keys for development.
     "django_recaptcha.recaptcha_test_key_error"


### PR DESCRIPTION
DEBUG is defined as True in the same file. Because the variable value is hardcoded, `if DEBUG` will always give same result - hence not needed