### PR TITLE
Fix fundraising page crash when corporate logos are SVGs

### DIFF
--- a/djangoproject/thumbnails.py
+++ b/djangoproject/thumbnails.py
@@ -1,6 +1,37 @@
 from sorl.thumbnail import get_thumbnail
 
 
+class SVGLogoWrapper:
+    def __init__(self, logo):
+        self.logo = logo
+
+    @property
+    def url(self):
+        return self.logo.url
+
+    @property
+    def width(self):
+        return None
+
+    @property
+    def height(self):
+        return None
+
+    @property
+    def x(self):
+        return None
+
+    @property
+    def y(self):
+        return None
+
+    def exists(self):
+        return self.logo.storage.exists(self.logo.name)
+
+    def __str__(self):
+        return self.logo.url
+
+
 class LogoThumbnailMixin:
     """
     Add this mixin to a model that has a `logo` ImageField to automatically
@@ -12,5 +43,9 @@ class LogoThumbnailMixin:
 
     @property
     def thumbnail(self):
+        if not self.logo:
+            return None
+        if self.logo.name.lower().endswith(".svg"):
+            return SVGLogoWrapper(self.logo)
         geometry = f"{self.THUMBNAIL_SIZE}x{self.THUMBNAIL_SIZE}"
-        return get_thumbnail(self.logo, geometry, quality=100) if self.logo else None
+        return get_thumbnail(self.logo, geometry, quality=100)

--- a/fundraising/tests/test_models.py
+++ b/fundraising/tests/test_models.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.core.files.base import ContentFile
 from django.test import TestCase
 
 from ..models import DjangoHero, Donation, InKindDonor
@@ -34,6 +35,18 @@ class TestDjangoHero(TemporaryMediaRootMixin, TestCase):
 
     def test_thumbnail_no_logo(self):
         self.assertIsNone(self.h2.thumbnail)
+
+    def test_thumbnail_svg(self):
+        self.h1.logo.save("logo.svg", ContentFile("<svg></svg>"))
+        self.h1.save()
+        thumbnail = self.h1.thumbnail
+        self.assertEqual(thumbnail.url, self.h1.logo.url)
+        self.assertIsNone(thumbnail.width)
+        self.assertIsNone(thumbnail.height)
+        self.assertIsNone(thumbnail.x)
+        self.assertIsNone(thumbnail.y)
+        self.assertTrue(thumbnail.exists())
+        self.h1.logo.delete()
 
     def test_name_with_fallback(self):
         hero = DjangoHero()


### PR DESCRIPTION
Fixes django/djangoproject.com#2664. Avoid generating thumbnails for SVG logos as they are vector images and do not require rasterized thumbnails. Instead, return a lightweight SVG wrapper when the logo ends with .svg, preventing PIL from raising UnidentifiedImageError and crashing the page.