### PR TITLE
Clean allowed hosts

### DIFF
--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -5,7 +5,7 @@ ALLOWED_HOSTS = [
     "djangoproject.localhost",
     "docs.djangoproject.localhost",
     "dashboard.djangoproject.localhost",
-] + SECRETS.get("allowed_hosts", [])
+]
 
 LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
 

--- a/djangoproject/settings/docker.py
+++ b/djangoproject/settings/docker.py
@@ -22,5 +22,3 @@ DATABASES["trac"] = {
 }
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
-
-ALLOWED_HOSTS = [".localhost", "127.0.0.1", "www.127.0.0.1"]


### PR DESCRIPTION
Small cleaning for `ALLOWED_HOSTS` in docker / dev settings.

This is not a duplicate of https://github.com/django/djangoproject.com/pull/2137