### PR TITLE
Remove GitHub auth link on registration page

### DIFF
--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -8,7 +8,7 @@
 
   <p>
   {% blocktranslate trimmed %}
-     Github login is currently unavailable.
+  Github login is currently unavailable.
   {% endblocktranslate %}
   </p>
 

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -7,9 +7,9 @@
   <h1>{% translate "Create an account" %}</h1>
 
   <p>
-  {% blocktranslate trimmed %}
-  Github login is currently unavailable.
-  {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+      Github login is currently unavailable.
+    {% endblocktranslate %}
   </p>
 
   {% if form.errors %}

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -7,9 +7,9 @@
   <h1>{% translate "Create an account" %}</h1>
 
   <p>
-    {% blocktranslate trimmed %}
-      Or, <a href="https://code.djangoproject.com/github/login">login with GitHub</a>.
-    {% endblocktranslate %}
+  {% blocktranslate trimmed %}
+     Github login is currently unavailable.
+  {% endblocktranslate %}
   </p>
 
   {% if form.errors %}

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -5,13 +5,6 @@
 
 {% block content %}
   <h1>{% translate "Create an account" %}</h1>
-
-  <p>
-    {% blocktranslate trimmed %}
-      Github login is currently unavailable.
-    {% endblocktranslate %}
-  </p>
-
   {% if form.errors %}
     <p class="errors">{% translate "Please correct the errors below:" %} {{ form.non_field_errors }}</p>
   {% endif %}


### PR DESCRIPTION
GitHub social login currently succeeds at the OAuth step but does not create
a local user account, resulting in users being redirected back to the login
page when attempting to add RSS feeds.

This PR temporarily disables the GitHub login link to avoid exposing users
to a broken authentication flow.

Scope:
-> UI-only change
-> No authentication or backend logic modified

Follow-up:
I’m happy to work on a proper fix for the GitHub/allauth configuration if the
maintainers agree on the expected behavior and approach.

temporily fixes https://github.com/django/djangoproject.com/issues/835