### PR TITLE
Added upgrade utilities section to ecosystem page

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -324,9 +324,9 @@
     </li>
   </ul>
 
-  <h3 id="update-utilities">
+  <h3 id="upgrade-utilities">
     Upgrade utilities
-    <a class="headerlink" href="#update-utilities" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
+    <a class="headerlink" href="#upgrade-utilities" aria-label="Link to this heading" aria-describedby="community-ecosystem">¶</a>
   </h3>
   <ul>
     <li>


### PR DESCRIPTION
Includes a section for upgrade utilities with a link to `django-upgrade`. It uses the ReadTheDocs link because that's what the GitHub repo directly links to in the README.