### PR TITLE
Fixed the version and language switcher for multiple versions/languages.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2345,6 +2345,8 @@ h2+.list-link-soup {
 #doc-languages,
 #doc-versions {
     position: relative;
+    flex-direction: row-reverse;
+    pointer-events: auto;
 
     li {
         display: inline-block;
@@ -2364,9 +2366,6 @@ h2+.list-link-soup {
 
         &.other {
             display: none;
-            position: absolute;
-            right: 100%;
-            top: 0;
             margin-right: 2px;
             white-space: nowrap;
             z-index: 2;


### PR DESCRIPTION
Stupidly, I was only testing with 1 extra language and 1 extra version locally. This is overlapping horribly on production making the switcher unuasable. This is now fixed

### Before on djangoproject.com

<img width="328" height="236" alt="Screenshot from 2025-12-18 13-47-30" src="https://github.com/user-attachments/assets/4b37e015-0c59-4191-8763-98d64978d841" />


### After

<img width="328" height="236" alt="Screenshot from 2025-12-18 13-48-04" src="https://github.com/user-attachments/assets/2eed4389-faa8-4685-9c21-ec837ace0759" />


