### PR TITLE
Fix color scheme issues on dark mode theme, and auto theme along with prefers-media-querry: dark

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -64,6 +64,7 @@ html[data-theme="light"],
 
 @media (prefers-color-scheme: dark) {
     html:not([data-theme="light"]) {
+        color-scheme: dark;
         --body-fg: #C1CAD2;
         --body-bg: #{$black};
         --logo-bg: #{$logo-bg-dark};
@@ -162,6 +163,7 @@ html[data-theme="light"],
 }
 
 html[data-theme="dark"] {
+    color-scheme: dark;
     --body-fg: #C1CAD2;
     --body-bg: #{$black};
     --logo-bg: #{$logo-bg-dark};


### PR DESCRIPTION
For example this how the scrollbar looks like in the search component in dark mode theme *(see it [here](https://docs.djangoproject.com/en/6.0/search/?q=models))* 

<img width="586" height="142" alt="image" src="https://github.com/user-attachments/assets/1339ea7d-a1aa-4274-8b16-d0a5025b22db" />

 the same thing would happen in auto-theme with prefers-media-querry: dark.
 
 The proposed solution not only fixes this issue, but any other issues relating to color-scheme for scrollbars and form's related items that were not targeted by specific style.