### PR TITLE
Docs: add contributor guidelines for issue assignment and Website WG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,35 @@ Install and run locally from a virtual environment
    http://docs.djangoproject.localhost:8000/,
    or http://dashboard.djangoproject.localhost:8000/.
 
+Contributing
+============
+
+We welcome contributions to the Django website! To ensure a smooth process,
+please keep the following guidelines in mind:
+
+Website Working Group (WG) Approval
+-----------------------------------
+
+While any community member can raise an issue, the `Website Working Group
+<https://www.djangoproject.com/foundation/teams/>`_ should agree that an
+issue is ready to be worked on before a Pull Request is submitted. Look
+for labels or comments from WG members indicating the issue is "accepted"
+or "ready for work."
+
+Issue "Assignment"
+------------------
+
+We do not use the GitHub "Assignee" field. Issues are available for anyone
+to work on if there is no active Pull Request linked to them.
+
+To avoid duplicate work, please:
+
+1. Check if there is already an open PR for the issue.
+2. Leave a comment stating your intention to work on it.
+3. Submit your PR promptly. If an issue has no active PR, it remains open
+   for others to pick up.
+
+
 Running the tests
 -----------------
 


### PR DESCRIPTION
### Description
This Pull Request adds a new **Contributing** section to the `README.rst` file. These updates provide clearer guidance for new community members and streamline the onboarding process by documenting the repository's specific workflow, as discussed in #2375.

### Key Changes
* **Website Working Group (WG) Approval**: Clarifies that the WG triages issues and should approve them before a Pull Request is submitted.
* **Issue Assignment Policy**: Explicitly states that the GitHub "Assignee" field is not used, helping to set correct expectations for new contributors.
* **Workflow Best Practices**: Provides a simple 3-step guide for claiming issues via comments to prevent duplicate work and overlapping PRs.

### Related Issues
Fixes #2375