### PR TITLE
Add djade linter for Django templates (Fixes #2372)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,8 @@ repos:
       rev: 0.2.2
       hooks:
           - id: checkmake
+    - repo: https://github.com/adamchainz/djade-pre-commit
+      rev: 1.7.0
+      hooks:
+          - id: djade
+            args: [--target-version, "6.0"]

--- a/checklists/templates/checklists/release-security-skeleton.md
+++ b/checklists/templates/checklists/release-security-skeleton.md
@@ -1,5 +1,4 @@
-{% load checklist_extras %}
-{% load tz %}
+{% load checklist_extras tz %}
 {% with cves=instance.cves versions=instance.versions cves_length=instance.cves|length %}
 # Django Security Release: {{ versions|enumerate_items }} ({{ when }})
 

--- a/checklists/templates/checklists/release_final_blogpost.md
+++ b/checklists/templates/checklists/release_final_blogpost.md
@@ -11,7 +11,7 @@ You can get Django {{ version }} from
 
 {% include "checklists/_releaser_info.md" %}
 {% if instance.eom_release %}
-With the release of Django {{ version }}, Django {{ instance.eom_release.feature_version}}
+With the release of Django {{ version }}, Django {{ instance.eom_release.feature_version }}
 has reached the end of mainstream support. The final minor bug fix release,
 [{{ instance.eom_release.version }}](https://docs.djangoproject.com/en/stable/releases/{{ instance.eom_release.version }}/),
 was issued on {{ instance.eom_release.date }}. Django {{ instance.eom_release.feature_version }}

--- a/checklists/templates/checklists/release_security_blogpost.md
+++ b/checklists/templates/checklists/release_security_blogpost.md
@@ -5,7 +5,7 @@ the Django team is issuing releases for
 These releases address the security issues detailed below. We encourage all
 users of Django to upgrade as soon as possible.
 {% for cve in cves %}
-## {{cve.headline_for_blogpost }}
+## {{ cve.headline_for_blogpost }}
 
 {{ cve.blogdescription|safe|default:cve.description }}
 {% if cve.reporter %}

--- a/dashboard/templates/base_dashboard.html
+++ b/dashboard/templates/base_dashboard.html
@@ -1,17 +1,18 @@
 {% extends "base.html" %}
-{% load i18n %}
-{% load static %}
+{% load i18n static %}
 
 {% block sectionid %}dashboard{% endblock %}
 
 {% block title %}{% translate 'Development dashboard' %}{% endblock %}
+
 {% block layout_class %}full-width{% endblock %}
+
 {% block header %}
   <h1>Development <em>dashboard</em></h1>
-{% endblock %}
+{% endblock header %}
 
 {% block javascript %}
   <script src="{% static "js/lib/jquery.min.js" %}"></script>
   <script src="{% static "js/lib/jquery.flot.min.js" %}"></script>
   <script src="{% static "js/dashboard/utils.js" %}"></script>
-{% endblock %}
+{% endblock javascript %}

--- a/dashboard/templates/dashboard/detail.html
+++ b/dashboard/templates/dashboard/detail.html
@@ -11,10 +11,10 @@
     </div>
     <a class="link-readmore back-link" href="{% url "dashboard-index" host "dashboard" %}">{% translate "All metrics" %}</a>
   </div>
-{% endblock %}
+{% endblock content %}
 
 {% block javascript %}
   {{ block.super }}
 
   <script src="{% static "js/dashboard/detail.js" %}"></script>
-{% endblock %}
+{% endblock javascript %}

--- a/dashboard/templates/dashboard/index.html
+++ b/dashboard/templates/dashboard/index.html
@@ -1,6 +1,5 @@
 {% extends "base_dashboard.html" %}
-{% load i18n %}
-{% load static %}
+{% load i18n static %}
 
 {% block content %}
   <div>
@@ -23,10 +22,10 @@
       {% blocktranslate with timestamp=data.0.latest.timestamp|timesince %}Updated {{ timestamp }} ago.{% endblocktranslate %}
     </p>
   </div>
-{% endblock %}
+{% endblock content %}
 
 {% block javascript %}
   {{ block.super }}
 
   <script src="{% static "js/dashboard/index.js" %}"></script>
-{% endblock %}
+{% endblock javascript %}

--- a/djangoproject/templates/400.html
+++ b/djangoproject/templates/400.html
@@ -9,4 +9,4 @@
     <h2>{% translate "Bad request" %}</h2>
 
     <p>{% translate "Yikes, this was a bad request. Not sure why, but it sure was bad." %}</p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/403.html
+++ b/djangoproject/templates/403.html
@@ -9,4 +9,4 @@
     <h2>{% translate "Permission denied" %}</h2>
 
     <p>{% translate "Apologies, but it seems as if you're not allowed to access this page. We honestly hope this is just a mistake." %}</p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/404.html
+++ b/djangoproject/templates/404.html
@@ -20,4 +20,4 @@
       Here's a link to the <a href="{{ homepage_url }}">homepage</a>. You know, just in case.
     {% endblocktranslate %}</p>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/410.html
+++ b/djangoproject/templates/410.html
@@ -23,4 +23,4 @@
     {% endblocktranslate %}
   </p>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/500.html
+++ b/djangoproject/templates/500.html
@@ -13,4 +13,4 @@
     <p>{% translate "We're messing around with things internally, and the server had a bit of a hiccup." %}</p>
 
     <p>{% translate "Please try again later." %}</p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/accounts/delete_profile.html
+++ b/djangoproject/templates/accounts/delete_profile.html
@@ -37,4 +37,4 @@
             </div>
         </form>
     {% endif %}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/accounts/delete_profile_success.html
+++ b/djangoproject/templates/accounts/delete_profile_success.html
@@ -13,4 +13,4 @@
             around on our <a href="{{ community_index_url }}">various community spaces</a>, online and off.
         {% endblocktranslate %}
     </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/accounts/edit_profile.html
+++ b/djangoproject/templates/accounts/edit_profile.html
@@ -31,7 +31,7 @@
             <input class="cta" type="submit" value="{% translate "Save" %}"/>
         </div>
     </form>
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
     <div role="complementary">
@@ -56,4 +56,4 @@
             </a>
         </p>
     </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/accounts/user_profile.html
+++ b/djangoproject/templates/accounts/user_profile.html
@@ -30,7 +30,7 @@
             </li>
         </ul>
     </div>
-{% endblock %}
+{% endblock content-related %}
 
 {% block content %}
     <div class="user-info">
@@ -54,7 +54,7 @@
             </ul>
         {% endif %}
 
-        {% with user_obj.owned_feeds.all as feeds %}
+        {% with feeds=user_obj.owned_feeds.all %}
             {% if feeds %}
                 <h2>{% translate "Community feeds:" %}</h2>
                 <ul>

--- a/djangoproject/templates/aggregator/delete-confirm.html
+++ b/djangoproject/templates/aggregator/delete-confirm.html
@@ -16,4 +16,4 @@
     {% csrf_token %}
     <p class="submit"><input class="cta" type="submit" value="{% translate "Yes, delete the feed." %}"></p>
   </form>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/aggregator/denied.html
+++ b/djangoproject/templates/aggregator/denied.html
@@ -5,4 +5,4 @@
     <h1>{% translate "Community" %}</h1>
 
     <h2>{% translate "Sorry, you can't do that." %}</h2>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -1,5 +1,5 @@
 {% extends "base_community.html" %}
-{% load i18n hosts %}
+{% load hosts i18n %}
 
 {% block content %}
 
@@ -478,4 +478,4 @@
     </li>
   </ul>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/aggregator/edit-feed.html
+++ b/djangoproject/templates/aggregator/edit-feed.html
@@ -27,4 +27,4 @@
     {% endif %}
   </form>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/aggregator/feeditem_list.html
+++ b/djangoproject/templates/aggregator/feeditem_list.html
@@ -44,4 +44,4 @@
     </div>
   {% endif %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/aggregator/index.html
+++ b/djangoproject/templates/aggregator/index.html
@@ -96,8 +96,8 @@
       </li>
     {% endfor %}
   </ul>
-{% endblock %}
+{% endblock content %}
 
 {% block content-related-extra %}
   {% top_corporate_members "diamond" "platinum" "gold" header="Diamond, Platinum and Gold Members" %}
-{% endblock %}
+{% endblock content-related-extra %}

--- a/djangoproject/templates/aggregator/local-django-community.html
+++ b/djangoproject/templates/aggregator/local-django-community.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-{#  Group meetups by country and then by location #}
+{# Group meetups by country and then by location #}
   {% regroup django_communities|dictsort:"continent" by continent as grouped_django_communities %}
 
 
@@ -14,14 +14,14 @@
   {% if grouped_django_communities %}<h3 id="table-of-contents">{% translate "Table of contents" %}<a class="plink" href="#table-of-contents"> ¶</a></h3>{% endif %}
   <ul>
     {% for local_django_community in grouped_django_communities %}
-      <li><a href="#{{ local_django_community.grouper.title | lower }}-meetups">{{ local_django_community.grouper.title }}</a></li>
+      <li><a href="#{{ local_django_community.grouper.title|lower }}-meetups">{{ local_django_community.grouper.title }}</a></li>
     {% endfor %}
   </ul>
 
 
   {% for local_django_community in grouped_django_communities %}
-    <div id="{{ local_django_community.grouper.title | lower }}-meetups" class="section">
-      <h2>{{ local_django_community.grouper.title }} <a class="plink" href="#{{ local_django_community.grouper.title | lower }}-meetups">¶</a></h2>
+    <div id="{{ local_django_community.grouper.title|lower }}-meetups" class="section">
+      <h2>{{ local_django_community.grouper.title }} <a class="plink" href="#{{ local_django_community.grouper.title|lower }}-meetups">¶</a></h2>
       <ul>
         {% for django_community in local_django_community.list %}
           <li>
@@ -50,5 +50,4 @@
     {% translate "Local Django communities are coming soon. Please check back later." %}
 
   {% endfor %}
-{##}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/aggregator/my-feeds.html
+++ b/djangoproject/templates/aggregator/my-feeds.html
@@ -24,4 +24,4 @@
   {# <li>Claim a feed already in the system.</li> #}
     </ul>
   </div>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -1,4 +1,4 @@
-{% load static banner %}<!DOCTYPE html>
+{% load banner static %}<!DOCTYPE html>
 <html lang="{% block html_language_code %}en{% endblock %}">
   <head>
     <meta charset="utf-8">
@@ -10,7 +10,7 @@
     <meta name="keywords" content="Python, Django, framework, open-source" />
     <meta name="description" content="{% block description %}{% endblock %}" />
     <meta name="fediverse:creator" content="@django@fosstodon.org" />
-    {% block link_rel_tags %}{% endblock link_rel_tags %}
+    {% block link_rel_tags %}{% endblock %}
     <!-- Favicons -->
     <link rel="apple-touch-icon" href="{% static "img/icon-touch.png" %}">
     <link rel="icon" sizes="192x192" href="{% static "img/icon-touch.png" %}">
@@ -23,12 +23,12 @@
       <meta property="og:title" content="{% block og_title %}Django{% endblock %}" />
       <meta property="og:description" content="{% block og_description %}{% spaceless %}
                                                  The web framework for perfectionists with deadlines.
-                                               {% endspaceless %}{% endblock %}" />
+                                               {% endspaceless %}{% endblock og_description %}" />
       <meta property="og:image" content="{% block og_image %}{% static "img/logos/django-logo-negative.png" %}{% endblock %}" />
       <meta property="og:image:alt" content="{% block og_image_alt %}Django logo{% endblock %}" />
       <meta property="og:image:width" content="{% block og_image_width %}1200{% endblock %}" />
       <meta property="og:image:height" content="{% block og_image_height %}546{% endblock %}" />
-      <meta property="og:image:type" content="{% block og_image_type%}image/png{% endblock %}"/>
+      <meta property="og:image:type" content="{% block og_image_type %}image/png{% endblock %}"/>
       <meta property="og:url" content="{{ request.build_absolute_uri }}" />
       <meta property="og:site_name" content="Django Project" />
 
@@ -42,7 +42,7 @@
     <link rel="stylesheet" href="{% static "css/output.css" %}" >
 
     <script src="{% static "js/mod/switch-dark-mode.js" %}"></script>
-    {% block head_extra %}{% endblock head_extra %}
+    {% block head_extra %}{% endblock %}
   </head>
 
   <body id="{% block sectionid %}generic{% endblock %}" class="{% block body_class %}{% endblock %}">
@@ -76,7 +76,7 @@
               {% endfor %}
             </ul>
           {% endif %}
-        {% endblock %}
+        {% endblock messages %}
 
         {% block content %}{% endblock %}
         <a href="#top" class="backtotop"><i class="icon icon-chevron-up"></i> Back to Top</a>
@@ -92,7 +92,7 @@
 
     {# Used to display urgent news, events, and alerts #}
     {% block alert %}
-    {% endblock %}
+    {% endblock alert %}
 
     <!-- SVGs -->
     <svg xmlns="http://www.w3.org/2000/svg">
@@ -104,7 +104,7 @@
 
     {% block footer %}
       {% include "includes/footer.html" %}
-    {% endblock %}
+    {% endblock footer %}
 
     {% block javascript %}
       {# Require JS #}
@@ -131,6 +131,6 @@
       </script>
       <script data-main="{% static "js/main.js" %}" src="{% static "js/lib/require.js" %}"></script>
       <script src="{% static "js/djangoproject.js" %}"></script>
-    {% endblock %}
+    {% endblock javascript %}
   </body>
 </html>

--- a/djangoproject/templates/base_2col.html
+++ b/djangoproject/templates/base_2col.html
@@ -3,12 +3,12 @@
 {% block columnwrap %}
   <div id="content-main">
     {% block content %}
-    {% endblock %}
+    {% endblock content %}
   </div>
   <!-- END #content-main -->
   <aside id="content-related" class="sidebar" aria-labelledby="aside-header">
     {% block content-related %}
-    {% endblock %}
+    {% endblock content-related %}
   </aside>
   <!-- END #content-related -->
-{% endblock %}
+{% endblock columnwrap %}

--- a/djangoproject/templates/base_3col.html
+++ b/djangoproject/templates/base_3col.html
@@ -16,4 +16,4 @@
     {% block content-extra %}{% endblock %}
   </div>
   <!-- END #content-extra -->
-{% endblock %}
+{% endblock columnwrap %}

--- a/djangoproject/templates/base_code.html
+++ b/djangoproject/templates/base_code.html
@@ -3,9 +3,11 @@
 {% block sectionid %}code{% endblock %}
 
 {% block og_title %}Django source code{% endblock %}
+
 {% block og_description %}Django source code{% endblock %}
 
 {% block title %}Code{% endblock %}
+
 {% block layout_class %}full-width{% endblock %}
 
 {% block header %}<h1>Django source code</h1>{% endblock %}

--- a/djangoproject/templates/base_community.html
+++ b/djangoproject/templates/base_community.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
-{% load fundraising_extras i18n hosts %}
+{% load fundraising_extras hosts i18n %}
 
 {% block og_title %}{% translate "Django Community" %}{% endblock %}
+
 {% block og_description %}{% translate "Building the Django Community. Come join us!" %}{% endblock %}
 
 {% block layout_class %}sidebar-right{% endblock %}
+
 {% block title %}{% translate "Django Community" %}{% endblock %}
 
 {% block header %}
@@ -18,7 +20,7 @@
     {% endif %}
     {% translate "Come join us!" %}
   </p>
-{% endblock %}
+{% endblock header %}
 
 {% block content-related %}
   <div role="complementary">
@@ -66,4 +68,4 @@
       <dd>{% translate "Download official logos" %}</dd>
     </dl>
   </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/base_foundation.html
+++ b/djangoproject/templates/base_foundation.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
-{% load fundraising_extras meetings i18n hosts %}
+{% load fundraising_extras hosts i18n meetings %}
 
 {% block og_title %}Django Software Foundation{% endblock %}
 
 {% block layout_class %}sidebar-right{% endblock %}
+
 {% block title %}Django Software Foundation{% endblock %}
 
 {% block header %}
   <p>Django Software Foundation</p>
-{% endblock %}
+{% endblock header %}
 
 {% block content-related %}
 
@@ -35,4 +36,4 @@
     {% render_latest_meeting_minute_entries 2 %}
     <a href="{% url 'foundation_meeting_archive_index' %}" class="link-readmore">{% translate "More meeting minutes" %}</a>
   </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/base_weblog.html
+++ b/djangoproject/templates/base_weblog.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
-{% load fundraising_extras i18n weblog hosts %}
+{% load fundraising_extras hosts i18n weblog %}
 {% block layout_class %}sidebar-right{% endblock %}
+
 {% block title %}{% translate "News &amp; Events" %}{% endblock %}
 
 {% block og_title %}{% translate "News &amp; Events" %}{% endblock %}
@@ -9,11 +10,11 @@
   {% if banner_is_title %}<h1>{% else %}<p>{% endif %}
   <a href="{% url 'weblog:index' %}">{% translate "News &amp; Events" %}</a>
   {% if banner_is_title %}</h1>{% else %}</p>{% endif %}
-{% endblock %}
+{% endblock header %}
 
 {% block head_extra %}
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url 'weblog-feed' %}" />
-{% endblock %}
+{% endblock head_extra %}
 
 {% block body_class %}blog{% endblock %}
 
@@ -59,4 +60,4 @@
       <li><a href="https://code.djangoproject.com/timeline?daysback=90&max=50&wiki=on&ticket=on&changeset=on&milestone=on&format=rss">{% translate "Recent code changes" %}</a></li>
     </ul>
   </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/blog/entry_archive.html
+++ b/djangoproject/templates/blog/entry_archive.html
@@ -24,4 +24,4 @@
 
   {% include 'blog/blog_pagination.html' %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/blog/entry_archive_day.html
+++ b/djangoproject/templates/blog/entry_archive_day.html
@@ -19,4 +19,4 @@
 
   {% include 'blog/blog_pagination.html' %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/blog/entry_archive_month.html
+++ b/djangoproject/templates/blog/entry_archive_month.html
@@ -19,4 +19,4 @@
 
   {% include 'blog/blog_pagination.html' %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/blog/entry_archive_year.html
+++ b/djangoproject/templates/blog/entry_archive_year.html
@@ -19,4 +19,4 @@
 
   {% include 'blog/blog_pagination.html' %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/blog/entry_detail.html
+++ b/djangoproject/templates/blog/entry_detail.html
@@ -20,4 +20,4 @@
         {% endblocktranslate %}
     </span>
     <div class="blog-entry-body">{{ object.body_html|safe }}</div>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/conduct/base.html
+++ b/djangoproject/templates/conduct/base.html
@@ -3,7 +3,7 @@
 
 {% block header %}
   <p>{% translate "Code of Conduct" %}</p>
-{% endblock %}
+{% endblock header %}
 
 {% block content-related %}
   <div role="complementary">
@@ -41,6 +41,6 @@
       {% endblocktranslate %}
     </p>
   </div>
-{% endblock %}
+{% endblock content-related %}
 
 {% block title %}{% translate "Django Code of Conduct" %}{% endblock %}

--- a/djangoproject/templates/conduct/changes.html
+++ b/djangoproject/templates/conduct/changes.html
@@ -4,6 +4,7 @@
 {% block title %}{% translate "Django Code of Conduct - Changes" %}{% endblock %}
 
 {% block og_title %}{% translate "Django Code of Conduct - Changes" %}{% endblock %}
+
 {% block og_description %}{% translate "Changes to the Code of Conduct" %}{% endblock %}
 
 {% block content %}
@@ -36,4 +37,4 @@
       <a href="https://github.com/django/code-of-conduct/blob/main/CHANGELOG.md">on
         GitHub</a>.{% endblocktranslate %}</p>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/conduct/enforcement.html
+++ b/djangoproject/templates/conduct/enforcement.html
@@ -4,6 +4,7 @@
 {% block title %}{% translate "Django Code of Conduct - Enforcement Manual" %}{% endblock %}
 
 {% block og_title %}{% translate "Django Code of Conduct - Enforcement Manual" %}{% endblock %}
+
 {% block og_description %}{% translate "This is the enforcement manual followed by Django's Code of Conduct working group" %}{% endblock %}
 
 {% block content %}
@@ -14,4 +15,4 @@
       This manual has moved to <a href="https://github.com/django/code-of-conduct/blob/main/working-group-manual.md">
         GitHub</a>. Please see the latest version there.{% endblocktranslate %}
   </h2>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/conduct/faq.html
+++ b/djangoproject/templates/conduct/faq.html
@@ -4,6 +4,7 @@
 {% block title %}{% translate "Django Code of Conduct - FAQ" %}{% endblock %}
 
 {% block og_title %}{% translate "Django Code of Conduct - FAQ" %}{% endblock %}
+
 {% block og_description %}{% translate "Common questions and concerns around the Django community's Code of Conduct" %}{% endblock %}
 
 {% block content %}
@@ -240,7 +241,7 @@
       whatever codes of conduct you want in the spaces that belong to you. Please
       honor this Code of Conduct in our spaces.{% endblocktranslate %}</p>
 
-{% endblock %}
+{% endblock content %}
 
 {% block head_extra %}
   {{ block.super }}

--- a/djangoproject/templates/conduct/index.html
+++ b/djangoproject/templates/conduct/index.html
@@ -4,6 +4,7 @@
 {% block title %}{% translate "Django Code of Conduct" %}{% endblock %}
 
 {% block og_title %}{% translate "Django Code of Conduct" %}{% endblock %}
+
 {% block og_description %}{% translate "Some ground rules for the community" %}{% endblock %}
 
 {% block content %}
@@ -558,4 +559,4 @@
     {% endblocktranslate %}
   </p>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/conduct/reporting.html
+++ b/djangoproject/templates/conduct/reporting.html
@@ -4,6 +4,7 @@
 {% block title %}{% translate "Django Code of Conduct - Reporting Guide" %}{% endblock %}
 
 {% block og_title %}{% translate "Django Code of Conduct - Reporting Guide" %}{% endblock %}
+
 {% block og_description %}{% translate "A guide to reporting issues in the community" %}{% endblock %}
 
 {% block content %}
@@ -259,11 +260,11 @@
   <h3 id="conflicts-of-interest">{% translate "Conflicts of Interest" %} <a class="plink" href="#conflicts-of-interest">#</a></h3>
 
   <p>
-    {% blocktrans trimmed %}
+    {% blocktranslate trimmed %}
       Any member of the working group must immediately notify the other members in
       writing (by disclosure on the report email thread) and recuse themselves from
       handling a report if they:
-    {% endblocktrans %}
+    {% endblocktranslate %}
   </p>
 
   <ul>
@@ -383,4 +384,4 @@
       decision-making. The board may request access to records for oversight purposes.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/contact/foundation.html
+++ b/djangoproject/templates/contact/foundation.html
@@ -48,4 +48,4 @@
       <button type="submit" class="cta arrow">{% translate "Send" %}</button>
     </div>
   </form>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/contact/sent.html
+++ b/djangoproject/templates/contact/sent.html
@@ -20,4 +20,4 @@
       it's an emergency.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/diversity/base.html
+++ b/djangoproject/templates/diversity/base.html
@@ -2,11 +2,12 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Django Community Diversity Statement" %}{% endblock %}
+
 {% block og_description %}{% translate "We welcome you." %}{% endblock %}
 
 {% block header %}
   <p>{% translate "Community Diversity Statement" %}</p>
-{% endblock %}
+{% endblock header %}
 
 {% block content-related %}
   <div role="complementary">
@@ -31,6 +32,6 @@
       </a>
     </p>
   </div>
-{% endblock %}
+{% endblock content-related %}
 
 {% block title %}{% translate "Django Community Diversity Statement" %}{% endblock %}

--- a/djangoproject/templates/diversity/changes.html
+++ b/djangoproject/templates/diversity/changes.html
@@ -2,6 +2,7 @@
 {% load date_format i18n %}
 
 {% block title %}{% translate "Django Community Diversity Statement - Changes" %}{% endblock %}
+
 {% block og_title %}{% translate "Django Community Diversity Statement - Changes" %}{% endblock %}
 
 {% block content %}
@@ -45,4 +46,4 @@
       {% translate "Initial release" %}</a>.</dd>
   </dl>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/diversity/index.html
+++ b/djangoproject/templates/diversity/index.html
@@ -109,4 +109,4 @@
       <a href="mailto:conduct@djangoproject.com">contact us</a>.
     {% endblocktranslate %}</p>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/flatfiles/default.html
+++ b/djangoproject/templates/flatfiles/default.html
@@ -4,4 +4,4 @@
     <h1>{{ flatpage.title }}</h1>
 
     {{ flatpage.content }}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/flatfiles/overview.html
+++ b/djangoproject/templates/flatfiles/overview.html
@@ -4,4 +4,4 @@
     <h1>{{ flatpage.title }}</h1>
 
     {{ flatpage.content }}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/flatpages/code.html
+++ b/djangoproject/templates/flatpages/code.html
@@ -6,4 +6,4 @@
     <h1>{{ flatpage.title }}</h1>
 
     {{ flatpage.content }}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/flatpages/community.html
+++ b/djangoproject/templates/flatpages/community.html
@@ -6,4 +6,4 @@
     <h1>{{ flatpage.title }}</h1>
 
     {{ flatpage.content }}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/flatpages/default.html
+++ b/djangoproject/templates/flatpages/default.html
@@ -8,8 +8,8 @@
 
 {% block header %}
     <h1>{{ flatpage.title }}</h1>
-{% endblock %}
+{% endblock header %}
 
 {% block content %}
     {{ flatpage.content }}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/flatpages/foundation.html
+++ b/djangoproject/templates/flatpages/foundation.html
@@ -7,8 +7,8 @@
 {% block content %}
     <h1>{{ flatpage.title }}</h1>
     {{ flatpage.content }}
-{% endblock %}
+{% endblock content %}
 
 {% block content-related-extra %}
     {% top_corporate_members "diamond" "platinum" "gold" header="Diamond, Platinum and Gold Members" %}
-{% endblock %}
+{% endblock content-related-extra %}

--- a/djangoproject/templates/foundation/banner_preview.html
+++ b/djangoproject/templates/foundation/banner_preview.html
@@ -6,4 +6,4 @@
     (last updated by {{ banner.updated_by }} on {{ banner.updated_at|date:"N j, Y, P" }})
   </p>
   {% include "foundation/banner.html" %}
-{% endblock %}
+{% endblock billboard %}

--- a/djangoproject/templates/foundation/coreawardcohort_list.html
+++ b/djangoproject/templates/foundation/coreawardcohort_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Django Core Developers" %}{% endblock %}
+
 {% block og_description %}{% translate "Former Django Core Team dissolved on March 12, 2020." %}{% endblock %}
 
 {% block content %}
@@ -21,10 +22,10 @@
     <ul>
       {% for recipient in cohort.recipients.all %}
         <li>
-          {% if recipient.link %}<a href="{{ recipient.link }}">{% endif %}{{ recipient}}{% if recipient.link %}</a>{% endif %}
+          {% if recipient.link %}<a href="{{ recipient.link }}">{% endif %}{{ recipient }}{% if recipient.link %}</a>{% endif %}
           {% if recipient.description %} &mdash; {{ recipient.description }}{% endif %}
         </li>
       {% endfor %}
     </ul>
   {% endfor %}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/foundation/meeting_archive.html
+++ b/djangoproject/templates/foundation/meeting_archive.html
@@ -2,11 +2,12 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Meeting minutes archive" %}{% endblock %}
+
 {% block og_description %}{% translate "View meeting minutes" %}{% endblock %}
 
 {% block head_extra %}
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url 'foundation-minutes-feed' %}" />
-{% endblock %}
+{% endblock head_extra %}
 
 {% block content %}
   <h1>{% translate "Meeting minutes archive" %}</h1>
@@ -22,4 +23,4 @@
       <li><a href="{% url 'foundation_meeting_archive_year' year=year.year %}">{{ year.year }}</a></li>
     {% endfor %}
   </ul>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/foundation/meeting_archive_day.html
+++ b/djangoproject/templates/foundation/meeting_archive_day.html
@@ -2,8 +2,9 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Meeting minutes archive" %}{% endblock %}
+
 {% block og_description %}{% blocktranslate trimmed with day=day|date:"DATE_FORMAT" %}
-  View meeting minutes for {{ day }}{% endblocktranslate %}{% endblock %}
+  View meeting minutes for {{ day }}{% endblocktranslate %}{% endblock og_description %}
 
 {% block content %}
   <h1>{% blocktranslate trimmed with day=day|date:"DATE_FORMAT" %}
@@ -14,4 +15,4 @@
       <li><a href="{{ meeting.get_absolute_url }}">{{ meeting }}</a></li>
     {% endfor %}
   </ul>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/foundation/meeting_archive_month.html
+++ b/djangoproject/templates/foundation/meeting_archive_month.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Meeting minutes archive" %}{% endblock %}
+
 {% block og_description %}{% blocktranslate with month=month|date:"F, Y" %}View meeting minutes for {{ month }}{% endblocktranslate %}{% endblock %}
 
 {% block content %}
@@ -12,4 +13,4 @@
       <li><a href="{{ meeting.get_absolute_url }}">{{ meeting }}</a></li>
     {% endfor %}
   </ul>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/foundation/meeting_archive_year.html
+++ b/djangoproject/templates/foundation/meeting_archive_year.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Meeting minutes archive" %}{% endblock %}
+
 {% block og_description %}{% blocktranslate with year=year|date:"Y" %}View meeting minutes for {{ year }}{% endblocktranslate %}{% endblock %}
 
 {% block content %}
@@ -12,4 +13,4 @@
       <li><a href="{{ meeting.get_absolute_url }}">{{ meeting }}</a></li>
     {% endfor %}
   </ul>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/foundation/meeting_detail.html
+++ b/djangoproject/templates/foundation/meeting_detail.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block og_title %}{% blocktranslate %}Meeting minutes: {{ meeting }}{% endblocktranslate %}{% endblock %}
+
 {% block og_description %}{% blocktranslate %}Meeting minutes for {{ meeting }}{% endblocktranslate %}{% endblock %}
 
 {% block content %}
@@ -103,4 +104,4 @@
       {% endfor %}
     </ul>
   {% endif %}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/foundation/meeting_snippet.html
+++ b/djangoproject/templates/foundation/meeting_snippet.html
@@ -5,7 +5,7 @@
       <h4>
         <a href="{{ m.get_absolute_url }}">{{ m }}</a>
       </h4>
-      {% with m.business.all as businesses %}
+      {% with businesses=m.business.all %}
         {% if businesses %}
           <div class="meta">
             <b>{% translate "New and Ongoing business" %}</b>

--- a/djangoproject/templates/fundraising/index.html
+++ b/djangoproject/templates/fundraising/index.html
@@ -1,10 +1,12 @@
 {% extends 'base.html' %}
-{% load fundraising_extras humanize i18n static hosts %}
+{% load fundraising_extras hosts humanize i18n static %}
 
 {% block title %}{% translate "Support Django" %}{% endblock %}
+
 {% block layout_class %}full-width{% endblock %}
 
 {% block og_title %}{% translate "Support Django" %}{% endblock %}
+
 {% block og_description %}{% translate "Support Django development by donating to the Django Software Foundation" %}{% endblock %}
 
 {% block header %}
@@ -13,7 +15,7 @@
       <em>Support Django development</em> by donating to the <em>Django Software Foundation</em>.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock header %}
 
 {% block billboard %}{% endblock %}
 
@@ -26,7 +28,7 @@
     <hr>
   {% endif %}
 
-{% endblock %}
+{% endblock messages %}
 
 {% block content %}
 
@@ -247,7 +249,7 @@
 
     {% display_django_heroes %}
   </div>
-{% endblock %}
+{% endblock content %}
 
 {% block content-extra %}
   <div class="layout-tertiary" id="about">
@@ -349,4 +351,4 @@
       </p>
     </div>
   </div>
-{% endblock %}
+{% endblock content-extra %}

--- a/djangoproject/templates/fundraising/manage-donations.html
+++ b/djangoproject/templates/fundraising/manage-donations.html
@@ -10,7 +10,7 @@
     <hr aria-hidden="true" />
   {% endif %}
 
-{% endblock %}
+{% endblock messages %}
 
 {% block content %}
 
@@ -83,6 +83,6 @@
         {% endfor %}
       </ul>
     {% endif %}
-{% endblock %}
+{% endblock content %}
 
 {% block content-extra %}{% endblock %}

--- a/djangoproject/templates/fundraising/thank-you.html
+++ b/djangoproject/templates/fundraising/thank-you.html
@@ -41,6 +41,6 @@
     {% endblocktranslate %}
   </p>
 
-{% endblock %}
+{% endblock content %}
 
 {% block content-extra %}{% endblock %}

--- a/djangoproject/templates/homepage.html
+++ b/djangoproject/templates/homepage.html
@@ -1,8 +1,10 @@
 {% extends "base_3col.html" %}
-{% load fundraising_extras i18n weblog hosts %}
+{% load fundraising_extras hosts i18n weblog %}
 
 {% block sectionid %}homepage{% endblock %}
+
 {% block body_class %}homepage{% endblock %}
+
 {% block layout_class %}column-container sidebar-right{% endblock %}
 
 {% block header %}
@@ -12,7 +14,7 @@
   <p>
     <a href="{% url 'start' %}" class="cta">{% translate "Get started with Django" %}</a>
   </p>
-{% endblock %}
+{% endblock header %}
 
 {% block content %}
   <div class="section">
@@ -100,7 +102,7 @@
     {% endcomment %}
 
     <!-- END #content-secondary -->
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
   <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
@@ -192,7 +194,7 @@
       {% endcomment %}
   </div>
 
-{% endblock %}
+{% endblock content-related %}
 
 {% block alert %}
   {% comment %}
@@ -211,4 +213,4 @@
     </div>
   </div>
   {% endcomment %}
-{% endblock %}
+{% endblock alert %}

--- a/djangoproject/templates/members/corporate_member_badges.html
+++ b/djangoproject/templates/members/corporate_member_badges.html
@@ -49,4 +49,4 @@
       {% endfor %}
     </div>
   {% endfor %}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/members/corporate_members_join_thanks.html
+++ b/djangoproject/templates/members/corporate_members_join_thanks.html
@@ -9,4 +9,4 @@
       response from the board after our next monthly meeting.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/members/corporatemember_form.html
+++ b/djangoproject/templates/members/corporatemember_form.html
@@ -14,7 +14,7 @@
     {% csrf_token %}
     {% for field in form %}
       <div class="form-control">
-        {% if field.name in form.label_fields  %}
+        {% if field.name in form.label_fields %}
           {{ field.label }}: {{ field }}
         {% else %}
           {{ field }}
@@ -25,4 +25,4 @@
     {% endfor %}
     <input class="cta" type="submit" value="{% translate "Send →" %}">
   </form>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/members/corporatemember_list.html
+++ b/djangoproject/templates/members/corporatemember_list.html
@@ -1,7 +1,8 @@
 {% extends "base_foundation.html" %}
-{% load humanize i18n hosts %}
+{% load hosts humanize i18n %}
 
 {% block og_title %}{% translate "Corporate members" %}{% endblock %}
+
 {% block og_description %}{% translate "The following organizations are corporate members of the Django Software Foundation." %}{% endblock %}
 
 {% block content %}
@@ -66,4 +67,4 @@
     </ul>
   {% endif %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/members/individualmember_list.html
+++ b/djangoproject/templates/members/individualmember_list.html
@@ -91,4 +91,4 @@
       {% endfor %}
     </ul>
   {% endif %}
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block og_title %}{% translate "Meet the Teams | Django Software Foundation" %}{% endblock %}
+
 {% block og_description %}{% spaceless %}
   {% blocktranslate trimmed %}
     Get to know the teams behind the Django Software Foundation,
@@ -9,13 +10,13 @@
     their roles and responsibilities in advancing the development and
     adoption of the Django web framework.
   {% endblocktranslate %}
-{% endspaceless %}{% endblock %}
+{% endspaceless %}{% endblock og_description %}
 
 {% block content %}
 
   <h2>{% translate "Teams" %}</h2>
   <p>
-    {% url 'document-detail' lang='en' version='dev' url='internals/organization' host 'docs'  as organization_url %}
+    {% url 'document-detail' lang='en' version='dev' url='internals/organization' host 'docs' as organization_url %}
     {% blocktranslate trimmed %}
       The following teams are groups of people who support the Django project
       and the Django Software Foundation. Apart from the Django Fellows, who
@@ -43,4 +44,4 @@
     </div>
   {% endfor %}
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/overview.html
+++ b/djangoproject/templates/overview.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 
 {% block title %}{% translate "Django overview" %}{% endblock %}
+
 {% block layout_class %}full-width{% endblock %}
+
 {% block og_title %}{% translate "Django overview" %}{% endblock %}
 
 {% block header %}
@@ -12,7 +14,7 @@
       requirements of <em>experienced web developers</em>.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock header %}
 
 {% block content %}
   <h1>{% translate "Why Django?" %}</h1>
@@ -80,7 +82,7 @@
   <div class="section">
     <a href="{% url 'start' %}" class="cta">{% translate "Get started <em>with Django</em>" %}</a>
   </div>
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
 
@@ -116,7 +118,7 @@
 </div>
 {% endcomment %}
 
-{% endblock %}
+{% endblock content-related %}
 
 {% block content-extra %}
 
@@ -137,4 +139,4 @@
       </ul>
     </div>
   </div>
-{% endblock %}
+{% endblock content-extra %}

--- a/djangoproject/templates/registration/activate.html
+++ b/djangoproject/templates/registration/activate.html
@@ -11,4 +11,4 @@
       the activation key for your account has expired; activation keys are
       only valid for {{ days }} days after registration.
     {% endblocktranslate %}</p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/registration/activation_complete.html
+++ b/djangoproject/templates/registration/activation_complete.html
@@ -11,4 +11,4 @@
       Thanks for signing up! Now you can <a href="{{ login_url }}">log in</a>.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/registration/base.html
+++ b/djangoproject/templates/registration/base.html
@@ -1,4 +1,5 @@
 {% extends "base_2col.html" %}
 {% load i18n %}
 {% block sectionid %}community{% endblock %}
+
 {% block header %}<p>{% translate "Accounts" %}</p>{% endblock %}

--- a/djangoproject/templates/registration/logged_out.html
+++ b/djangoproject/templates/registration/logged_out.html
@@ -11,4 +11,4 @@
       Thanks for stopping by; when you come back, don't forget to <a href="{{ login_url }}">log in</a> again.
     {% endblocktranslate %}
   </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/registration/login.html
+++ b/djangoproject/templates/registration/login.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 
 {% block title %}{% translate "Log in" %}{% endblock %}
+
 {% block og_title %}{% translate "Log in" %}{% endblock %}
+
 {% block og_description %}{% translate "Log in to your account" %}{% endblock %}
 
 {% block content %}
@@ -37,7 +39,7 @@
             <input type="submit" value="{% translate 'Log in' %}" class="cta"/>
         </p>
     </form>
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
     <div role="complementary">
@@ -57,4 +59,4 @@
             {% endblocktranslate %}
         </p>
     </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/registration/password_reset_email.html
+++ b/djangoproject/templates/registration/password_reset_email.html
@@ -6,7 +6,7 @@
     {% translate "Please go to the following page and choose a new password:" %}
     {% block reset_link %}
         {% url 'password_reset_confirm' uidb64=uid token=token %}
-    {% endblock %}
+    {% endblock reset_link %}
     {% translate "Your username, in case you've forgotten:" %} {{ user.username }}
 
     {% translate "Thanks for using our site!" %}

--- a/djangoproject/templates/registration/registration_complete.html
+++ b/djangoproject/templates/registration/registration_complete.html
@@ -11,4 +11,4 @@
             for activating your account.
         {% endblocktranslate %}
     </p>
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -45,7 +45,7 @@
     </p>
   </form>
 
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
   <div role="complementary">
@@ -79,4 +79,4 @@
       {% endblocktranslate %}
     </p>
   </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -2,19 +2,28 @@
 {% load fundraising_extras release_notes static %}
 
 {% block sectionid %}download{% endblock %}
+
 {% block title %}Download Django{% endblock %}
+
 {% block layout_class %}sidebar-right{% endblock %}
 
 {% block og_title %}Download Django{% endblock %}
+
 {% block og_image %}{% static "img/release-roadmap.svg" %}{% endblock %}
+
 {% block og_image_alt %}Django's release roadmap{% endblock %}
+
 {% block og_description %}The latest official version is {{ current.version }}{% if current.is_lts %} (LTS){% endif %}{% endblock %}
+
 {% block og_image_width %}1030{% endblock %}
+
 {% block og_image_height %}480{% endblock %}
+
 {% block og_image_type %}image/svg+xml{% endblock %}
+
 {% block header %}
   <p>Download</p>
-{% endblock %}
+{% endblock header %}
 
 {% block content %}
   <h1>How to get Django</h1>
@@ -35,7 +44,7 @@
   <pre class="literal-block"><code>py -m pip install Django=={{ current.version }}</code></pre>
 
   {% if preview %}
-    {% with preview.version|slice:":3" as major_version %}
+    {% with major_version=preview.version|slice:":3" %}
       <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
       <p>As part of the
         <a href="https://code.djangoproject.com/wiki/Version{{ major_version }}Roadmap">
@@ -272,7 +281,7 @@
     <sup id="ft3">[3] Last version to support Python 2.7.</sup>
   </p>
 
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
 
@@ -323,4 +332,4 @@
 
   </div>
 
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/releases/roadmap.html
+++ b/djangoproject/templates/releases/roadmap.html
@@ -2,12 +2,14 @@
 {% load date_format fundraising_extras hosts %}
 
 {% block sectionid %}roadmap{% endblock %}
+
 {% block title %}Django {{ series }} Roadmap{% endblock %}
+
 {% block layout_class %}sidebar-right{% endblock %}
 
 {% block header %}
   <p>Download</p>
-{% endblock %}
+{% endblock header %}
 
 {% block content %}
   <h1>Django {{ series }} Roadmap</h1>
@@ -116,11 +118,11 @@
     </section>
   </section>
 
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %}
   <div role="complementary">
     <h2 class="visuallyhidden" id="aside-header">Additional Information</h2>
     {% donation_snippet %}
   </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/start.html
+++ b/djangoproject/templates/start.html
@@ -2,8 +2,11 @@
 {% load docs i18n %}
 
 {% block layout_class %}full-width{% endblock %}
+
 {% block title %}{% translate "Getting started with Django" %}{% endblock %}
+
 {% block og_title %}{% translate "Getting started with Django" %}{% endblock %}
+
 {% block og_description %}{% translate "It's quick & easy to get up and running with Django" %}{% endblock %}
 
 {% block header %}
@@ -17,7 +20,7 @@
       </a>
     </div>
   </div>
-{% endblock %}
+{% endblock header %}
 
 {% block content %}
 
@@ -345,4 +348,4 @@ def homepage(request):
         </li>
       </ul>
 
-{% endblock %}
+{% endblock content %}

--- a/djangoproject/templates/styleguide.html
+++ b/djangoproject/templates/styleguide.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}Django Web Styleguide{% endblock %}
+
 {% block body_class %}styleguide{% endblock %}
 
 {% block header %}<p>Style Guide</p>{% endblock %}
@@ -408,7 +409,7 @@
     </div>
   </div>
 
-{% endblock %}
+{% endblock content %}
 
 {% block content-related %} {# Always include <h1> label and <div> with aria role. #}
   <div role="complementary">
@@ -445,4 +446,4 @@
       </li>
     </ul>
   </div>
-{% endblock %}
+{% endblock content-related %}

--- a/djangoproject/templates/tracdb/bouncing_tickets.html
+++ b/djangoproject/templates/tracdb/bouncing_tickets.html
@@ -30,4 +30,4 @@
     </tbody>
   </table>
 
-{% endblock %}
+{% endblock content %}

--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -3,14 +3,14 @@
 
 {% block html_language_code %}{{ lang|default:"en" }}{% endblock %}
 
-{% block title %}{% trans 'Django Documentation' %}{% endblock %}
+{% block title %}{% translate 'Django Documentation' %}{% endblock %}
 
 {% block header-classes %}
   container--flex container--flex--wrap--mobile
-{% endblock %}
+{% endblock header-classes %}
 
 {% block header %}
-  <p><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></p>
-{% endblock %}
+  <p><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% translate 'Documentation' %}</a></p>
+{% endblock header %}
 
 {% block layout_class %}sidebar-right{% endblock %}

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -1,8 +1,9 @@
 {% extends "base_docs.html" %}
-{% load i18n fundraising_extras docs %}
+{% load docs fundraising_extras i18n %}
 
-{% block title %}{{ doc.title|striptags|safe }} | {% trans "Django documentation" %}{% endblock %}
-{% block og_title %}{{ doc.title|striptags }} | {% trans "Django documentation" %}{% endblock %}
+{% block title %}{{ doc.title|striptags|safe }} | {% translate "Django documentation" %}{% endblock %}
+
+{% block og_title %}{{ doc.title|striptags }} | {% translate "Django documentation" %}{% endblock %}
 
 {% block doc_url %}{% url 'document-index' lang=lang version=version host 'docs' %}{% endblock %}
 
@@ -31,23 +32,23 @@
   <link rel="search"
         type="application/opensearchdescription+xml"
         href="{% url 'document-search-description' lang=lang version=version host 'docs' %}"
-        title="{% trans "Django documentation" %}">
+        title="{% translate "Django documentation" %}">
 {% endblock link_rel_tags %}
 
 {% block before_header %}
   {% if release.is_dev %}
     {% if "internals" not in docurl %}{# The dev version is canonical for internals/. #}
       <div id="dev-warning" class="doc-floating-warning">
-        {% trans "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
+        {% translate "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
       </div>
     {% endif %}
   {% elif release.is_preview %}
     <div id="dev-warning" class="doc-floating-warning">
-      {% trans "This document is for a preview release of Django, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
+      {% translate "This document is for a preview release of Django, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
     </div>
   {% elif not release.is_supported %}
     <div id="outdated-warning" class="doc-floating-warning">
-      {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
+      {% translate "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
     </div>
   {% endif %}
 {% endblock before_header %}
@@ -57,13 +58,13 @@
     <ul id="faq-link">
       <li class="current-link">
         <a href="{% url 'document-detail' lang=lang version=version url='faq/help' host 'docs' %}">
-          <span>{% trans "Getting Help" %}</span>
+          <span>{% translate "Getting Help" %}</span>
         </a>
       </li>
     </ul>
     <ul id="doc-languages" class="language-switcher doc-switcher">
       <li class="current">
-        <button>{% trans "Language:" %} <strong>{{ lang }}</strong></button>
+        <button>{% translate "Language:" %} <strong>{{ lang }}</strong></button>
       </li>
       {% for available_lang in available_languages reversed %}
         {% if lang != available_lang %}
@@ -82,7 +83,7 @@
     {% get_all_doc_versions docurl as other_versions %}
     <ul id="doc-versions" class="version-switcher doc-switcher">
       <li class="current {% if release.is_dev %}dev{% endif %}">
-        <button>{% trans "Documentation version:" %}
+        <button>{% translate "Documentation version:" %}
           <strong>{% if release.is_dev %}development{% else %}{{ version }}{% endif %}</strong>
         </button>
       </li>
@@ -126,7 +127,6 @@
 
 {% endblock content %}
 
-
 {% block content-related %}
   <div role="complementary">
     <h2 class="visuallyhidden" id="aside-header">{% translate "Additional Information" %}</h2>
@@ -134,7 +134,7 @@
     {% donation_snippet %}
 
     {% block toc-wrapper %}
-      <h3>{% trans "Contents" %}</h3>
+      <h3>{% translate "Contents" %}</h3>
       {% block toc %}
         {{ doc.toc|safe }}
       {% endblock toc %}
@@ -142,16 +142,16 @@
 
     {% block browse-wrapper %}
       <nav aria-labelledby="browse-header">
-        <h3 id="browse-header">{% trans "Browse" %}</h3>
+        <h3 id="browse-header">{% translate "Browse" %}</h3>
         <ul>
           {% block browse %}
             {% if doc.prev %}
-              <li>{% trans "Prev:" %} <a rel="prev" href="{{ doc.prev.link }}">{{ doc.prev.title|safe }}</a></li>
+              <li>{% translate "Prev:" %} <a rel="prev" href="{{ doc.prev.link }}">{{ doc.prev.title|safe }}</a></li>
             {% endif %}
             {% if doc.next %}
-              <li>{% trans "Next:" %} <a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }}</a></li>
+              <li>{% translate "Next:" %} <a rel="next" href="{{ doc.next.link }}">{{ doc.next.title|safe }}</a></li>
             {% endif %}
-            <li><a href="{% url 'document-detail' lang=lang version=version url="contents" host 'docs' %}">{% trans "Table of contents" %}</a></li>
+            <li><a href="{% url 'document-detail' lang=lang version=version url="contents" host 'docs' %}">{% translate "Table of contents" %}</a></li>
             {% for doc, title, accesskey, shorttitle in env.rellinks %}
               <li><a href="{% url 'document-detail' lang=lang version=version url=doc host 'docs' %}">{{ title }}</a></li>
             {% endfor %}
@@ -162,14 +162,14 @@
 
     {% block breadcrumbs-wrapper %}
       <nav aria-labelledby="breadcrumbs-header">
-        <h3 id="breadcrumbs-header">{% trans "You are here:" %}</h3>
+        <h3 id="breadcrumbs-header">{% translate "You are here:" %}</h3>
         <ul>
           <li>
-            <a href="{% url 'document-index' lang=lang version=version host 'docs' %}">{% blocktrans %}Django {{ version }} documentation{% endblocktrans %}</a>
+            <a href="{% url 'document-index' lang=lang version=version host 'docs' %}">{% blocktranslate %}Django {{ version }} documentation{% endblocktranslate %}</a>
             {% for p in doc.parents %}
               <ul><li><a href="{{ p.link }}">{{ p.title|safe }}</a>
             {% endfor %}
-            <ul><li>{% block current-page-title %}{{ doc.title|safe }}{% endblock current-page-title %}</li></ul>
+            <ul><li>{% block current-page-title %}{{ doc.title|safe }}{% endblock %}</li></ul>
             {% for p in doc.parents %}</li></ul>{% endfor %}
           </li>
         </ul>
@@ -178,38 +178,38 @@
 
     {% block help-wrapper %}
       <section aria-labelledby="getting-help-sidebar">
-        <h3 id="getting-help-sidebar">{% trans "Getting help" %}</h3>
+        <h3 id="getting-help-sidebar">{% translate "Getting help" %}</h3>
         <dl class="list-links">
-          <dt><a href="{% url 'document-detail' lang=lang version=version url="faq" host 'docs' %}">{% trans "FAQ" %}</a></dt>
-          <dd>{% blocktrans %}Try the FAQ — it's got answers to many common questions.{% endblocktrans %}</dd>
+          <dt><a href="{% url 'document-detail' lang=lang version=version url="faq" host 'docs' %}">{% translate "FAQ" %}</a></dt>
+          <dd>{% blocktranslate %}Try the FAQ — it's got answers to many common questions.{% endblocktranslate %}</dd>
 
-          <dt><a href="{% url 'document-detail' lang='en' version='stable' url='genindex' host 'docs' %}">{% trans "Index" %}</a>, <a href="{% url 'document-detail' lang='en' version='stable' url='py-modindex' host 'docs' %}">{% trans "Module Index" %}</a>, or <a href="{% url 'document-detail' lang='en' version='stable' url='contents' host 'docs' %}">{% trans "Table of Contents" %}</a></dt>
-          <dd>{% blocktrans %}Handy when looking for specific information.{% endblocktrans %}</dd>
+          <dt><a href="{% url 'document-detail' lang='en' version='stable' url='genindex' host 'docs' %}">{% translate "Index" %}</a>, <a href="{% url 'document-detail' lang='en' version='stable' url='py-modindex' host 'docs' %}">{% translate "Module Index" %}</a>, or <a href="{% url 'document-detail' lang='en' version='stable' url='contents' host 'docs' %}">{% translate "Table of Contents" %}</a></dt>
+          <dd>{% blocktranslate %}Handy when looking for specific information.{% endblocktranslate %}</dd>
 
-          <dt><a href="https://chat.djangoproject.com">{% trans "Django Discord Server" %}</a></dt>
-          <dd>{% blocktrans %}Join the Django Discord Community.{% endblocktrans %}</dd>
+          <dt><a href="https://chat.djangoproject.com">{% translate "Django Discord Server" %}</a></dt>
+          <dd>{% blocktranslate %}Join the Django Discord Community.{% endblocktranslate %}</dd>
 
-          <dt><a href="https://forum.djangoproject.com/">{% trans "Official Django Forum" %}</a></dt>
-          <dd>{% blocktrans %}Join the community on the Django Forum.{% endblocktrans %}</dd>
+          <dt><a href="https://forum.djangoproject.com/">{% translate "Official Django Forum" %}</a></dt>
+          <dd>{% blocktranslate %}Join the community on the Django Forum.{% endblocktranslate %}</dd>
 
-          <dt><a href="https://code.djangoproject.com/">{% trans "Ticket tracker" %}</a></dt>
-          <dd>{% blocktrans %}Report bugs with Django or Django documentation in our ticket tracker.{% endblocktrans %}</dd>
+          <dt><a href="https://code.djangoproject.com/">{% translate "Ticket tracker" %}</a></dt>
+          <dd>{% blocktranslate %}Report bugs with Django or Django documentation in our ticket tracker.{% endblocktranslate %}</dd>
         </dl>
       </section>
     {% endblock help-wrapper %}
 
     {% block links-wrapper %}
       <section aria-labelledby="links-wrapper-header">
-        <h3 id="links-wrapper-header">{% trans "Download:" %}</h3>
+        <h3 id="links-wrapper-header">{% translate "Download:" %}</h3>
         <p>
-          {% if version == "dev" %}{% trans "Offline (development version):" %}
-          {% else %}{% blocktrans %}Offline (Django {{ version }}):{% endblocktrans %}{% endif %}
+          {% if version == "dev" %}{% translate "Offline (development version):" %}
+          {% else %}{% blocktranslate %}Offline (Django {{ version }}):{% endblocktranslate %}{% endif %}
           <a href="{{ MEDIA_URL }}docs/django-docs-{{ version }}-{{ lang }}.zip">HTML</a> |
           <a href="https://media.readthedocs.org/pdf/django/{{ rtd_version }}/django.pdf">PDF</a> |
           <a href="https://media.readthedocs.org/epub/django/{{ rtd_version }}/django.epub">ePub</a>
           <br>
           <span class="quiet">
-            {% blocktrans %}Provided by <a href="https://readthedocs.org/">Read the Docs</a>.{% endblocktrans %}
+            {% blocktranslate %}Provided by <a href="https://readthedocs.org/">Read the Docs</a>.{% endblocktranslate %}
           </span>
         </p>
       </section>

--- a/docs/templates/docs/genindex.html
+++ b/docs/templates/docs/genindex.html
@@ -1,12 +1,14 @@
 {% extends "docs/doc.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "General Index | Django Documentation" %}{% endblock %}
+{% block title %}{% translate "General Index | Django Documentation" %}{% endblock %}
+
 {% block toc-wrapper %}{% endblock %}
-{% block current-page-title %}{% trans "General Index" %}{% endblock %}
+
+{% block current-page-title %}{% translate "General Index" %}{% endblock %}
 
 {% block body %}
-  <h1>{% trans "General Index" %}</h1>
+  <h1>{% translate "General Index" %}</h1>
 
   <p class="indexletters">
     {% for letter, _ in doc.genindexentries %}
@@ -36,11 +38,11 @@
           {% for subname, sublinks in contents.1 %}
             <dd>
               <a href="{{ sublinks.0.1 }}">{{ subname }}</a>
-              {% for link in sublinks|slice:"1:" %}, <a href="{{ link.1 }}">{% trans "[Link]" %}</a>{% endfor %}
+              {% for link in sublinks|slice:"1:" %}, <a href="{{ link.1 }}">{% translate "[Link]" %}</a>{% endfor %}
             </dd>
           {% endfor %}
         {% endif %}
       {% endfor %}
     </dl>
   {% endfor %}
-{% endblock %}
+{% endblock body %}

--- a/docs/templates/docs/py-modindex.html
+++ b/docs/templates/docs/py-modindex.html
@@ -1,12 +1,14 @@
 {% extends "docs/doc.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Module Index | Django Documentation" %}{% endblock %}
+{% block title %}{% translate "Module Index | Django Documentation" %}{% endblock %}
+
 {% block toc-wrapper %}{% endblock %}
-{% block current-page-title %}{% trans "Module Index" %}{% endblock %}
+
+{% block current-page-title %}{% translate "Module Index" %}{% endblock %}
 
 {% block body %}
-    <h1>{% trans "Module Index" %}</h1>
+    <h1>{% translate "Module Index" %}</h1>
 
     <ul class="jump_links">
         {% for letter, objects in doc.content %}
@@ -31,4 +33,4 @@
         </ul>
     {% endfor %}
 
-{% endblock %}
+{% endblock body %}

--- a/docs/templates/docs/search_description.xml
+++ b/docs/templates/docs/search_description.xml
@@ -1,14 +1,14 @@
 {% load i18n static %}<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
                        xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-  <ShortName>{% blocktrans with version=release.human_version %}Django {{ version }} documentation{% endblocktrans %}</ShortName>
-  <Description>{% blocktrans with version=release.human_version %}Search Django {{ version }} documentation{% endblocktrans %}</Description>
+  <ShortName>{% blocktranslate with version=release.human_version %}Django {{ version }} documentation{% endblocktranslate %}</ShortName>
+  <Description>{% blocktranslate with version=release.human_version %}Search Django {{ version }} documentation{% endblocktranslate %}</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <OutputEncoding>UTF-8</OutputEncoding>
   <Image width="16" height="16" type="image/x-icon">{% static "img/favicon.ico" %}</Image>
   <Image width="32" height="32" type="image/x-icon">{% static "img/favicon.ico" %}</Image>
   <Query role="example" searchTerms="testing" />
-  <Developer>{% trans "Django team" %}</Developer>
+  <Developer>{% translate "Django team" %}</Developer>
   <SyndicationRight>open</SyndicationRight>
   <AdultContent>false</AdultContent>
   <Language>{{ release.lang }}</Language>

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -1,13 +1,18 @@
 {% extends "docs/doc.html" %}
-{% load i18n docs %}
+{% load docs i18n %}
 
 {% block title %}{% translate "Search" %}{% endblock %}
+
 {% block header %}<h1>{% translate "Search" %}</h1>{% endblock %}
 
 {% block toc-wrapper %}{% endblock %}
+
 {% block breadcrumbs-wrapper %}{% endblock %}
+
 {% block last-update-wrapper %}{% endblock %}
+
 {% block browse-wrapper %}{% endblock %}
+
 {% block links-wrapper %}{% endblock %}
 
 {% block body %}
@@ -105,4 +110,4 @@
     {% endif %}
 
   {% endif %}
-{% endblock %}
+{% endblock body %}


### PR DESCRIPTION
### Summary
This PR adds the `djade` linter to the project's pre-commit configuration and applies formatting fixes to existing Django templates. This ensures consistent code style (e.g., standardizing whitespace in `{{ variables }}`) across the codebase. Fixes https://github.com/django/djangoproject.com/issues/2372

### Rationale
As discussed in #2372, `djade` was selected over alternatives like `djLint` because `djade` is actively maintained and specifically targets Django template formatting. This aligns with the project's goal of using stable, long-term tools.

### Changes
- **Configuration:** Added `adamchainz/djade-pre-commit` (v1.6.0) to `.pre-commit-config.yaml`.
- **Formatting:** Ran the linter across all files, which automatically updated inconsistent spacing in `.html` templates.

### Verification
- [x] Ran `pre-commit run djade --all-files` locally (passed formatting checks).