### PR TITLE
Renamed "About" in header to "Foundation".

### DIFF
--- a/djangoproject/templates/includes/header.html
+++ b/djangoproject/templates/includes/header.html
@@ -27,14 +27,14 @@
         <li{% if 'weblog' in request.path %} class="active"{% endif %}>
           <a href="{% url 'weblog:index' %}">News</a>
         </li>
-        <li{% if 'community' in request.path or 'conduct' in request.path %} class="active"{% endif %}>
-          <a href="{% url 'community-index' %}">Community</a>
-        </li>
         <li>
           <a href="https://github.com/django/django" target="_blank" rel="noopener">Code</a>
         </li>
         <li>
           <a href="https://code.djangoproject.com/">Issues</a>
+        </li>
+        <li{% if 'community' in request.path or 'conduct' in request.path %} class="active"{% endif %}>
+          <a href="{% url 'community-index' %}">Community</a>
         </li>
         <li{% if 'foundation' in request.path %} class="active"{% endif %}>
           <a href="{% url 'homepage' %}foundation/">Foundation</a>


### PR DESCRIPTION
Fixes https://github.com/django/djangoproject.com/issues/2340

<img width="1221" height="469" alt="Screenshot from 2025-11-18 08-23-34" src="https://github.com/user-attachments/assets/0af7f9f3-ce68-4983-9081-f0a38493b24f" />

Did a poll on Mastodon and "Foundation" was the most popular with 28 votes, "DSF" had 2, and "About" also had 2 votes.