### PR TITLE
This change runs each Sphinx build in an isolated subprocess instead …

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -4,6 +4,7 @@ app.
 """
 
 import json
+
 # import multiprocessing
 import os
 import shutil
@@ -18,13 +19,16 @@ from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
+
 # from sphinx.application import Sphinx
 from sphinx.config import Config
+
+from ...models import DocumentRelease
+
 # from sphinx.errors import SphinxError
 # from sphinx.testing.util import _clean_up_global_state
 # from sphinx.util.docutils import docutils_namespace, patch_docutils
 
-from ...models import DocumentRelease
 
 
 class Command(BaseCommand):
@@ -264,7 +268,17 @@ class Command(BaseCommand):
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-    def run_sphinx_build(self,*,source_dir,build_dir,doctreedir,builder,language,extensions,):
+
+    def run_sphinx_build(
+        self,
+        *,
+        source_dir,
+        build_dir,
+        doctreedir,
+        builder,
+        language,
+        extensions,
+    ):
         env = os.environ.copy()
         env["SPHINXOPTS"] = " ".join(
             [
@@ -273,21 +287,22 @@ class Command(BaseCommand):
             ]
         )
         subprocess.check_call(
-                [
+            [
                 sys.executable,
                 "-m",
                 "sphinx",
                 "-b",
                 builder,
                 "-c",
-                str(source_dir),  
+                str(source_dir),
                 "-d",
                 str(doctreedir),
-                str(source_dir),      
-                str(build_dir),     
+                str(source_dir),
+                str(build_dir),
             ],
             env=env,
         )
+
     def update_git(self, url, destdir, changed_dir="."):
         """
         Update a source checkout and return True if any docs were changed,


### PR DESCRIPTION
…of reusing a single Python process. This prevents global translation and doctree state from leaking between builds, which was the cause of the mixed-language labels.