### PR TITLE
Run Sphinx builds in isolated subprocesses

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -178,6 +178,12 @@ class Command(BaseCommand):
             builders = self.default_builders[:] + ["gettext"]
         else:
             builders = self.default_builders
+        if release.lang != settings.DEFAULT_LANGUAGE_CODE:
+            os.environ["LANGUAGE"] = release.lang
+            os.environ["LC_ALL"] = release.lang
+        else:
+            os.environ.pop("LANGUAGE", None)
+            os.environ.pop("LC_ALL", None)
 
         #
         # Use Sphinx to build the release docs into JSON and HTML documents.
@@ -264,9 +270,6 @@ class Command(BaseCommand):
         builder,
         language,
     ):
-        env = os.environ.copy()
-        env["SPHINXOPTS"] = f"-D language={language}"
-
         subprocess.check_call(
             [
                 sys.executable,
@@ -274,14 +277,15 @@ class Command(BaseCommand):
                 "sphinx",
                 "-b",
                 builder,
+                "-D",
+                f"language={language}",
                 "-c",
                 str(source_dir),
                 "-d",
                 str(doctreedir),
                 str(source_dir),
                 str(build_dir),
-            ],
-            env=env,
+            ]
         )
 
     def update_git(self, url, destdir, changed_dir="."):

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -289,7 +289,6 @@ class Command(BaseCommand):
             env=env,
         )
 
-
     def update_git(self, url, destdir, changed_dir="."):
         """
         Update a source checkout and return True if any docs were changed,

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -18,7 +18,9 @@ from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
 from sphinx.config import Config
+
 from ...models import DocumentRelease
+
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
@@ -258,7 +260,7 @@ class Command(BaseCommand):
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-        
+
     def run_sphinx_build(
         self,
         *,

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -265,7 +265,7 @@ class Command(BaseCommand):
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-        def run_sphinx_build(self,*,source_dir,build_dir,doctreedir,builder,language,extensions,):
+    def run_sphinx_build(self,*,source_dir,build_dir,doctreedir,builder,language,extensions,):
             env = os.environ.copy()
             env["SPHINXOPTS"] = " ".join(
                 [

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -17,8 +17,6 @@ from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
-from sphinx.config import Config
-
 from ...models import DocumentRelease
 
 
@@ -193,10 +191,6 @@ class Command(BaseCommand):
             if doctreedir.exists():
                 shutil.rmtree(doctreedir)
             doctreedir.mkdir(parents=True)
-
-            # conf_extensions = Config.read(source_dir.resolve()).extensions
-            # extensions = ",".join([*conf_extensions, "docs.builder"])
-
             try:
                 self.run_sphinx_build(
                     source_dir=source_dir,
@@ -288,8 +282,6 @@ class Command(BaseCommand):
             ],
             env=env,
         )
-
-
     def update_git(self, url, destdir, changed_dir="."):
         """
         Update a source checkout and return True if any docs were changed,

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -4,7 +4,7 @@ app.
 """
 
 import json
-import multiprocessing
+# import multiprocessing
 import os
 import shutil
 import subprocess
@@ -18,11 +18,11 @@ from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
-from sphinx.application import Sphinx
+# from sphinx.application import Sphinx
 from sphinx.config import Config
-from sphinx.errors import SphinxError
-from sphinx.testing.util import _clean_up_global_state
-from sphinx.util.docutils import docutils_namespace, patch_docutils
+# from sphinx.errors import SphinxError
+# from sphinx.testing.util import _clean_up_global_state
+# from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 from ...models import DocumentRelease
 

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -189,43 +189,31 @@ class Command(BaseCommand):
         # Use Sphinx to build the release docs into JSON and HTML documents.
         #
         for builder in builders:
-            # Wipe and re-create the build directory. See #18930.
             build_dir = parent_build_dir / "_build" / builder
             if build_dir.exists():
-                shutil.rmtree(str(build_dir))
+                shutil.rmtree(build_dir)
             build_dir.mkdir(parents=True)
 
-            if self.verbosity >= 2:
-                self.stdout.write(f"  building {builder} ({source_dir} -> {build_dir})")
-            # Retrieve the extensions from the conf.py so we can append to them.
+            doctreedir = parent_build_dir / "_doctrees" / release.lang / builder
+            if doctreedir.exists():
+                shutil.rmtree(doctreedir)
+            doctreedir.mkdir(parents=True)
+
             conf_extensions = Config.read(source_dir.resolve()).extensions
-            extensions = [*conf_extensions, "docs.builder"]
+            extensions = ",".join([*conf_extensions, "docs.builder"])
+
             try:
-                # Prevent global state persisting between builds
-                # https://github.com/sphinx-doc/sphinx/issues/12130
-                with patch_docutils(source_dir), docutils_namespace():
-                    Sphinx(
-                        srcdir=source_dir,
-                        confdir=source_dir,
-                        outdir=build_dir,
-                        doctreedir=build_dir / ".doctrees",
-                        buildername=builder,
-                        # Translated docs builds generate a lot of warnings, so send
-                        # stderr to stdout to be logged (rather than generating an email)
-                        warning=sys.stdout,
-                        parallel=multiprocessing.cpu_count(),
-                        verbosity=0,
-                        confoverrides={
-                            "language": to_locale(release.lang),
-                            "extensions": extensions,
-                        },
-                    ).build()
-                # Clean up global state after building each language.
-                _clean_up_global_state()
-            except SphinxError as e:
+                self.run_sphinx_build(
+                    source_dir=source_dir,
+                    build_dir=build_dir,
+                    doctreedir=doctreedir,
+                    builder=builder,
+                    language=to_locale(release.lang),
+                    extensions=extensions,
+                )
+            except subprocess.CalledProcessError as e:
                 self.stderr.write(
-                    "sphinx-build returned an error (release %s, builder %s): %s"
-                    % (release, builder, str(e))
+                    f"sphinx-build failed (release={release}, builder={builder}): {e}"
                 )
                 return
 
@@ -277,7 +265,30 @@ class Command(BaseCommand):
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-
+        def run_sphinx_build(self,*,source_dir,build_dir,doctreedir,builder,language,extensions,):
+            env = os.environ.copy()
+            env["SPHINXOPTS"] = " ".join(
+                [
+                    f"-D language={language}",
+                    f"-D extensions={extensions}",
+                ]
+            )
+            subprocess.check_call(
+                    [
+                    sys.executable,
+                    "-m",
+                    "sphinx",
+                    "-b",
+                    builder,
+                    "-c",
+                    str(source_dir),  
+                    "-d",
+                    str(doctreedir),
+                    str(source_dir),      
+                    str(build_dir),     
+                ],
+                env=env,
+            )
     def update_git(self, url, destdir, changed_dir="."):
         """
         Update a source checkout and return True if any docs were changed,

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -194,8 +194,8 @@ class Command(BaseCommand):
                 shutil.rmtree(doctreedir)
             doctreedir.mkdir(parents=True)
 
-            conf_extensions = Config.read(source_dir.resolve()).extensions
-            extensions = ",".join([*conf_extensions, "docs.builder"])
+            # conf_extensions = Config.read(source_dir.resolve()).extensions
+            # extensions = ",".join([*conf_extensions, "docs.builder"])
 
             try:
                 self.run_sphinx_build(
@@ -204,7 +204,6 @@ class Command(BaseCommand):
                     doctreedir=doctreedir,
                     builder=builder,
                     language=to_locale(release.lang),
-                    extensions=extensions,
                 )
             except subprocess.CalledProcessError as e:
                 self.stderr.write(
@@ -269,15 +268,9 @@ class Command(BaseCommand):
         doctreedir,
         builder,
         language,
-        extensions,
     ):
         env = os.environ.copy()
-        env["SPHINXOPTS"] = " ".join(
-            [
-                f"-D language={language}",
-                f"-D extensions={extensions}",
-            ]
-        )
+        env["SPHINXOPTS"] = f"-D language={language}"
 
         subprocess.check_call(
             [
@@ -295,6 +288,7 @@ class Command(BaseCommand):
             ],
             env=env,
         )
+
 
     def update_git(self, url, destdir, changed_dir="."):
         """

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -4,8 +4,6 @@ app.
 """
 
 import json
-
-# import multiprocessing
 import os
 import shutil
 import subprocess
@@ -19,17 +17,8 @@ from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
-
-# from sphinx.application import Sphinx
 from sphinx.config import Config
-
 from ...models import DocumentRelease
-
-# from sphinx.errors import SphinxError
-# from sphinx.testing.util import _clean_up_global_state
-# from sphinx.util.docutils import docutils_namespace, patch_docutils
-
-
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -4,6 +4,7 @@ app.
 """
 
 import json
+
 # import multiprocessing
 import os
 import shutil
@@ -18,13 +19,16 @@ from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
+
 # from sphinx.application import Sphinx
 from sphinx.config import Config
+
+from ...models import DocumentRelease
+
 # from sphinx.errors import SphinxError
 # from sphinx.testing.util import _clean_up_global_state
 # from sphinx.util.docutils import docutils_namespace, patch_docutils
 
-from ...models import DocumentRelease
 
 
 class Command(BaseCommand):
@@ -265,7 +269,17 @@ class Command(BaseCommand):
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-        def run_sphinx_build(self,*,source_dir,build_dir,doctreedir,builder,language,extensions,):
+
+        def run_sphinx_build(
+            self,
+            *,
+            source_dir,
+            build_dir,
+            doctreedir,
+            builder,
+            language,
+            extensions,
+        ):
             env = os.environ.copy()
             env["SPHINXOPTS"] = " ".join(
                 [
@@ -274,21 +288,22 @@ class Command(BaseCommand):
                 ]
             )
             subprocess.check_call(
-                    [
+                [
                     sys.executable,
                     "-m",
                     "sphinx",
                     "-b",
                     builder,
                     "-c",
-                    str(source_dir),  
+                    str(source_dir),
                     "-d",
                     str(doctreedir),
-                    str(source_dir),      
-                    str(build_dir),     
+                    str(source_dir),
+                    str(build_dir),
                 ],
                 env=env,
             )
+
     def update_git(self, url, destdir, changed_dir="."):
         """
         Update a source checkout and return True if any docs were changed,

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 from django.utils.translation import to_locale
+
 from ...models import DocumentRelease
 
 
@@ -282,6 +283,7 @@ class Command(BaseCommand):
             ],
             env=env,
         )
+
     def update_git(self, url, destdir, changed_dir="."):
         """
         Update a source checkout and return True if any docs were changed,

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -30,7 +30,6 @@ from ...models import DocumentRelease
 # from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 
-
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
@@ -269,30 +268,40 @@ class Command(BaseCommand):
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-    def run_sphinx_build(self,*,source_dir,build_dir,doctreedir,builder,language,extensions,):
-            env = os.environ.copy()
-            env["SPHINXOPTS"] = " ".join(
-                [
-                    f"-D language={language}",
-                    f"-D extensions={extensions}",
-                ]
-            )
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "sphinx",
-                    "-b",
-                    builder,
-                    "-c",
-                    str(source_dir),
-                    "-d",
-                    str(doctreedir),
-                    str(source_dir),
-                    str(build_dir),
-                ],
-                env=env,
-            )
+
+    def run_sphinx_build(
+        self,
+        *,
+        source_dir,
+        build_dir,
+        doctreedir,
+        builder,
+        language,
+        extensions,
+    ):
+        env = os.environ.copy()
+        env["SPHINXOPTS"] = " ".join(
+            [
+                f"-D language={language}",
+                f"-D extensions={extensions}",
+            ]
+        )
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "sphinx",
+                "-b",
+                builder,
+                "-c",
+                str(source_dir),
+                "-d",
+                str(doctreedir),
+                str(source_dir),
+                str(build_dir),
+            ],
+            env=env,
+        )
 
     def update_git(self, url, destdir, changed_dir="."):
         """


### PR DESCRIPTION
Fixed issue :- Docs intermittently mix translations of Sphinx labels #2416

Run each Sphinx build in a separate subprocess to avoid global state leakage
between documentation builds.