### PR TITLE
Navbar layout inconsistency: issue #2414 fixed

### DIFF
--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -9,8 +9,6 @@
   container--flex container--flex--wrap--mobile
 {% endblock %}
 
-{% block header %}
-  <p><a href="{% block doc_url %}{% url 'homepage' %}{% endblock %}">{% trans 'Documentation' %}</a></p>
-{% endblock %}
+
 
 {% block layout_class %}sidebar-right{% endblock %}


### PR DESCRIPTION
### Summary

This PR fixes a layout inconsistency in the Documentation site header where the
navigation could wrap onto an extra line above the logo, creating unnecessary
vertical spacing. The issue was caused by a redundant Docs-specific header block
being rendered in addition to the global site header.

### What changed

- Removed the redundant documentation-only header block
- Ensured the global site header is used consistently on Docs pages
- Prevented unintended flex wrapping at desktop widths

### Notes on the theme toggle

While investigating this issue, I noticed that the light/dark mode toggle is not
present on the Issues site. After further inspection, the Issues pages are served
by Trac and do not share Django’s template stack or frontend assets.

I have **not attempted to address this in this PR**, as it appears to be outside
the scope of the Django site templates. I’m happy to open a follow-up issue or
work on this if there’s interest in coordinating a solution on the Trac side.

### Screenshots / Verification
<img width="1911" height="520" alt="Screenshot From 2025-12-30 21-16-21" src="https://github.com/user-attachments/assets/34ba7c11-3fed-4a7a-a5eb-392f75b5b94b" />
<img width="1911" height="520" alt="Screenshot From 2025-12-30 23-24-03" src="https://github.com/user-attachments/assets/95262884-1602-4e00-9b4f-c3641bc943b7" />


- Docs navbar remains on a single line at desktop widths
- No regression on the main site or other sections
