### PR TITLE
Moved Django 4.2 to unsupported versions table.

### DIFF
--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -85,12 +85,6 @@
       <th>End of extended support<sup><a href="#ft2">2</a></sup></th>
     </tr>
     <tr>
-      <td>4.2 LTS</td>
-      <td>{% get_latest_micro_release '4.2' %}</td>
-      <td>December 4, 2023</td>
-      <td>April 2026</td>
-    </tr>
-    <tr>
       <td>5.2 LTS</td>
       <td>{% get_latest_micro_release '5.2' %}</td>
       <td>December 3, 2025</td>
@@ -160,6 +154,12 @@
       <td>{% get_latest_micro_release '5.0' %}</td>
       <td>August 7, 2024</td>
       <td>April 2, 2025</td>
+    </tr>
+    <tr>
+      <td>4.2 LTS</td>
+      <td>{% get_latest_micro_release '4.2' %}</td>
+      <td>December 4, 2023</td>
+      <td>April 7, 2026</td>
     </tr>
     <tr>
       <td>4.1</td>


### PR DESCRIPTION
Announcement: https://www.djangoproject.com/weblog/2026/apr/07/security-releases/