### PR TITLE
Link to the corporate membership page, not straight to the signup form

### DIFF
--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -33,11 +33,10 @@
           {% endblocktranslate %}
         </li>
         <li>
-          {% url 'members:corporate-members-join' as corp_join_url %}
           {% blocktranslate trimmed %}
             Companies able to make a <strong>larger donation</strong>
             ($2,000+/year) are invited to apply to be Corporate Members
-            <a href="{{ corp_join_url }}">here</a>.
+            <a href="https://www.djangoproject.com/foundation/corporate-membership/">here</a>.
           {% endblocktranslate %}
         </li>
       </ul>

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -35,8 +35,8 @@
         <li>
           {% blocktranslate trimmed %}
             Companies able to make a <strong>larger donation</strong>
-            ($2,000+/year) are invited to apply to be Corporate Members
-            <a href="https://www.djangoproject.com/foundation/corporate-membership/">here</a>.
+            ($2,000+/year) are invited to be
+            <a href="https://www.djangoproject.com/foundation/corporate-membership/">Corporate Members</a>.
           {% endblocktranslate %}
         </li>
       </ul>

--- a/djangoproject/templates/members/corporatemember_form.html
+++ b/djangoproject/templates/members/corporatemember_form.html
@@ -9,6 +9,12 @@
       organization!
     {% endblocktranslate %}
   </p>
+  <p>
+    {% blocktranslate trimmed %}
+      See the various sponsorship benefits on our
+      <a href="https://www.djangoproject.com/foundation/corporate-membership/">corporate membership page</a>.
+    {% endblocktranslate %}
+  </p>
   <form class="form-input corporate-membership-join-form" method="post" action="."
         enctype="multipart/form-data">
     {% csrf_token %}


### PR DESCRIPTION
The main fundraising page links straight to the corporate membership signup form, and the signup form has no link back to the page that explains membership.

People likely want to know what they're getting before signing up. Also `apply` isn't mentioned anywhere other than the primary CTA :) 