### PR TITLE
Add GitHub Actions workflow configuration for running accessibility checks on production

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,42 @@
+name: Accessibility
+
+on:
+    workflow_dispatch:
+    schedule:
+        # Runs every Saturday at 4:00 AM UTC
+        - cron: "0 4 * * 6"
+    # Remove the following triggers when no longer needed.
+    pull_request:
+        branches:
+            - main
+    push:
+
+jobs:
+    accessibility:
+        name: Pa11y CI
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v6
+            - name: Set up Node.js
+              uses: actions/setup-node@v6
+            - name: Install Pa11y CI
+              run: npm install -g pa11y-ci
+            - name: Configure Chromium
+              # Ubuntu 23+ requires AppArmor configuration for dev Chromium to run
+              # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+              run: |
+                  export CHROMIUM_BUILD_PATH=/@{HOME}/.cache/puppeteer/**/**/**
+                  cat | sudo tee /etc/apparmor.d/chrome-dev-builds <<EOF
+                  abi <abi/4.0>,
+                  include <tunables/global>
+
+                  profile chrome $CHROMIUM_BUILD_PATH flags=(unconfined) {
+                    userns,
+                    include if exists <local/chrome>
+                  }
+                  EOF
+                  sudo service apparmor reload
+            - name: Run Pa11y CI
+              run: pa11y-ci

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,34 @@
+{
+    "defaults": {
+        "hideElements": "iframe[title='reCAPTCHA']",
+        "ignore": [
+            "color-contrast"
+        ],
+        "runners": [
+            "axe"
+        ],
+        "timeout": 10000,
+        "useIncognitoBrowserContext": false
+    },
+    "urls": [
+        "https://www.djangoproject.com/",
+        "https://www.djangoproject.com/start/",
+        "https://www.djangoproject.com/start/overview/",
+        "https://www.djangoproject.com/download/",
+        "https://www.djangoproject.com/weblog/",
+        "https://www.djangoproject.com/foundation/",
+        "https://www.djangoproject.com/foundation/teams/",
+        "https://www.djangoproject.com/foundation/individual-members/",
+        "https://www.djangoproject.com/foundation/corporate-members/",
+        "https://www.djangoproject.com/fundraising/",
+        "https://www.djangoproject.com/conduct/",
+        "https://www.djangoproject.com/diversity/",
+        "https://www.djangoproject.com/community/",
+        "https://docs.djangoproject.com/en/dev/internals/contributing/",
+        "https://docs.djangoproject.com/en/dev/internals/contributing/bugs-and-features/",
+        "https://docs.djangoproject.com/en/dev/internals/security/",
+        "https://docs.djangoproject.com/en/6.0/faq/",
+        "https://docs.djangoproject.com/en/6.0/intro/install/",
+        "https://code.djangoproject.com/"
+    ]
+}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow configuration for running accessibility checks. The workflow is run every Saturday at 4 AM UTC, but it can also be triggered manually. For purposes of testing the changes in this PR during review, I've also added triggers for PRs and push.

Accessibility checks are run using https://github.com/pa11y/pa11y-ci and [Axe as its runner](https://github.com/dequelabs/axe-core). Given the effort needed to set up an instance of the site on CI with enough data to closely represent the real website, I think we should start off by running the tests against the production website first. There aren't any risks as far as I understand, since it's basically the same as browsing the website normally.

The `color-contrast` rule is intentionally ignored for now, as there are a lot of violations and it would require a significant change to the design system to fix. The website is due for a redesign in the near future, so I think it's better to enable it later when we get the new designs in place.

I also added the reCAPTCHA iframe (seen in the fundraising page) to the ignore list, as otherwise Axe would raise a violation about it needing to be tested ([`frame-tested`](https://dequeuniversity.com/rules/axe/4.11/frame-tested?application=axeAPI)). We can't test the iframe as we'd need to load Axe in there too, which is impossible as we don't have control over it.

The set of URLs are by no means complete. I just added ones that are easily accessible from the homepage. Feel free to suggest URLs to add or remove.

cc: @django/accessibility 