### PR TITLE
[foundation] Added BoardMember inline for Term admin

### DIFF
--- a/foundation/admin.py
+++ b/foundation/admin.py
@@ -10,11 +10,6 @@ class OfficeAdmin(admin.ModelAdmin):
     pass
 
 
-@admin.register(models.Term)
-class TermAdmin(admin.ModelAdmin):
-    pass
-
-
 @admin.register(models.BoardMember)
 class BoardMemberAdmin(admin.ModelAdmin):
     list_display = ("full_name", "office", "term")
@@ -25,6 +20,17 @@ class BoardMemberAdmin(admin.ModelAdmin):
     @admin.display(ordering="account__last_name")
     def full_name(self, obj):
         return obj.account.get_full_name()
+
+
+class BoardMemberInline(admin.TabularInline):
+    model = models.BoardMember
+    raw_id_fields = ("account",)
+    extra = 1
+
+
+@admin.register(models.Term)
+class TermAdmin(admin.ModelAdmin):
+    inlines = [BoardMemberInline]
 
 
 @admin.register(models.NonBoardAttendee)


### PR DESCRIPTION
I created the board member positions for the 2026 board today and got annoyed that I had to add the board members one by one.

This PR makes the process a bit smoother by allowing you to create/edit the board members inline when creating/editing a term.

## Screenshots

<details><summary>Adding a new term</summary>
<p>

<img width="1621" height="436" alt="Screenshot 2025-12-12 at 23-13-20 Add term Django site admin" src="https://github.com/user-attachments/assets/1a245dee-9e94-4eb4-87f3-306f1923e918" />


</p>
</details> 

<details><summary>Editing an existing term</summary>
<p>

<img width="1621" height="970" alt="Screenshot 2025-12-12 at 23-13-08 2026 Change term Django site admin" src="https://github.com/user-attachments/assets/da7f5f5b-c879-48ca-9d3e-1fb941c5d884" />


</p>
</details> 