### PR TITLE
Inlined svgs for dark mode theme switcher.

### DIFF
--- a/djangoproject/scss/_dark-mode.scss
+++ b/djangoproject/scss/_dark-mode.scss
@@ -296,30 +296,25 @@ html[data-theme="dark"] .img-release {
     justify-content: center;
 }
 
-.theme-toggle svg {
-    max-width: 16px;
-    max-height: 16px;
-    display: none;
-}
-
 /* ICONS */
-.theme-toggle svg.theme-icon-when-auto,
-.theme-toggle svg.theme-icon-when-dark,
-.theme-toggle svg.theme-icon-when-light {
-    fill: var(--menu);
-    color: $green-dark;
-}
+.theme-toggle .theme-icon {
+    width: 16px;
+    height: 16px;
+    color: var(--menu);
 
-html[data-theme="auto"] .theme-toggle svg.theme-icon-when-auto {
-    display: block;
-}
+    display: none;
 
-html[data-theme="dark"] .theme-toggle svg.theme-icon-when-dark {
-    display: block;
-}
+    html[data-theme="auto"] &.theme-icon-when-auto {
+        display: block;
+    }
 
-html[data-theme="light"] .theme-toggle svg.theme-icon-when-light {
-    display: block;
+    html[data-theme="dark"] &.theme-icon-when-dark {
+        display: block;
+    }
+
+    html[data-theme="light"] &.theme-icon-when-light {
+        display: block;
+    }
 }
 
 /* Fully hide screen reader text so we only show the one matching the current theme */

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -94,14 +94,6 @@
     {% block alert %}
     {% endblock alert %}
 
-    <!-- SVGs -->
-    <svg xmlns="http://www.w3.org/2000/svg">
-      <symbol viewBox="0 0 24 24" id="icon-auto"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2V4a8 8 0 1 0 0 16z"/></symbol>
-      <symbol viewBox="0 0 24 24" id="icon-moon"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/></symbol>
-      <symbol viewBox="0 0 24 24" id="icon-sun"><path d="M0 0h24v24H0z" fill="currentColor"/><path d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/></symbol>
-    </svg>
-    <!-- END SVGs -->
-
     {% block footer %}
       {% include "includes/footer.html" %}
     {% endblock footer %}

--- a/djangoproject/templates/includes/toggle_theme.html
+++ b/djangoproject/templates/includes/toggle_theme.html
@@ -6,13 +6,13 @@
   <div class="visually-hidden theme-label-when-dark">{% translate 'Toggle theme (current theme: dark)' %}</div>
 
   <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
-  <svg aria-hidden="true" class="theme-icon-when-auto">
-    <use xlink:href="#icon-auto" />
+  <svg aria-hidden="true" class="theme-icon theme-icon-when-auto" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2V4a8 8 0 1 0 0 16z"/>
   </svg>
-  <svg aria-hidden="true" class="theme-icon-when-dark">
-    <use xlink:href="#icon-moon" />
+  <svg aria-hidden="true" class="theme-icon theme-icon-when-dark" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2h.1A6.979 6.979 0 0 0 10 7zm-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938 7.999 7.999 0 0 0 4 12z"/>
   </svg>
-  <svg aria-hidden="true" class="theme-icon-when-light">
-    <use xlink:href="#icon-sun" />
+  <svg aria-hidden="true" class="theme-icon theme-icon-when-light" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM11 1h2v3h-2V1zm0 19h2v3h-2v-3zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2h3zM4 11v2H1v-2h3z"/>
   </svg>
 </button>


### PR DESCRIPTION
Fixes #2650 by moving the theme-switcher svgs into toggle_theme.html, removing the svg sprite from base.html. (This is option 2 from the report, and an alternative to PR #2652 which uses FontAwesome icons instead.)