### PR TITLE
Fixed the missing labels for community images.

### DIFF
--- a/djangoproject/templates/aggregator/index.html
+++ b/djangoproject/templates/aggregator/index.html
@@ -9,7 +9,7 @@
   <div class="community-cta-wrapper">
     <a href="https://forum.djangoproject.com/" class="community-cta-a">
       <div class="community-cta">
-        <div>
+        <div aria-hidden="true">
           {% include "svg_logos/forum.html" %}
         </div>
         <h3>{% translate "Forum - Post a question" %}</h3>
@@ -17,7 +17,7 @@
     </a>
     <a href="https://chat.djangoproject.com" class="community-cta-a">
       <div class="community-cta">
-        <div>
+        <div aria-hidden="true">
           {% include "svg_logos/discord.html" %}
         </div>
         <h3>{% translate "Discord - Chat with us" %}</h3>
@@ -29,7 +29,7 @@
   <div class="community-cta-wrapper">
     <a href="{% url "community-ecosystem" %}" class="community-cta-a">
       <div class="community-cta">
-        <div>
+        <div aria-hidden="true">
           {% include "svg_logos/package.html" %}
         </div>
         <h3>{% translate "Package Ecosystem" %}</h3>
@@ -41,7 +41,7 @@
   <div class="community-cta-wrapper">
     <a href="{% url 'document-detail' lang='en' version='dev' url='internals/contributing/bugs-and-features' host 'docs' %}#reporting-bugs" class="community-cta-a">
       <div class="community-cta">
-        <div>
+        <div aria-hidden="true">
           {% include "svg_logos/bug.html" %}
         </div>
         <h3>{% translate "Report an issue" %}</h3>
@@ -49,7 +49,7 @@
     </a>
     <a href="{% url 'document-detail' lang='en' version='dev' url='internals/contributing' host 'docs' %}" class="community-cta-a">
       <div class="community-cta">
-        <div>
+        <div aria-hidden="true">
           {% include "svg_logos/notepad.html" %}
         </div>
         <h3>{% translate "Contribute to Django" %}</h3>
@@ -57,7 +57,7 @@
     </a>
     <a href="/community/local/" class="community-cta-a">
       <div class="community-cta">
-        <div>
+        <div aria-hidden="true">
           {% include "svg_logos/world.html" %}
         </div>
         <h3>{% translate "Local Django Community" %}</h3>


### PR DESCRIPTION
Fixes: #2554 

Added missing labels for Community page images to make it clear for screenreaders .

<img width="411" height="467" alt="Forum icon" src="https://github.com/user-attachments/assets/be6eec9a-6cd9-4012-b45e-2e632f4a9cd2" />

Alternate way:

1. if these images are completely decorative ,  `<div aria-hidden="true">`  can be added to hide them completely from screen readers .