### PR TITLE
[checklists] Fix UTC template tag use

### DIFF
--- a/checklists/templates/checklists/release-security-skeleton.md
+++ b/checklists/templates/checklists/release-security-skeleton.md
@@ -88,7 +88,7 @@
 - [ ] Post announcement in mailing list (without details in django-announce):
     ```
     Django versions {{ versions|enumerate_items }} will be released on
-    {{ instance.when.date|utc|date:"l, F j" }} around {{ instance.when.time|utc|date:"H:i" }} UTC.
+    {{ instance.when|utc|date:"l, F j" }} around {{ instance.when|utc|date:"H:i" }} UTC.
     {% if cves_length == 1 %}
     They will fix one security defect with severity "{{ cves.0.severity }}".
     {% else %}

--- a/checklists/tests/test_models.py
+++ b/checklists/tests/test_models.py
@@ -396,6 +396,14 @@ class SecurityReleaseChecklistTestCase(BaseChecklistTestCaseMixin, TestCase):
             with self.subTest(detail=detail):
                 self.assertInChecklistContent(detail, checklist_content, flat=True)
 
+        announce = [
+            "Wednesday, May 7 around 16:18 UTC.",
+            "They will fix 2 security defects",
+        ]
+        for detail in announce:
+            with self.subTest(detail=detail):
+                self.assertInChecklistContent(detail, checklist_content, flat=True)
+
     def test_render_checklist_blogdescription_display(self):
         checklist = self.make_checklist(releases=[])
         blog = (


### PR DESCRIPTION
Follow-up to #2480, one template misuse of the `utc` tag snuck through without a test.