### PR TITLE
Add info banner for supported but non-latest documentation versions

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3704,3 +3704,14 @@ ul.corporate-members li {
         top: 0;
     }
 }
+.docs-info-banner {
+  background-color: #eef6ff;
+  border-left: 4px solid #3b82f6;
+  padding: 10px 14px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.docs-info-banner a {
+  font-weight: 600;
+}

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -49,6 +49,12 @@
     <div id="outdated-warning" class="doc-floating-warning">
       {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
     </div>
+  {% elif release.is_supported and not release.is_default %}
+    <div class="docs-info-banner">
+      You are viewing documentation for Django {{ release.version }}.
+      A newer version is available.
+      <a href="/en/stable/">View latest docs</a>.
+    </div>
   {% endif %}
 {% endblock before_header %}
 


### PR DESCRIPTION
Refs #1122 — Docs for old supported versions should indicate that a newer version is available

Adds a small informational banner to documentation pages when viewing a supported but non-default Django version, letting users know a newer version exists and linking to the latest docs. The banner is subtle and does not affect unsupported, preview, or development version warnings.