### PR TITLE
Update --selection bg-color when default browser theme is dark

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -107,7 +107,7 @@ html[data-theme="light"],
         --search-link-hover: #{$green-light};
         --search-mark-text: #{$black-light-5};
 
-        --selection: #{$green-medium};
+        --selection: #{$green-dark};
 
         --community-img-bg: #{$green-dark};
         --community-img-fg: #{$white};


### PR DESCRIPTION
The `--selection` bg-color when default theme for browser is dark (and the user hasn't changed the theme at all, thus theme-icon-when-auto shows up) is **$(green-medium)** but the contrast is way too terrible (the actual value is 2.35 which is way too low)
<img width="554" height="174" alt="django-project" src="https://github.com/user-attachments/assets/a02d075f-e5b6-45ab-8a8e-e74eeb85c48c" />
