### PR TITLE
Add --target-version to black call

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
       rev: 25.12.0
       hooks:
           - id: black
+            args: ["--target-version=py312"]
 
     - repo: https://github.com/rbubley/mirrors-prettier
       rev: v3.7.4

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -113,25 +113,25 @@ class UserProfileTests(TracDBCreateDatabaseMixin, ReleaseMixin, TestCase):
             author="user1",
             newvalue="Accepted",
             ticket=Ticket.objects.create(),
-            **initial_ticket_values
+            **initial_ticket_values,
         )
         TicketChange.objects.create(
             author="user1",
             newvalue="Someday/Maybe",
             ticket=Ticket.objects.create(),
-            **initial_ticket_values
+            **initial_ticket_values,
         )
         TicketChange.objects.create(
             author="user1",
             newvalue="Ready for checkin",
             ticket=Ticket.objects.create(),
-            **initial_ticket_values
+            **initial_ticket_values,
         )
         TicketChange.objects.create(
             author="user2",
             newvalue="Accepted",
             ticket=Ticket.objects.create(),
-            **initial_ticket_values
+            **initial_ticket_values,
         )
 
         response = self.client.get(self.user1_url)
@@ -147,13 +147,13 @@ class UserProfileTests(TracDBCreateDatabaseMixin, ReleaseMixin, TestCase):
             oldvalue="Unreviewed",
             newvalue="Accepted",
             ticket=Ticket.objects.create(),
-            **common_ticket_values
+            **common_ticket_values,
         )
         TicketChange.objects.create(
             oldvalue="Accepted",
             newvalue="Unreviewed",
             ticket=Ticket.objects.create(),
-            **common_ticket_values
+            **common_ticket_values,
         )
 
         response = self.client.get(self.user1_url)

--- a/releases/migrations/0005_release_artifacts.py
+++ b/releases/migrations/0005_release_artifacts.py
@@ -35,17 +35,17 @@ def populate_artifacts(apps, schema_editor):
         # releases/{major}.{minor}/Django-{version}.tar.gz
         tarball=Case(
             *(When(version=k, then=Value(v)) for k, v in VERSION_TO_TARBALL.items()),
-            default=default_artifact(".tar.gz")
+            default=default_artifact(".tar.gz"),
         ),
         # releases/{major}.{minor}/Django-{version}-py3-none-any.whl
         wheel=Case(
             *(When(version=k, then=Value(v)) for k, v in VERSION_TO_WHEEL.items()),
-            default=default_artifact("-py3-none-any.whl")
+            default=default_artifact("-py3-none-any.whl"),
         ),
         # pgp/Django-{version}.checksum.txt
         checksum=Case(
             *(When(version=k, then=Value(v)) for k, v in VERSION_TO_CHECKSUM.items()),
-            default=Concat(Value("pgp/Django-"), F("version"), Value(".checksum.txt"))
+            default=Concat(Value("pgp/Django-"), F("version"), Value(".checksum.txt")),
         ),
     )
 


### PR DESCRIPTION
The goal is to handle mysterious trailing commas appearing during pyproject.toml migration. It seems pyproject.toml's requires-python key automatically picked up by black, and causing additional changes because it didn't have the version info before.

Relates to #2321