### PR TITLE
Made nav header fit in smaller mobile screens.

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -361,7 +361,6 @@ html[data-theme="light"] .theme-toggle .theme-label-when-light {
     .light-dark-mode-toggle {
       height: 45px;
       width: 45px;
-      margin: 2px;
     }
 }
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -517,7 +517,6 @@ header {
         cursor: pointer;
         display: block;
         height: 45px;
-        margin: 2px;
         text-align: center;
         text-decoration: none;
         width: 45px;
@@ -3065,7 +3064,10 @@ form {
     &.search {
         width: 20%;
         min-width: 200px;
-        margin: 10px;
+        margin: 10px 8px 10px 0;
+        @include respond-min(768px) {
+            margin-left: 10px;
+        }
 
         input {
           margin: 0;


### PR DESCRIPTION
I have a small mobile and since the last deployment the header doesn't quite fit on my small mobile
I have tweaked some margin to fit this smaller size

### Before:

<img width="455" height="802" alt="Screenshot from 2025-12-18 13-26-38" src="https://github.com/user-attachments/assets/947b2f8d-9f47-4d3b-9d2a-180f42eb2709" />


### After:

<img width="455" height="802" alt="Screenshot from 2025-12-18 13-19-20" src="https://github.com/user-attachments/assets/6c21e17a-1f9e-4b50-8b30-3809ce9ec641" />
