### PR TITLE
fix: keyboard focus visibility for footer logo and in-kind-donors links

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ django-push @ git+https://github.com/brutasse/django-push.git@22fda99641cfbd2f30
 django-read-only==1.21.0
 django-recaptcha==4.1.0
 django-registration-redux==2.13
-Django==6.0.2
+Django==6.0.3
 docutils==0.21.2
 feedparser==6.0.12
 Jinja2==3.1.6


### PR DESCRIPTION
fix: #2535 

After changes:

<img width="1496" height="152" alt="keyboard focus visibility around django logo in footer" src="https://github.com/user-attachments/assets/6fdd46c0-1955-4923-973b-956a053873bd" />

<img width="1496" height="149" alt="consistent keyboard focus visibility for in-kind-donors with respect to the others" src="https://github.com/user-attachments/assets/df61fbda-c51d-4235-90a9-23eb26f757b6" />
