### PR TITLE
Remove obsolete CSS targeting the Opera browser

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1882,19 +1882,6 @@ h2+.list-link-soup {
                     background-position: -334px -12px;
                 }
             }
-
-            // Fixing opera svg-border-radius bug
-            // http://stackoverflow.com/questions/11114636/opera-border-radius-svg-background-bug
-            :-o-prefocus,
-            & {
-                background: $green-medium !important;
-
-                -webkit-transition: none !important;
-                transition: none !important;
-
-                -webkit-transform: none !important;
-                transform: none !important;
-            }
         }
     }
 


### PR DESCRIPTION
This CSS was added in 2014 when the site was redesigned (88bcfc32), and Opera switched from its own rendering engine to Chromium in 2013. The selector and associated bug is no longer relevant.

- https://en.wikipedia.org/wiki/Opera_(web_browser)#:~:text=In%202013,%20it%20switched%20from%20the%20Presto%20engine%20to%20Chromium.
- https://web.archive.org/web/20130306150536/http://www.opera.com/docs/specs/presto2.12/css/o-vendor/