### PR TITLE
Normalize URLs with extra slashes

### DIFF
--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -1,10 +1,11 @@
 from django.conf import settings
+from django.http import HttpResponsePermanentRedirect
 from django.http.request import split_domain_port
 from django.middleware.locale import LocaleMiddleware
+from django.urls import Resolver404, resolve
 from django.utils.functional import cached_property
 from django.utils.http import is_same_domain
-from django.http import HttpResponsePermanentRedirect
-from django.urls import resolve, Resolver404
+
 
 class CORSMiddleware:
     """
@@ -51,6 +52,7 @@ class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
         if self._is_host_included(request.get_host()):
             return super().process_response(request, response)
         return response
+
 
 class NormalizeSlashesMiddleware:
 

--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
 from django.http.request import split_domain_port
@@ -5,7 +7,6 @@ from django.middleware.locale import LocaleMiddleware
 from django.urls import Resolver404, resolve
 from django.utils.functional import cached_property
 from django.utils.http import is_same_domain
-import re
 
 
 class CORSMiddleware:
@@ -62,14 +63,14 @@ class NormalizeSlashesMiddleware:
 
     def __call__(self, request):
         path = request.path
-        normalized_path = re.sub(r"/{2,}","/",path)
+        normalized_path = re.sub(r"/{2,}", "/", path)
 
         if normalized_path != path:
             try:
-              resolve(normalized_path)
+                resolve(normalized_path)
             except Resolver404:
                 pass
             else:
-               return HttpResponsePermanentRedirect(normalized_path)
+                return HttpResponsePermanentRedirect(normalized_path)
 
         return self.get_response(request)

--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -5,6 +5,7 @@ from django.middleware.locale import LocaleMiddleware
 from django.urls import Resolver404, resolve
 from django.utils.functional import cached_property
 from django.utils.http import is_same_domain
+import re
 
 
 class CORSMiddleware:
@@ -61,15 +62,14 @@ class NormalizeSlashesMiddleware:
 
     def __call__(self, request):
         path = request.path
-        if "//" in path[1:]:
-            normalized_path = "/" + "/".join(filter(None, path.split("/"))) + "/"
+        normalized_path = re.sub(r"/{2,}","/",path)
 
-            if normalized_path != path:
-                try:
-                    resolve(normalized_path)
-                except Resolver404:
-                    pass
-                else:
-                    return HttpResponsePermanentRedirect(normalized_path)
+        if normalized_path != path:
+            try:
+              resolve(normalized_path)
+            except Resolver404:
+                pass
+            else:
+               return HttpResponsePermanentRedirect(normalized_path)
 
         return self.get_response(request)

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -158,6 +158,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "djangoproject.middleware.NormalizeSlashesMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
     "django.contrib.redirects.middleware.RedirectFallbackMiddleware",

--- a/djangoproject/tests/test_www_urls.py
+++ b/djangoproject/tests/test_www_urls.py
@@ -6,12 +6,13 @@ class IndividualMembershipNominationRedirectTests(TestCase):
         response = self.client.get("/foundation/individual-membership-nomination/")
         self.assertEqual(response.status_code, 302)
 
+
 class NormalizeSlashesMiddlewareTests(TestCase):
     def test_double_slash_redirects_to_single_slash(self):
         response = self.client.get(
             "/community//",
             follow=False,
-            HTTP_HOST="www.djangoproject.localhost",
+            headers={"host": "www.djangoproject.localhost"},
         )
 
         self.assertEqual(response.status_code, 301)

--- a/djangoproject/tests/test_www_urls.py
+++ b/djangoproject/tests/test_www_urls.py
@@ -5,3 +5,14 @@ class IndividualMembershipNominationRedirectTests(TestCase):
     def test_individual_membership_nomination_redirect_exists(self):
         response = self.client.get("/foundation/individual-membership-nomination/")
         self.assertEqual(response.status_code, 302)
+
+class NormalizeSlashesMiddlewareTests(TestCase):
+    def test_double_slash_redirects_to_single_slash(self):
+        response = self.client.get(
+            "/community//",
+            follow=False,
+            HTTP_HOST="www.djangoproject.localhost",
+        )
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "/community/")

--- a/djangoproject/tests/test_www_urls.py
+++ b/djangoproject/tests/test_www_urls.py
@@ -17,31 +17,31 @@ class NormalizeSlashesMiddlewareTests(TestCase):
 
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], "/community/")
-    
+
     def test_triple_slash_redirects(self):
         response = self.client.get(
-        "/community///",
-        follow=False,
-        headers={"host": "www.djangoproject.localhost"},
-    )
+            "/community///",
+            follow=False,
+            headers={"host": "www.djangoproject.localhost"},
+        )
 
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], "/community/")
-    
-    def test_normal_url_no_redirect(self):
-         response = self.client.get(
-        "/community/",
-        follow=False,
-        headers={"host": "www.djangoproject.localhost"},
-    )
 
-         self.assertEqual(response.status_code, 200)
+    def test_normal_url_no_redirect(self):
+        response = self.client.get(
+            "/community/",
+            follow=False,
+            headers={"host": "www.djangoproject.localhost"},
+        )
+
+        self.assertEqual(response.status_code, 200)
 
     def test_invalid_normalized_path_no_redirect(self):
-         response = self.client.get(
-        "/nonexistent//page/",
-        follow=False,
-        headers={"host": "www.djangoproject.localhost"},
-    )
+        response = self.client.get(
+            "/nonexistent//page/",
+            follow=False,
+            headers={"host": "www.djangoproject.localhost"},
+        )
 
-         self.assertNotEqual(response.status_code, 301)
+        self.assertNotEqual(response.status_code, 301)

--- a/djangoproject/tests/test_www_urls.py
+++ b/djangoproject/tests/test_www_urls.py
@@ -17,3 +17,31 @@ class NormalizeSlashesMiddlewareTests(TestCase):
 
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], "/community/")
+    
+    def test_triple_slash_redirects(self):
+        response = self.client.get(
+        "/community///",
+        follow=False,
+        headers={"host": "www.djangoproject.localhost"},
+    )
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "/community/")
+    
+    def test_normal_url_no_redirect(self):
+         response = self.client.get(
+        "/community/",
+        follow=False,
+        headers={"host": "www.djangoproject.localhost"},
+    )
+
+         self.assertEqual(response.status_code, 200)
+
+    def test_invalid_normalized_path_no_redirect(self):
+         response = self.client.get(
+        "/nonexistent//page/",
+        follow=False,
+        headers={"host": "www.djangoproject.localhost"},
+    )
+
+         self.assertNotEqual(response.status_code, 301)


### PR DESCRIPTION
Fixes #2067

This PR adds middleware to normalize URLs containing extra slashes
(e.g. `//community//` → `/community/`) so links and assets resolve correctly.

Includes tests to ensure correct redirects on www.djangoproject.com.