### PR TITLE
Redirected /about to /foundation issue #2428

### DIFF
--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -95,6 +95,7 @@ urlpatterns = [
         name="diversity_changes",
     ),
     path("contact/", include("contact.urls")),
+    path("about/", RedirectView.as_view(url="/foundation/", permanent=True)),
     path("foundation/django_core/", CoreDevelopers.as_view()),
     path("foundation/minutes/", include("foundation.urls.meetings")),
     path("foundation/", include("members.urls")),


### PR DESCRIPTION
Redirect "https://www.djangoproject.com/about" so it goes to "https://www.djangoproject.com/foundation/" instead of a 404 page as stated in issue #2428 