### PR TITLE
Update initial header level in BLOG_DOCUTILS_SETTINGS to 2

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -17,7 +17,7 @@ from markdown.extensions.toc import TocExtension, slugify as _md_title_slugify
 
 BLOG_DOCUTILS_SETTINGS = {
     "doctitle_xform": False,
-    "initial_header_level": 1,
+    "initial_header_level": 2,
     "id_prefix": "s-",
     "raw_enabled": False,
     "file_insertion_enabled": False,
@@ -61,7 +61,10 @@ class ContentFormat(models.TextChoices):
                 source,
                 output_format="html",
                 extensions=[
-                    # baselevel matches `initial_header_level` from BLOG_DOCUTILS_SETTINGS
+                    # baselevel is 1 unlike `initial_header_level` from
+                    # BLOG_DOCUTILS_SETTINGS because rst always starts from heading
+                    # level 1, but markdown can have specific heading levels so
+                    # starting from 1 makes sense.
                     "tables",
                     TocExtension(baselevel=1, slugify=_md_slugify),
                 ],

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -129,7 +129,7 @@ class EntryTestCase(DateTimeMixin, TestCase):
             content_format=ContentFormat.REST,
         )
         self.assertHTMLEqual(
-            entry.body_html, '<div class="section" id="s-test"><h1>test</h1></div>'
+            entry.body_html, '<div class="section" id="s-test"><h2>test</h2></div>'
         )
 
     def test_header_base_level_markdown(self):


### PR DESCRIPTION
Sets initial header level for rst to 2 since it always starts with heading level 1 automatically but keeps markdown baselevel to 1 since markdown has actual heading level applied.