### PR TITLE
Hide the site banner on foundation pages

### DIFF
--- a/djangoproject/templates/base_foundation.html
+++ b/djangoproject/templates/base_foundation.html
@@ -11,6 +11,8 @@
   <p>Django Software Foundation</p>
 {% endblock header %}
 
+{% block billboard %}{% endblock %}
+
 {% block content-related %}
 
 {# Always include <h2> label and <div> with aria role. #}

--- a/djangoproject/templates/base_foundation.html
+++ b/djangoproject/templates/base_foundation.html
@@ -11,6 +11,7 @@
   <p>Django Software Foundation</p>
 {% endblock header %}
 
+{# Override the billboard block to hide the site-wide banner, a distraction on foundation pages. #}
 {% block billboard %}{% endblock %}
 
 {% block content-related %}


### PR DESCRIPTION
The site-wide banner is a distraction on the foundation pages (corporate membership and the rest). 

I'm less than 100% sure on this PR -- but in general if people want to give you money, the "giving you money" thing should be the primary CTA on the page. 