### PR TITLE
Fix duplicated dev docs warning for assistive technologies

### DIFF
--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -162,11 +162,10 @@ document.querySelectorAll('.btn-clipboard').forEach(function (el) {
 
   // This element will dynamically enforce the correct amount of top spacing
   const warning_el_copy = warning_el.cloneNode(true);
-warning_el_copy.setAttribute('aria-hidden', 'true');
-warning_el_copy.style.position = 'relative';
+  warning_el_copy.setAttribute('aria-hidden', 'true');
+  warning_el_copy.style.position = 'relative';
 
-document.body.prepend(warning_el_copy);
-
+  document.body.prepend(warning_el_copy);
 
   function scroll_to_hash(e) {
     const target_el = document.querySelector(window.location.hash || null);


### PR DESCRIPTION
This change addresses an accessibility issue in the Django documentation theme where the development-version warning was duplicated in the page HTML.

The warning element is cloned and prepended to the document body to compensate for layout spacing, which results in the same content being exposed twice to assistive technologies.

To resolve this, the cloned warning element is now marked with aria-hidden="true". This preserves the existing visual behavior and layout while ensuring that only a single instance of the warning is announced.

Fixes #2167