### PR TITLE
Enable codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,13 @@ jobs:
                   echo '"trac_db_host": "localhost", ' >> conf/secrets.json
                   echo '"trac_db_password": "secret", ' >> conf/secrets.json
                   echo '"secret_key": "a"}' >> conf/secrets.json
+
             - name: Run tests
               run: |
                   make ci
+                  coverage xml
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v5.5.1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,6 @@ jobs:
                   coverage xml
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5.5.1
+              uses: codecov/codecov-action@v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Coming from the discussion we had during the removal of coveralls. We are already using Sentry and it looks like codecov doesn't need any extra config.