### PR TITLE
Updated the ecosystem page with Django Tasks changes.

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -326,15 +326,15 @@
   </h3>
   <ul>
     <li>
-      <a href="https://github.com/RealOrangeOne/django-tasks-db">Django Tasks</a>
+      <a href="https://github.com/RealOrangeOne/django-tasks-db">django-tasks-db</a>
       &mdash; A lightweight task queue for Django applications, with an ORM-based backend, suitable for simple background task processing.
     </li>
     <li>
-      <a href="https://github.com/RealOrangeOne/django-tasks-rq">Django Tasks</a>
+      <a href="https://github.com/RealOrangeOne/django-tasks-rq">django-tasks-rq</a>
       &mdash; A lightweight task queue for Django applications, with an <a href="https://python-rq.org/">RQ-based</a> backend, suitable for simple background task processing.
     </li>
     <li>
-      <a href="https://github.com/RealOrangeOne/django-tasks">Django Tasks</a>
+      <a href="https://github.com/RealOrangeOne/django-tasks">django-tasks</a>
       &mdash; A backport of <code>django.tasks</code> - Django's built-in <a href="https://docs.djangoproject.com/en/stable/topics/tasks/">Tasks framework</a>.
     </li>
   </ul>


### PR DESCRIPTION
Changes the mention of django-tasks state that it's a backport library. It also adds the two supported backends, db and RQ to the page.

#### Screenshots
| New      | Old      |
| ----------- | ------------- |
| <img width="948" height="499" alt="Screenshot from 2026-02-19 10-52-08" src="https://github.com/user-attachments/assets/14946832-dc9b-4836-a607-dcb7095b62e0" /> | <img width="959" height="393" alt="Screenshot from 2026-02-19 10-48-53" src="https://github.com/user-attachments/assets/901384c9-69f7-4a57-a2cf-13723d71d557" /> |


