### PR TITLE
Improved styling of tables in docs

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2633,6 +2633,30 @@ table.foundation td {
     padding: 0 5px;
 }
 
+table.docutils {
+    margin-bottom: 1.5em;
+
+    td,
+    th {
+        border-bottom: 1px solid var(--hairline-color);
+        padding: 8px 12px;
+    }
+
+    thead th {
+        border-bottom: 2px solid $gray-medium;
+        font-weight: bold;
+    }
+
+    tr:nth-child(even) {
+        background-color: var(--sidebar-bg);
+        background-color: color-mix(in oklab, currentColor 5%, transparent);
+    }
+
+    tr:hover {
+        background-color: color-mix(in oklab, currentColor 10%, transparent);
+    }
+}
+
 table.django-supported-versions,
 table.django-unsupported-versions {
     border: 1px solid var(--hairline-color);


### PR DESCRIPTION
Addresses #2128, PR is a follow on from #2129. The various comments have been addressed.

For the row highlight I went with a color-mix approach, making it 5% darker/lighter for even rows and 10% for hover.
That is less colorful than what was there from the previous PR and my original prototyping. I'm still happy with it.

Color-mix is supported since May 2023 according to caniuse and mdn. I put in a fallback for the even row highlight, but the hover is more additive so I left it out.

<img width="488" height="463" alt="image" src="https://github.com/user-attachments/assets/76de5e1d-0e9d-483a-bbdd-21938e8ec3a4" />

<img width="501" height="448" alt="image" src="https://github.com/user-attachments/assets/fd99d2a3-51ca-4520-9126-b33db995c049" />

It's subtle in darkmode, but its a tradeoff with color contrast.
Currently the dark-mode hover highlight is already slightly outside AAA. If we aim for that, I'd recommend droping the hover highlight in darkmode, like I said above, additive.

If you are reviewing this, worth checking out how it looks in places with lots of tables near each other like 
/en/dev/ref/templates/builtins/#floatformat

and somewhere with an example box (which has a similar background) right above a table
/en/dev/ref/templates/builtins/#yesno