### PR TITLE
Fixed #2647 -- Reduced billboard banner height on small screens.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -694,20 +694,41 @@ header {
     }
 
     .banner {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
         text-align: center;
-        padding: 1em 3em;
+        // Narrower side padding than desktop widens the text column on mobile
+        // (fewer wrapped lines), while vertical padding stays comfortable.
+        padding: 1em 1.25em;
         max-width: 60em;
         margin: 0 auto;
-        p {
-            @include sans-serif;
-            font-size: 3.2rem;
-            font-weight: 300;
-            margin: 0.35em 0 0.35em;
-            line-height: 1.3;
-            padding: 1px 0 6px;
+
+        @include sans-serif;
+        font-size: 1.8rem;
+        font-weight: 300;
+        line-height: 1.4;
+
+        @include respond-min(768px) {
+            padding: 1em 3em;
         }
+
+        // gap owns the spacing between items; clear the inherited margins
+        // (the h2 UA default and the global .cta margins) so the gaps stay
+        // uniform and the outer edges are defined by the container padding.
+        > * {
+            margin: 0;
+        }
+
+        .cta {
+            box-sizing: border-box;
+            width: 100%;
+            max-width: 400px;
+            margin: 0 auto;
+        }
+
         .underlined {
-          text-decoration: underline;
+            text-decoration: underline;
         }
     }
 

--- a/djangoproject/templates/foundation/banner.html
+++ b/djangoproject/templates/foundation/banner.html
@@ -1,7 +1,8 @@
 {% if banner %}
   <div class="banner">
     <h2>{{ banner.title }}</h2>
-    {% if banner.body %}{{ banner.body|safe }}{% endif %}
+    {# Wrapper keeps the body a single flex item so inline content flows. #}
+    {% if banner.body %}<div class="banner-body">{{ banner.body|safe }}</div>{% endif %}
     {% if banner.cta_url and banner.cta_label %}
       <a id="banner-cta" class="cta" href="{{ banner.cta_url }}">{{ banner.cta_label }}</a>
     {% endif %}

--- a/foundation/tests.py
+++ b/foundation/tests.py
@@ -46,7 +46,9 @@ class BannerTestCase(ReleaseMixin, TestCase):
         )
         response = self.client.get("/")
         self.assertContains(response, "<h2>Support Django!</h2>", html=True)
-        self.assertContains(response, "Please donate.")
+        self.assertContains(
+            response, '<div class="banner-body">Please donate.</div>', html=True
+        )
         self.assertContains(
             response,
             '<a id="banner-cta" class="cta" href="https://djangoproject.com/donate/">'


### PR DESCRIPTION
On small screens the billboard banner took up an excessive share of the viewport, leaving little room for page content.

Reworked the banner into a flex column where the container padding defines the outer edges and `gap` owns the spacing between the title, body, and call-to-action, clearing inherited margins so the rhythm stays uniform. The body now renders at a single consistent size and the mobile height is trimmed mainly by widening the text column (narrower horizontal padding) rather than by cramping the vertical spacing, which stays comfortable.

The body is wrapped in a block-level element so that, in the flex container, inline content such as links flows inline instead of each inline node being promoted to its own flex item and stacking onto separate lines.

The call-to-action button is capped and centered at every breakpoint instead of stretching full width on mid-size screens.

Screenshots:
<img width="2148" height="1909" alt="image" src="https://github.com/user-attachments/assets/73aa2ae9-e004-406e-839a-c1657d5fcf10" />
<img width="2148" height="1909" alt="image" src="https://github.com/user-attachments/assets/e8a74ab8-75f1-4ee8-b55e-20895ad22bd0" />
<img width="270" height="750" alt="image" src="https://github.com/user-attachments/assets/d8883746-f01e-4140-b58f-21cfefbcc5ce" />
<img width="270" height="750" alt="image" src="https://github.com/user-attachments/assets/f66cc28f-8aa7-4d91-af2b-d1bd1439eb76" />
