### PR TITLE
Handle corporate member SVG logos

### DIFF
--- a/djangoproject/templates/fundraising/includes/_hero_with_logo.html
+++ b/djangoproject/templates/fundraising/includes/_hero_with_logo.html
@@ -4,13 +4,13 @@
     {% if obj.url %}<a href="{{ obj.url }}" rel="nofollow">{% endif %}
     {% if obj.logo %}
       <img
-        {% if obj.logo_is_svg %}
-          src="{{ obj.logo.url }}"
-        {% else %}
+        {% if obj.thumbnail %}
           src="{{ obj.thumbnail.url }}"
           srcset="{{ obj.thumbnail.url|resolution:'2x' }} 2x"
           width="{{ obj.thumbnail.width }}"
           height="{{ obj.thumbnail.height }}"
+        {% else %}
+          src="{{ obj.logo.url }}"
         {% endif %}
         loading="lazy"
         alt="{% blocktranslate trimmed with company_name=obj.display_name %}

--- a/djangoproject/templates/fundraising/includes/_hero_with_logo.html
+++ b/djangoproject/templates/fundraising/includes/_hero_with_logo.html
@@ -4,10 +4,14 @@
     {% if obj.url %}<a href="{{ obj.url }}" rel="nofollow">{% endif %}
     {% if obj.logo %}
       <img
-        src="{{ obj.thumbnail.url }}"
-        srcset="{{ obj.thumbnail.url|resolution:'2x' }} 2x"
-        width="{{ obj.thumbnail.width }}"
-        height="{{ obj.thumbnail.height }}"
+        {% if obj.logo_is_svg %}
+          src="{{ obj.logo.url }}"
+        {% else %}
+          src="{{ obj.thumbnail.url }}"
+          srcset="{{ obj.thumbnail.url|resolution:'2x' }} 2x"
+          width="{{ obj.thumbnail.width }}"
+          height="{{ obj.thumbnail.height }}"
+        {% endif %}
         loading="lazy"
         alt="{% blocktranslate trimmed with company_name=obj.display_name %}
                Logo of company {{ company_name }}{% endblocktranslate %}"

--- a/djangoproject/templates/fundraising/includes/top_corporate_members.html
+++ b/djangoproject/templates/fundraising/includes/top_corporate_members.html
@@ -5,7 +5,15 @@
       <div class="clearfix">
         <div class="member-logo">
           <a href="{{ obj.url }}" title="{{ obj.display_name }}">
-            <img src="{{ obj.thumbnail.url }}" alt="{{ obj.display_name }}" />
+            {% if obj.logo %}
+              <img
+                {% if obj.thumbnail %}
+                  src="{{ obj.thumbnail.url }}"
+                {% else %}
+                  src="{{ obj.logo.url }}"
+                {% endif %}
+                alt="{{ obj.display_name }}" />
+            {% endif %}
           </a>
         </div>
         <div class="small-cta">

--- a/djangoproject/templates/members/includes/_member_with_logo.html
+++ b/djangoproject/templates/members/includes/_member_with_logo.html
@@ -1,9 +1,14 @@
 {% load static thumbnail %}
 <li>
-    {% if obj.logo %}
-        <img src="{{ obj.thumbnail.url }}"
-             alt="{{ obj.display_name }}" class="corporate-member-logo" />
-    {% endif %}
-    <h3><a href="{{ obj.url }}">{{ obj.display_name }}</a></h3>
-    <p>{{ obj.description|linebreaksbr }}</p>
+  {% if obj.logo %}
+    <img
+      {% if obj.thumbnail %}
+        src="{{ obj.thumbnail.url }}"
+      {% else %}
+        src="{{ obj.logo.url }}"
+      {% endif %}
+      alt="{{ obj.display_name }}" class="corporate-member-logo" />
+  {% endif %}
+  <h3><a href="{{ obj.url }}">{{ obj.display_name }}</a></h3>
+  <p>{{ obj.description|linebreaksbr }}</p>
 </li>

--- a/djangoproject/thumbnails.py
+++ b/djangoproject/thumbnails.py
@@ -1,4 +1,8 @@
+import logging
+
 from sorl.thumbnail import get_thumbnail
+
+logger = logging.getLogger(__name__)
 
 
 class LogoThumbnailMixin:
@@ -12,10 +16,16 @@ class LogoThumbnailMixin:
 
     @property
     def thumbnail(self):
+        if not self.logo:
+            return None
         if self.logo_is_svg:
             return None
         geometry = f"{self.THUMBNAIL_SIZE}x{self.THUMBNAIL_SIZE}"
-        return get_thumbnail(self.logo, geometry, quality=100) if self.logo else None
+        try:
+            return get_thumbnail(self.logo, geometry, quality=100)
+        except Exception:
+            logger.warning("Could not thumbnail logo %r", self.logo.name)
+        return None
 
     @property
     def logo_is_svg(self):

--- a/djangoproject/thumbnails.py
+++ b/djangoproject/thumbnails.py
@@ -12,5 +12,11 @@ class LogoThumbnailMixin:
 
     @property
     def thumbnail(self):
+        if self.logo_is_svg:
+            return None
         geometry = f"{self.THUMBNAIL_SIZE}x{self.THUMBNAIL_SIZE}"
         return get_thumbnail(self.logo, geometry, quality=100) if self.logo else None
+
+    @property
+    def logo_is_svg(self):
+        return bool(self.logo) and self.logo.name.lower().endswith(".svg")

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -103,6 +103,25 @@ class TestCampaign(ReleaseMixin, TemporaryMediaRootMixin, TestCase):
             html=True,
         )
 
+    def test_corporate_member_with_no_thumbnail_logo_available(self):
+        logo = ImageFileFactory("no_thumbnail.png", width=10)
+        member = CorporateMember.objects.create(
+            display_name="Test Member", membership_level=1, logo=logo
+        )
+        Invoice.objects.create(amount=100, expiration_date=date.today(), member=member)
+        with patch("djangoproject.thumbnails.get_thumbnail", side_effect=OSError):
+            response = self.client.get(self.index_url)
+
+        self.assertContains(
+            response,
+            """<img
+                src="/m/corporate-members/no_thumbnail.png"
+                loading="lazy"
+                alt="Logo of company Test Member"
+            >""",
+            html=True,
+        )
+
     def test_anonymous_donor(self):
         hero = DjangoHero.objects.create(
             is_visible=True, approved=True, hero_type="individual"

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -85,6 +85,24 @@ class TestCampaign(ReleaseMixin, TemporaryMediaRootMixin, TestCase):
             html=True,
         )
 
+    def test_corporate_member_with_svg_logo(self):
+        logo = ImageFileFactory("wide.svg", width=10)
+        member = CorporateMember.objects.create(
+            display_name="Test Member", membership_level=1, logo=logo
+        )
+        Invoice.objects.create(amount=100, expiration_date=date.today(), member=member)
+        response = self.client.get(self.index_url)
+
+        self.assertContains(
+            response,
+            """<img
+                src="/m/corporate-members/wide.svg"
+                loading="lazy"
+                alt="Logo of company Test Member"
+            >""",
+            html=True,
+        )
+
     def test_anonymous_donor(self):
         hero = DjangoHero.objects.create(
             is_visible=True, approved=True, hero_type="individual"

--- a/fundraising/tests/utils.py
+++ b/fundraising/tests/utils.py
@@ -12,9 +12,21 @@ def ImageFileFactory(name, width=1, height=1, color=(12, 75, 51)):
     The image will be of the given size, and of solid color. The format will
     be inferred from the filename.
     """
-    img = Image.new("RGB", (width, height), color=color)
     out = BytesIO()
-    img.save(out, format=name.split(".")[-1])
+    if name.lower().endswith(".svg"):
+        # Pillow doesn't support SVG, so write XML.
+        r, g, b = color
+        out.write(
+            (
+                '<svg xmlns="http://www.w3.org/2000/svg" '
+                f'width="{width}" height="{height}" viewBox="0 0 {width} {height}">'
+                f'<rect width="{width}" height="{height}" fill="rgb({r},{g},{b})"/>'
+                "</svg>"
+            ).encode()
+        )
+    else:
+        img = Image.new("RGB", (width, height), color=color)
+        img.save(out, format=name.split(".")[-1])
     return ImageFile(out, name=name)
 
 


### PR DESCRIPTION
The `DjangoHeroForm`/`CorporateMemberSignUpForm` accepted SVG logos, but SVG aren't processable via Pillow, so the thumbnail code threw errors when trying to run them through Pillow.

sorl-thumbnail logged this Pillow error:

```py
cannot identify image file <_io.BytesIO object at 0x7965b761e7a0>
```

And the /fundraising page crashed on trying to access the `.width` property on a thumbnail that didn't exist. (The dimension properties in `sorl_thumbnail` are unsafely implemented, accessing `._size[0]` even though `._size` is `None` in a case like this.)

In the template, that resulted in:
```py
'NoneType' object is not subscriptable
```

Closes #2664

