### PR TITLE
Replaced deprecated name attribute with id in py-modindex.html.

### DIFF
--- a/docs/templates/docs/py-modindex.html
+++ b/docs/templates/docs/py-modindex.html
@@ -17,7 +17,7 @@
     </ul>
 
     {% for letter, objects in doc.content %}
-        <h3><a name="{{ letter }}">{{ letter|upper }}</a></h3>
+        <h3><a id="{{ letter }}">{{ letter|upper }}</a></h3>
         <ul>
             {% for module_name, subtype, docname, path, platforms, qualifier, synopsis in objects %}
                 {% if docname %}


### PR DESCRIPTION
Fixes #2658.