### PR TITLE
Fix typo: duplicated 'Python' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To run locally, you can either:
 Install and run locally from a virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Create a `Python Python 3.12 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
+#. Create a `Python 3.12 virtualenv and activate it <https://docs.python.org/3/library/venv.html>`_
 
 #. Install dependencies::
 


### PR DESCRIPTION
This PR fixes a small typo in README.rst where "Python Python 3.12" appeared instead of "Python 3.12".

No functional changes, documentation-only fix.
