### PR TITLE
Redirect /about/ to /foundation/

### DIFF
--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -98,6 +98,7 @@ urlpatterns = [
     ),
     path("checklists/", include("checklists.urls")),
     path("contact/", include("contact.urls")),
+    path("about/", RedirectView.as_view(url="/foundation/", permanent=True)),
     path("foundation/django_core/", CoreDevelopers.as_view()),
     path("foundation/minutes/", include("foundation.urls.meetings")),
     path("foundation/", include("members.urls")),


### PR DESCRIPTION
Closes #2428

`/about/` currently returns a 404. Adds a permanent redirect to `/foundation/` where the foundation content lives.

Uses the same `RedirectView` pattern already used elsewhere in the URL config (e.g., `/overview/` redirect on line 39, `/foundation/individual-membership-nomination/` on line 154).

---
*This change was made with AI assistance.*