### PR TITLE
Improved checklist generator for security releases.

### DIFF
--- a/checklists/templates/checklists/_stub_release_notes.md
+++ b/checklists/templates/checklists/_stub_release_notes.md
@@ -33,4 +33,4 @@ Bugfixes
         - `git commit -a -m 'Added stub release notes for {{ next_version }}.'`
 
     - Backport stub release notes to latest stable branch!
-        - `backport.sh {HASH}`{% endwith %}
+        - `scripts/backport.sh {HASH}`{% endwith %}

--- a/checklists/templates/checklists/_update_security_archive.md
+++ b/checklists/templates/checklists/_update_security_archive.md
@@ -19,5 +19,5 @@
 
     - Backport security archive update to all branches!
         {% for release in instance.affected_releases %}
-        - `git checkout {{ release.stable_branch }} && backport.sh {HASH}`
+        - `git checkout {{ release.stable_branch }} && scripts/backport.sh {HASH}`
         {% endfor %}

--- a/checklists/templates/checklists/_write_blogpost.md
+++ b/checklists/templates/checklists/_write_blogpost.md
@@ -4,6 +4,8 @@
     - Slug: `{{ slug }}`
     - Format: reStructuredText
     - Summary: `{{ instance.blogpost_summary }}`
+    - Author: `{{ instance.releaser.user.get_full_name }}`
+    - Active: `False`
     - Body:
 ```
 {% include instance.blogpost_template %}

--- a/checklists/templates/checklists/release-security-skeleton.md
+++ b/checklists/templates/checklists/release-security-skeleton.md
@@ -150,6 +150,7 @@
 
         - Store each CVE record in a `.json` file and run:
         {% for cve in cves %}
+            - Get CVE Record from {% url "checklists:cve_json_record" cve %}
             - `cve publish {{ cve }} --cve-json-file {{ cve }}.json`{% endfor %}
 {% endif %}
 - [ ] Send email to the OSS Security mailing list notifying about the release

--- a/checklists/tests/test_models.py
+++ b/checklists/tests/test_models.py
@@ -6,6 +6,7 @@ from datetime import UTC, date, datetime
 from django.db import IntegrityError
 from django.template.loader import render_to_string
 from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
 from django.utils.timezone import make_aware
 
 from checklists.models import (
@@ -352,6 +353,11 @@ class SecurityReleaseChecklistTestCase(BaseChecklistTestCaseMixin, TestCase):
                 "Disclose report(s) in HackerOne", checklist_content
             )
 
+        with self.subTest(task="Write blogpost author and active status"):
+            releaser_name = checklist.releaser.user.get_full_name()
+            self.assertIn(f"- Author: `{releaser_name}`", checklist_content)
+            self.assertIn("- Active: `False`", checklist_content)
+
     def test_render_checklist_affects_prerelease(self):
         releases = [
             self.factory.make_release(version="5.0.14", date=date(2025, 4, 2)),
@@ -403,6 +409,22 @@ class SecurityReleaseChecklistTestCase(BaseChecklistTestCaseMixin, TestCase):
         for detail in announce:
             with self.subTest(detail=detail):
                 self.assertInChecklistContent(detail, checklist_content, flat=True)
+
+    def test_render_checklist_cve_record_url(self):
+        release = self.factory.make_release(version="5.2.1")
+        checklist = self.make_checklist(releases=[])
+        issue = self.factory.make_security_issue(
+            checklist,
+            [release],
+            cve_year_number="CVE-2025-11111",
+            cna="DSF",
+        )
+        checklist_content = self.do_render_checklist(checklist)
+
+        expected_url = reverse(
+            "checklists:cve_json_record", args=[issue.cve_year_number]
+        )
+        self.assertIn(f"Get CVE Record from {expected_url}", checklist_content)
 
     def test_render_checklist_blogdescription_display(self):
         checklist = self.make_checklist(releases=[])

--- a/checklists/tests/test_views.py
+++ b/checklists/tests/test_views.py
@@ -92,5 +92,9 @@ class SecurityIssueViewTestCase(TestCase):
         response = self.client.get(self.url(issue))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/json")
+        self.assertEqual(
+            response["Content-Disposition"],
+            f'inline; filename="{issue.cve_year_number}.json"',
+        )
         data = response.json()
         self.assertEqual(data, issue.cve_data)

--- a/checklists/views.py
+++ b/checklists/views.py
@@ -74,4 +74,6 @@ def securityrelease_checklist(request, pk):
 @permission_required("checklists.view_securityissue", raise_exception=True)
 def cve_json_record(request, cve_id):
     issue = get_object_or_404(SecurityIssue, cve_year_number=cve_id)
-    return JsonResponse(issue.cve_data)
+    response = JsonResponse(issue.cve_data)
+    response["Content-Disposition"] = f'inline; filename="{cve_id}.json"'
+    return response


### PR DESCRIPTION
* Add details about blogpost author and active fields.
* Add link to the CVE record json URL.
* Ensure that the json download include the CVE number in the file name.