### PR TITLE
Improve spacing on search form field

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -581,7 +581,7 @@ header {
                 border: 0;
                 float: left;
                 text-align: left;
-                > :not(.search){
+                > :not(.search) {
                   padding: 10px;
                 }
             }
@@ -3057,12 +3057,9 @@ form {
         width: 20%;
         min-width: 200px;
         margin: 10px;
-        margin-left: 0;
+
         input {
           margin: 0;
-          @include respond-min(1080px) {
-            margin: 0 10px;
-          }
         }
     }
 }


### PR DESCRIPTION
Currently, there are two spacing issues I see in Vivaldi/Chrome around the searchbar in the top nav. Not sure if this is viewport width thing or a browser thing, though.

<img width="310" height="100" alt="Screenshot 2025-11-29 at 8 11 59 AM" src="https://github.com/user-attachments/assets/ac093cea-256d-436e-bdec-7fa3b9d634c9" />

This is what it looks like Firefox for me:

<img width="430" height="101" alt="image" src="https://github.com/user-attachments/assets/371f5cf3-113e-48e8-a103-068c130aa4f0" />

1. Too much whitespace to the right of the magnifying glass `button`.

Removing the explicit `width: 40px` takes away some of the whitespace around the magnifying button and makes the spacing look a little better to my eyes. When I search the repo for other `form-input` classes, I didn't see anywhere else that uses a `button` element inside the `form`, so I don't think this would affect anything else.

This is what it looks like in Vivaldi with that change:

<img width="399" height="97" alt="image" src="https://github.com/user-attachments/assets/f8bc4415-8b06-45e3-94d8-56c45713e3fa" />

And this is in Firefox:

<img width="438" height="100" alt="image" src="https://github.com/user-attachments/assets/e23af2e2-ecb8-4b06-93af-d7010e991753" />

2. The toggle is too close to the searchbar in Vivaldi. This does *not* seem to happen in Firefox. I have some ideas for that fix, but was thinking it might be better as a separate PR. Let me know if that makes sense or if it'd be better in this one.

Tagging @sarahboyce since she might know the most about the search bar because of https://github.com/django/djangoproject.com/pull/2262.