### PR TITLE
Improve docs version-switcher mobile styles

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2399,7 +2399,9 @@ h2+.list-link-soup {
 
     &:hover li.other,
     &.open li.other {
-        display: inline-block;
+        @include respond-min(1200px) {
+            display: inline-block;
+        }
     }
 }
 


### PR DESCRIPTION
This is a reimplementation of #1489.