### PR TITLE
Removed references to "Documentation" in search as now a global search.

### DIFF
--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -1,7 +1,8 @@
 {% extends "docs/doc.html" %}
 {% load i18n docs %}
 
-{% block title %}{% translate "Search | Django documentation" %}{% endblock %}
+{% block title %}{% translate "Search" %}{% endblock %}
+{% block header %}<h1>{% translate "Search" %}</h1>{% endblock %}
 
 {% block toc-wrapper %}{% endblock %}
 {% block breadcrumbs-wrapper %}{% endblock %}


### PR DESCRIPTION
Realized I missed some old references that imply that the search is docs only

Before:

<img width="1422" height="529" alt="Screenshot from 2025-11-22 17-26-18" src="https://github.com/user-attachments/assets/76cb1a3d-fc4b-46ed-a38c-2ae79113d3f8" />


After: 

<img width="1422" height="529" alt="image" src="https://github.com/user-attachments/assets/b4191442-7796-4280-8417-868e3f0d97d4" />
