### PR TITLE
Improve semantic HTML and screen reader support for pagination

### DIFF
--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -82,45 +82,45 @@
     <div class="pagination">
       <nav aria-label="{% translate 'Pagination' context 'pagination' %}">
         <ul class="nav-pagination">
-    
+
           {% if page.has_previous %}
             <li>
               <a rel="prev"
                  class="previous"
                  href="{% querystring page=page.previous_page_number %}"
                  aria-label="{% blocktranslate with page_number=page.previous_page_number num_pages=page.paginator.num_pages trimmed %}
-                   Previous page, Page {{ page_number }} of {{ num_pages }}
-                 {% endblocktranslate %}">
+                               Previous page, Page {{ page_number }} of {{ num_pages }}
+                             {% endblocktranslate %}">
                 <i class="icon icon-chevron-left"></i>
                 <span class="visuallyhidden">{% translate "Previous" context "pagination" %}</span>
               </a>
             </li>
           {% endif %}
-    
+
           <li class="page-current">
             {% blocktranslate with page_number=page.number num_pages=page.paginator.num_pages trimmed %}
               Page {{ page_number }} of {{ num_pages }}
             {% endblocktranslate %}
           </li>
-    
+
           {% if page.has_next %}
             <li>
               <a rel="next"
                  class="next"
                  href="{% querystring page=page.next_page_number %}"
                  aria-label="{% blocktranslate with page_number=page.next_page_number num_pages=page.paginator.num_pages trimmed %}
-                   Next page, Page {{ page_number }} of {{ num_pages }}
-                 {% endblocktranslate %}">
+                               Next page, Page {{ page_number }} of {{ num_pages }}
+                             {% endblocktranslate %}">
                 <i class="icon icon-chevron-right"></i>
                 <span class="visuallyhidden">{% translate "Next" context "pagination" %}</span>
               </a>
             </li>
           {% endif %}
-    
+
         </ul>
       </nav>
     </div>
-    
+
 
   {% endif %}
 {% endblock %}

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -79,30 +79,48 @@
         {% endfor %}
       </dl>
     </div>
-
-    {% if page.has_previous or page.has_next %}
-      <div class="pagination">
-        <ul class="nav-pagination" role="navigation">
+    <div class="pagination">
+      <nav aria-label="{% translate 'Pagination' context 'pagination' %}">
+        <ul class="nav-pagination">
+    
           {% if page.has_previous %}
-            <li><a rel="prev" class="previous" href="{% querystring page=page.previous_page_number %}">
-              <i class="icon icon-chevron-left"></i>
-              <span class="visuallyhidden">{% translate "Previous" context "pagination" %}</span>
-            </a></li>
+            <li>
+              <a rel="prev"
+                 class="previous"
+                 href="{% querystring page=page.previous_page_number %}"
+                 aria-label="{% blocktranslate with page_number=page.previous_page_number num_pages=page.paginator.num_pages trimmed %}
+                   Previous page, Page {{ page_number }} of {{ num_pages }}
+                 {% endblocktranslate %}">
+                <i class="icon icon-chevron-left"></i>
+                <span class="visuallyhidden">{% translate "Previous" context "pagination" %}</span>
+              </a>
+            </li>
           {% endif %}
-          <span class="page-current">
+    
+          <li class="page-current">
             {% blocktranslate with page_number=page.number num_pages=page.paginator.num_pages trimmed %}
               Page {{ page_number }} of {{ num_pages }}
             {% endblocktranslate %}
-          </span>
+          </li>
+    
           {% if page.has_next %}
-            <li><a rel="next" class="next" href="{% querystring page=page.next_page_number %}">
-              <i class="icon icon-chevron-right"></i>
-              <span class="visuallyhidden">{% translate "Next" context "pagination" %}</span>
-            </a></li>
+            <li>
+              <a rel="next"
+                 class="next"
+                 href="{% querystring page=page.next_page_number %}"
+                 aria-label="{% blocktranslate with page_number=page.next_page_number num_pages=page.paginator.num_pages trimmed %}
+                   Next page, Page {{ page_number }} of {{ num_pages }}
+                 {% endblocktranslate %}">
+                <i class="icon icon-chevron-right"></i>
+                <span class="visuallyhidden">{% translate "Next" context "pagination" %}</span>
+              </a>
+            </li>
           {% endif %}
+    
         </ul>
-      </div>
-    {% endif %}
+      </nav>
+    </div>
+    
 
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
- Replaced incorrect role="navigation" usage with a semantic <nav> element.

- Ensured <ul> contains only <li> elements.
 
- Moved the current page indicator inside a <li> to fix invalid HTML structure.
 
- Added descriptive aria-label attributes to previous/next links to improve screen reader context.
 
- Preserved Django i18n ({% translate %} / {% blocktranslate %})