### PR TITLE
Add "Become a sponsor" link to the corporate members sidebar

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3569,6 +3569,11 @@ ul.corporate-members li {
         margin-bottom: 20px;
     }
 
+    .become-a-sponsor {
+        clear: both;
+        margin-top: 10px;
+    }
+
     clear: both;
 }
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -3569,11 +3569,6 @@ ul.corporate-members li {
         margin-bottom: 20px;
     }
 
-    .become-a-sponsor {
-        clear: both;
-        margin-top: 10px;
-    }
-
     clear: both;
 }
 

--- a/djangoproject/templates/fundraising/includes/top_corporate_members.html
+++ b/djangoproject/templates/fundraising/includes/top_corporate_members.html
@@ -18,5 +18,8 @@
         </div>
       </div>
     {% endfor %}
+    <p class="become-a-sponsor">
+      <a href="https://www.djangoproject.com/foundation/corporate-membership/">Become a sponsor &rarr;</a>
+    </p>
   </div>
 {% endif %}

--- a/djangoproject/templates/fundraising/includes/top_corporate_members.html
+++ b/djangoproject/templates/fundraising/includes/top_corporate_members.html
@@ -18,8 +18,8 @@
         </div>
       </div>
     {% endfor %}
-    <p class="become-a-sponsor">
-      <a href="https://www.djangoproject.com/foundation/corporate-membership/">Become a sponsor &rarr;</a>
-    </p>
+    <ul class="list-links-small">
+      <li><a href="https://www.djangoproject.com/foundation/corporate-membership/">Become a sponsor</a></li>
+    </ul>
   </div>
 {% endif %}


### PR DESCRIPTION
The corporate members sidebar lists current sponsors but offers no way for prospective ones to get involved.