### PR TITLE
Add link to stable documentation in warning alert

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -46,9 +46,12 @@
       {% trans "This document is for a preview release of Django, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
     </div>
   {% elif not release.is_supported %}
-    <div id="outdated-warning" class="doc-floating-warning">
-      {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
-    </div>
+<div id="outdated-warning" class="doc-floating-warning">
+    {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
+    <a href="https://docs.djangoproject.com/en/stable/">
+        View Stable Documentation
+    </a>
+</div>
   {% endif %}
 {% endblock before_header %}
 

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -48,7 +48,7 @@
   {% elif not release.is_supported %}
     <div id="outdated-warning" class="doc-floating-warning">
       {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
-      <a href="https://docs.djangoproject.com/en/stable/">
+      <a href="{% url 'docs' %}">
         View Stable Documentation
       </a>
     </div>

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -46,12 +46,12 @@
       {% trans "This document is for a preview release of Django, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
     </div>
   {% elif not release.is_supported %}
-<div id="outdated-warning" class="doc-floating-warning">
-    {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
-    <a href="https://docs.djangoproject.com/en/stable/">
+    <div id="outdated-warning" class="doc-floating-warning">
+      {% trans "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!" %}
+      <a href="https://docs.djangoproject.com/en/stable/">
         View Stable Documentation
-    </a>
-</div>
+      </a>
+    </div>
   {% endif %}
 {% endblock before_header %}
 


### PR DESCRIPTION
## Fix: Add link to Stable documentation in warning alert

This PR adds a link to the stable documentation version in the outdated warning alert.

Fixes #2094

### Changes:
- Added link to stable documentation in outdated warning