### PR TITLE
Removed root font-size override.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -705,7 +705,7 @@ header {
         margin: 0 auto;
 
         @include sans-serif;
-        font-size: 1.8rem;
+        @include font-size(18);
         font-weight: 300;
         line-height: 1.4;
 
@@ -2458,13 +2458,13 @@ h2+.list-link-soup {
 
 @include respond-min(768px) {
     body:has(.doc-floating-warning) [id] {
-        scroll-margin-top: 6.3rem;
+        scroll-margin-top: 63px;
     }
 }
 
 @include respond-min(1300px) {
     body:has(.doc-floating-warning) [id] {
-        scroll-margin-top: 4.2rem;
+        scroll-margin-top: 42px;
     }
 }
 
@@ -3715,7 +3715,7 @@ ul.corporate-members li {
 
     .community-cta-wrapper {
         display: flex;
-        gap: 6rem;
+        gap: 60px;
         flex-wrap: wrap;
         align-content: center;
     }

--- a/djangoproject/scss/_utils.scss
+++ b/djangoproject/scss/_utils.scss
@@ -125,14 +125,8 @@ $logo-bg-dark: #272c27;
     overflow-wrap: break-word;
 }
 
-// Font Sizing Mixin (http://css-tricks.com/snippets/css/less-mixin-for-rem-font-sizing/)
-html {
-    font-size: 62.5%;
-}
-
 @mixin font-size ($size: 16) {
-    font-size: $size + px;
-    font-size: $size/10 + rem;
+    font-size: $size/16 + rem;
 }
 
 // Boilerplate Helper mixins (https://github.com/h5bp/html5-boilerplate/blob/v4.1.0/doc/css.md)


### PR DESCRIPTION
Removed CSS rule that changed 1rem to be 10px and updated font-size mixin to match. Removed unnecessary font-size fallback for browsers that don't support rem (IE8). Changed the few uses of rem-based spacing to px based on 1rem=16px browser default.

Fixes #2651.