### PR TITLE
Link to maintained version of django-impersonate

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -281,7 +281,7 @@
       &mdash; Implementation of per-object permissions for Django, allowing fine-grained access control.
     </li>
     <li>
-      <a href="https://github.com/BetterWorks/django-impersonate">django-impersonate</a>
+      <a href="https://code.netlandish.com/~petersanchez/django-impersonate">django-impersonate</a>
       &mdash; Allows superusers to impersonate other users for debugging or support purposes.
     </li>
     <li>


### PR DESCRIPTION
The GH repository linked in the ecosystem page for django-impersonate is a fork that doesn't appear to be maintained, the original repository has received recent commits and security fixes. I tried to contact the owners of the fork about the missing security fixes, but I didn't get a response (https://github.com/BetterWorks/django-impersonate/issues/11).