### PR TITLE
Prevent caching of 404 responses and add regression test

### DIFF
--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -51,6 +51,7 @@ class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
             return super().process_response(request, response)
         return response
 
+
 class Disable404CachingMiddleware:
     """
     Prevent caching of 404 responses so that missing pages

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -47,9 +47,10 @@ MEDIA_URL = f"https://media.{DOMAIN_NAME}/"
 MIDDLEWARE = (
     ["django.middleware.cache.UpdateCacheMiddleware"]
     + MIDDLEWARE
-    + ["django.middleware.cache.FetchFromCacheMiddleware",
-       "djangoproject.middleware.Disable404CachingMiddleware",
-       ]
+    + [
+        "django.middleware.cache.FetchFromCacheMiddleware",
+        "djangoproject.middleware.Disable404CachingMiddleware",
+    ]
 )
 
 SESSION_COOKIE_SECURE = True

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -164,12 +164,12 @@ class ExcludeHostsLocaleMiddlewareTests(ReleaseMixin, TestCase):
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn("Content-Language", resp)
         self.assertIn("Vary", resp)
-    
+
     class Disable404CachingMiddlewareTests(TestCase):
-     def test_404_responses_are_not_cached(self):
-        response = self.client.get("/this-page-does-not-exist/")
-        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
-        self.assertIn("no-store", response["Cache-Control"])
+        def test_404_responses_are_not_cached(self):
+            response = self.client.get("/this-page-does-not-exist/")
+            self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+            self.assertIn("no-store", response["Cache-Control"])
 
 
 # https://adamj.eu/tech/2024/06/23/django-test-pending-migrations/


### PR DESCRIPTION
This PR fixes an issue where 404 responses were being cached, which could cause valid pages to continue returning 404s even after the underlying problem was resolved.

Updated the caching behavior to avoid caching 404 (Not Found) responses
Added a regression test to ensure 404 responses are never cached again
Added a regression test covering the 404 caching scenario

I was unable to run the full test suite locally due to PostgreSQL/Docker environment issues (connection timeout while creating the test database), but the changes are limited in scope and covered by tests

fixes #2341 