### PR TITLE
:pencil: Extend PyCharm discount end date to Nov 19

### DIFF
--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -62,7 +62,7 @@
         <div class="banner">
           <p>
             <a href="https://www.jetbrains.com/pycharm/promo/support-django/?utm_campaign=pycharm&utm_content=django25&utm_medium=referral&utm_source=dsf-banner">
-              Until November 11, 2025, <em class="underlined">get PyCharm for 30% off</em>.
+              Extended until November 19, 2025, <em class="underlined">get PyCharm for 30% off</em>.
               All money goes to the <em>Django Software Foundation</em>!
             </a>
           </p>


### PR DESCRIPTION
Our fundraising date has been extended through November 19th. See https://www.jetbrains.com/pycharm/promo/support-django/ 