### PR TITLE
Temporarily disable broken GitHub login link

### DIFF
--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -6,11 +6,11 @@
 {% block content %}
   <h1>{% translate "Create an account" %}</h1>
 
- <p>
-  {% blocktranslate trimmed %}
-    GitHub login is currently unavailable.
-  {% endblocktranslate %}
-</p>
+  <p>
+    {% blocktranslate trimmed %}
+      GitHub login is currently unavailable.
+    {% endblocktranslate %}
+  </p>
 
 
   {% if form.errors %}


### PR DESCRIPTION
GitHub social login currently succeeds at the OAuth step but does not create
a local user account, resulting in users being redirected back to the login
page when attempting to add RSS feeds.

This PR temporarily disables the GitHub login link to avoid exposing users
to a broken authentication flow.

Scope:
-> UI-only change
-> No authentication or backend logic modified

Follow-up:
I’m happy to work on a proper fix for the GitHub/allauth configuration if the
maintainers agree on the expected behavior and approach.

temporily fixes #835 