### PR TITLE
Add link to stable documentation in insecure version warning banner

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -47,10 +47,10 @@
     </div>
   {% elif not release.is_supported %}
     <div id="outdated-warning" class="doc-floating-warning">
-     {% blocktrans %}
-This document is for an insecure version of Django that is no longer supported.
-Please <a href="https://docs.djangoproject.com/en/stable/">click here</a> for the latest stable version.
-{% endblocktrans %}
+      {% blocktrans %}
+        This document is for an insecure version of Django that is no longer supported.
+        Please <a href="https://docs.djangoproject.com/en/stable/">click here</a> for the latest stable version.
+      {% endblocktrans %}
 
     </div>
   {% endif %}

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -47,7 +47,11 @@
     </div>
   {% elif not release.is_supported %}
     <div id="outdated-warning" class="doc-floating-warning">
-      {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
+     {% blocktrans %}
+This document is for an insecure version of Django that is no longer supported.
+Please <a href="https://docs.djangoproject.com/en/stable/">click here</a> for the latest stable version.
+{% endblocktrans %}
+
     </div>
   {% endif %}
 {% endblock before_header %}


### PR DESCRIPTION
Added a clickable link to the latest stable documentation version in the insecure version warning banner.

This replaces the plain text message with a blocktrans version to safely include an HTML link.
Closes #2094.
