### PR TITLE
Keep github actions up to date with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
           day: "monday"
           time: "12:00"
           timezone: "Europe/Oslo" # hipp hipp hurra
+
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "12:00"
+          timezone: "Europe/Oslo" # hipp hipp hurra


### PR DESCRIPTION
I think its worth automating github actions with dependabot which reduce manual intervention of creating pr to update github actions.

