### PR TITLE
Updated new features proposal process on roadmap pages.

### DIFF
--- a/djangoproject/templates/releases/roadmap.html
+++ b/djangoproject/templates/releases/roadmap.html
@@ -19,9 +19,9 @@
     <p>Django {{ series }} will be a time-based release. Any features completed and committed
       to main by the alpha feature freeze deadline noted below will be included. Any
       that miss the deadline won't.</p>
-    <p>If you have a major feature you'd like to contribute, please introduce yourself
-      on the <a href="https://forum.djangoproject.com/c/internals/5">django-internals forum</a>
-      so you can find a shepherd for your feature.</p>
+    <p>If you have a major feature you'd like to contribute, please propose it on
+      <a href="https://github.com/orgs/django/projects/24/">new feature ideas GitHub project</a> and review the
+      <a href="https://docs.djangoproject.com/en/dev/internals/contributing/bugs-and-features/#requesting-features">requesting features documentation</a>.</p>
     <p>Minor features and bug fixes will be merged as they are completed. If you
       have submitted a patch, ensure the flags on the Trac ticket are correct so it
       appears in the "Patches needing review" filter of the


### PR DESCRIPTION
This now references the new features GitHub project board process the 6.x Steering Council has started. It also links to the docs regarding new features. Hopefully this provides readers with the information they would be looking for.