### PR TITLE
fix(templates/aggregator): Link correctly to tutorial page

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -139,7 +139,7 @@
   <ul>
     <li>
       <a href="https://tutorial.djangogirls.org/">DjangoGirls Tutorial</a>
-      &mdash; A great tutorial you can do in addition to the <a href="{% url 'document-detail' lang='en' version='stable' url='intro/tutorial01/' host 'docs' %}">official tutorial</a>.
+      &mdash; A great tutorial you can do in addition to the <a href="{% url 'document-detail' lang='en' version='stable' url='intro/tutorial01' host 'docs' %}">official tutorial</a>.
     </li>
   </ul>
 


### PR DESCRIPTION
Closes #2417