### PR TITLE
Fixed several issues in switch-dark-mode.js

### DIFF
--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
 function setTheme(mode) {
@@ -7,9 +9,9 @@ function setTheme(mode) {
   }
   document.documentElement.dataset.theme = mode;
   // trim host to get base domain name for set in cookie domain name for subdomain access
-  arrHost = window.location.hostname.split('.');
-  prefix = arrHost.shift();
-  host = arrHost.join('.');
+  const arrHost = window.location.hostname.split('.');
+  const prefix = arrHost.shift();
+  const host = arrHost.join('.');
   setCookie('theme', mode, host);
 }
 
@@ -46,7 +48,7 @@ function initTheme() {
 function setupTheme() {
   // Attach event handlers for toggling themes
   let buttons = document.getElementsByClassName('theme-toggle');
-  for (var i = 0; i < buttons.length; i++) {
+  for (let i = 0; i < buttons.length; i++) {
     buttons[i].addEventListener('click', cycleTheme);
   }
 }
@@ -56,8 +58,8 @@ function setCookie(cname, cvalue, domain) {
   d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000); // 1 year
   let expires = 'expires=' + d.toUTCString();
   // change the SameSite attribute if it's on development or production
-  sameSiteAttribute =
-    domain == 'localhost'
+  const sameSiteAttribute =
+    domain === 'localhost'
       ? 'SameSite=Lax;'
       : `Domain=${domain}; SameSite=None; Secure;`;
   document.cookie = `${cname}=${cvalue}; ${sameSiteAttribute} ${expires}; path=/;`;
@@ -69,10 +71,10 @@ function getCookie(cname) {
   let ca = decodedCookie.split(';');
   for (let i = 0; i < ca.length; i++) {
     let c = ca[i];
-    while (c.charAt(0) == ' ') {
+    while (c.charAt(0) === ' ') {
       c = c.substring(1);
     }
-    if (c.indexOf(name) == 0) {
+    if (c.indexOf(name) === 0) {
       return c.substring(name.length, c.length);
     }
   }

--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -97,6 +97,13 @@ document.addEventListener('DOMContentLoaded', function () {
   setupThemeToggle();
 });
 
+window.addEventListener('pageshow', function (e) {
+  if (e.persisted) {
+    // Re-initialize from cookie in case theme was changed on another page.
+    initTheme();
+  }
+});
+
 prefersDarkMediaQuery.addEventListener('change', (e) => {
   prefersDark = e.matches;
 });

--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -16,7 +16,10 @@ function setTheme(mode) {
 }
 
 function cycleTheme() {
-  const currentTheme = getCookie('theme') || 'auto';
+  let currentTheme = document.documentElement.dataset.theme;
+  if (currentTheme !== 'light' && currentTheme !== 'dark' && currentTheme !== 'auto') {
+    currentTheme = 'auto';
+  }
 
   if (prefersDark) {
     // Auto (dark) -> Light -> Dark
@@ -92,5 +95,4 @@ window
   .matchMedia('(prefers-color-scheme: dark)')
   .addEventListener('change', function (e) {
     prefersDark = e.matches;
-    initTheme();
   });

--- a/djangoproject/static/js/mod/switch-dark-mode.js
+++ b/djangoproject/static/js/mod/switch-dark-mode.js
@@ -1,84 +1,91 @@
+// To prevent a flash of un-themed content, this script must be loaded in the
+// <head> and cannot be marked async, defer, or type=module.
 'use strict';
 
-let prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const themes = ['auto', 'light', 'dark'];
+const defaultTheme = themes[0];
+const dataSetName = 'theme'; // <html data-___> attr for current theme
 
-function setTheme(mode) {
-  if (mode !== 'light' && mode !== 'dark' && mode !== 'auto') {
-    console.error(`Got invalid theme mode: ${mode}. Resetting to auto.`);
-    mode = 'auto';
+const cookieName = 'theme';
+const cookieMaxAgeMs = 365 * 24 * 60 * 60 * 1000; // 1 year
+const cookieDomain = getCookieDomain(window.location.hostname, [
+  // Share the cookie between all subdomains (code, docs, www, etc.) in
+  // these base domains. More-specific bases must be listed first.
+  'preview.djangoproject.com',
+  'djangoproject.com',
+  'djangoproject.localhost',
+  'djangoproject.local',
+  // Any other hostname (localhost, 127.0.0.1, pr-123.readthedocs.build, etc.)
+  // will use a host-only cookie.
+]);
+const cookieSecure = window.location.protocol === 'https:';
+const cookieSameSite = 'Lax';
+
+const prefersDarkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+let prefersDark = prefersDarkMediaQuery.matches;
+
+function setTheme(theme) {
+  if (themes.indexOf(theme) < 0) {
+    console.error(`Invalid theme: '${theme}'. Resetting to '${defaultTheme}'.`);
+    theme = defaultTheme;
   }
-  document.documentElement.dataset.theme = mode;
-  // trim host to get base domain name for set in cookie domain name for subdomain access
-  const arrHost = window.location.hostname.split('.');
-  const prefix = arrHost.shift();
-  const host = arrHost.join('.');
-  setCookie('theme', mode, host);
+  document.documentElement.dataset[dataSetName] = theme;
+  setThemeCookie(theme);
 }
 
 function cycleTheme() {
-  let currentTheme = document.documentElement.dataset.theme;
-  if (currentTheme !== 'light' && currentTheme !== 'dark' && currentTheme !== 'auto') {
-    currentTheme = 'auto';
-  }
-
-  if (prefersDark) {
-    // Auto (dark) -> Light -> Dark
-    if (currentTheme === 'auto') {
-      setTheme('light');
-    } else if (currentTheme === 'light') {
-      setTheme('dark');
-    } else {
-      setTheme('auto');
-    }
-  } else {
-    // Auto (light) -> Dark -> Light
-    if (currentTheme === 'auto') {
-      setTheme('dark');
-    } else if (currentTheme === 'dark') {
-      setTheme('light');
-    } else {
-      setTheme('auto');
-    }
-  }
+  // If prefersDark, cycle Auto (dark) -> Light -> Dark;
+  // otherwise, cycle Auto (light) -> Dark -> Light.
+  const currentThemeIndex = Math.max(
+    0,
+    themes.indexOf(document.documentElement.dataset[dataSetName]),
+  );
+  const direction = prefersDark ? 1 : -1;
+  const newThemeIndex =
+    (currentThemeIndex + direction + themes.length) % themes.length;
+  setTheme(themes[newThemeIndex]);
 }
 
 function initTheme() {
-  // set theme defined in localStorage if there is one, or fallback to auto mode
-  const currentTheme = getCookie('theme');
-  currentTheme ? setTheme(currentTheme) : setTheme('auto');
+  // Set theme stored in cookie if there is one, or fallback to auto mode.
+  const currentTheme = getThemeCookie() || defaultTheme;
+  setTheme(currentTheme);
 }
 
-function setupTheme() {
-  // Attach event handlers for toggling themes
-  let buttons = document.getElementsByClassName('theme-toggle');
-  for (let i = 0; i < buttons.length; i++) {
-    buttons[i].addEventListener('click', cycleTheme);
+function setupThemeToggle() {
+  // Attach event handlers for theme toggle buttons.
+  for (const button of document.getElementsByClassName('theme-toggle')) {
+    button.addEventListener('click', cycleTheme);
   }
 }
 
-function setCookie(cname, cvalue, domain) {
-  const d = new Date();
-  d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000); // 1 year
-  let expires = 'expires=' + d.toUTCString();
-  // change the SameSite attribute if it's on development or production
-  const sameSiteAttribute =
-    domain === 'localhost'
-      ? 'SameSite=Lax;'
-      : `Domain=${domain}; SameSite=None; Secure;`;
-  document.cookie = `${cname}=${cvalue}; ${sameSiteAttribute} ${expires}; path=/;`;
+function setThemeCookie(theme) {
+  const expires = new Date(Date.now() + cookieMaxAgeMs).toUTCString();
+  const attributes = [
+    `${cookieName}=${encodeURIComponent(theme)}`,
+    'Path=/',
+    `Expires=${expires}`,
+    `SameSite=${cookieSameSite}`,
+    cookieDomain ? `Domain=${cookieDomain}` : '',
+    cookieSecure ? 'Secure' : '',
+  ];
+  document.cookie = attributes.filter(Boolean).join('; ');
 }
 
-function getCookie(cname) {
-  let name = cname + '=';
-  let decodedCookie = decodeURIComponent(document.cookie);
-  let ca = decodedCookie.split(';');
-  for (let i = 0; i < ca.length; i++) {
-    let c = ca[i];
-    while (c.charAt(0) === ' ') {
-      c = c.substring(1);
-    }
-    if (c.indexOf(name) === 0) {
-      return c.substring(name.length, c.length);
+function getThemeCookie() {
+  // This must be synchronous to avoid a flash of un-themed content on load,
+  // so cannot use the Cookie Store API.
+  const cookie = document.cookie
+    .split(/;\s*/g)
+    .find((cookie) => cookie.startsWith(`${cookieName}=`));
+  return cookie ? decodeURIComponent(cookie.slice(cookieName.length + 1)) : '';
+}
+
+function getCookieDomain(hostname, baseDomains) {
+  hostname = hostname.toLowerCase();
+  for (const baseDomain of baseDomains) {
+    if (hostname === baseDomain || hostname.endsWith(`.${baseDomain}`)) {
+      return baseDomain;
     }
   }
   return '';
@@ -87,12 +94,9 @@ function getCookie(cname) {
 initTheme();
 
 document.addEventListener('DOMContentLoaded', function () {
-  setupTheme();
+  setupThemeToggle();
 });
 
-// reset theme and release image if auto mode activated and os preferences have changed
-window
-  .matchMedia('(prefers-color-scheme: dark)')
-  .addEventListener('change', function (e) {
-    prefersDark = e.matches;
-  });
+prefersDarkMediaQuery.addEventListener('change', (e) => {
+  prefersDark = e.matches;
+});


### PR DESCRIPTION
Fixes #2669, which details four semi-related issues in switch-dark-mode.js:

* Leaked global variables
* Theme switcher gets stuck when cookies blocked
* Cookie domain logic can't handle IP addresses and other domains
* Theme choice lost during bfcache navigation

This is currently split into four separate commits, one for each problem. They can be squashed, or pulled apart if we decide some of these aren't worth fixing.

The changes to address the third issue ended up large enough that I did some additional refactoring to try to make the script more maintainable. But I can go back and try to make a minimal-delta edit if we'd prefer that.