### PR TITLE
Add Django template linguist instruction

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # shell scripts need LF endings to work
 *.sh text eol=lf
+*.html linguist-language=django


### PR DESCRIPTION
Same as on the django repo, this patch highlight template tags and filters.