### PR TITLE
Updated corporate membership amounts to match new prospectus

### DIFF
--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -230,7 +230,7 @@ document.querySelectorAll('.btn-clipboard').forEach(function (el) {
 
   const amount_el = form_el.querySelector('#id_amount');
   const level_el = form_el.querySelector('#id_membership_level');
-  const levels = [-Infinity, 2000, 5000, 12500, 30000, 100000];
+  const levels = [-Infinity, 2200, 5500, 13750, 30000, 100000];
 
   amount_el.addEventListener('change', function () {
     let value;

--- a/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
+++ b/djangoproject/templates/fundraising/includes/donation_form_with_heart.html
@@ -36,7 +36,7 @@
           {% url 'members:corporate-members-join' as corp_join_url %}
           {% blocktranslate trimmed %}
             Companies able to make a <strong>larger donation</strong>
-            ($2,000+/year) are invited to apply to be Corporate Members
+            ($2,200+/year) are invited to apply to be Corporate Members
             <a href="{{ corp_join_url }}">here</a>.
           {% endblocktranslate %}
         </li>

--- a/members/models.py
+++ b/members/models.py
@@ -21,9 +21,9 @@ DIAMOND_MEMBERSHIP = 5
 CORPORATE_MEMBERSHIP_AMOUNTS = {
     "diamond": 100000,
     "platinum": 30000,
-    "gold": 12500,
-    "silver": 5000,
-    "bronze": 2000,
+    "gold": 13750,
+    "silver": 5500,
+    "bronze": 2200,
 }
 
 MEMBERSHIP_LEVELS = (


### PR DESCRIPTION
Fixes #2657

Updates the Bronze, Silver, and Gold corporate membership tier amounts in
`CORPORATE_MEMBERSHIP_AMOUNTS` to match the new DSF prospectus published
at /sponsor/:

- Bronze: $2,000 → $2,200
- Silver: $5,000 → $5,500
- Gold: $12,500 → $13,750

Also updates the corresponding "$2,000+/year" reference on the fundraising
page donation form.

Note: The `/foundation/corporate-membership/` page (items 2, 4, 5, and 6
from the issue) appears to be database-managed flat page content and is not
in the repo. Those sections will need to be updated separately by someone
with admin access.