### PR TITLE
Add copy buttons to all documentation code blocks

### DIFF
--- a/djangoproject/scss/_pygments.scss
+++ b/djangoproject/scss/_pygments.scss
@@ -6,9 +6,44 @@
     overflow: auto;
     border-radius: 4px;
     margin: 25px 0;
+    position: relative;
 
     pre {
         margin: 15px 20px;
+    }
+
+    > .btn-clipboard {
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        cursor: pointer;
+        z-index: 10;
+        opacity: 0.6;
+        transition: opacity 200ms ease;
+        padding: 5px;
+        border-radius: 4px;
+        background: var(--code-bg);
+
+        &:hover {
+            opacity: 1;
+            color: var(--link-color);
+        }
+
+        i {
+            color: var(--code-fg);
+        }
+
+        .clipboard-success {
+            font-size: 80%;
+            margin-right: 6px;
+            color: var(--link-color);
+            @include monospace;
+
+            &.fade-out {
+                opacity: 0;
+                transition: opacity 400ms;
+            }
+        }
     }
 }
 

--- a/djangoproject/static/js/djangoproject.js
+++ b/djangoproject/static/js/djangoproject.js
@@ -123,6 +123,29 @@ window.addEventListener('keydown', function (e) {
       highlight_el.appendChild(button_el.cloneNode(true));
     }
   });
+
+  document.querySelectorAll('.highlight').forEach(function (highlight_el) {
+    // Skip if inside console block
+    if (highlight_el.closest('.console-block')) {
+      return;
+    }
+    // Skip if has snippet-filename as previous sibling
+    const prev = highlight_el.previousElementSibling;
+    if (prev && prev.classList.contains('snippet-filename')) {
+      return;
+    }
+    // Skip if parent has code-block-caption as previous sibling
+    const parent = highlight_el.parentElement;
+    if (parent) {
+      const parent_prev = parent.previousElementSibling;
+      if (parent_prev && parent_prev.classList.contains('code-block-caption')) {
+        return;
+      }
+    }
+
+    // Append copy button directly to standalone highlight block
+    highlight_el.appendChild(button_el.cloneNode(true));
+  });
 })();
 
 // Attach copy functionality to clipboard buttons
@@ -167,6 +190,9 @@ document.querySelectorAll('.btn-clipboard').forEach(function (el) {
     if (console_section) {
       const pre_el = console_section.querySelector('.highlight pre');
       text = pre_el.textContent.replace(prompt_regex, '');
+    } else if (this.parentElement.classList.contains('highlight')) {
+      const pre_el = this.parentElement.querySelector('pre');
+      text = pre_el ? pre_el.textContent : this.parentElement.textContent;
     } else {
       text = this.parentElement.nextElementSibling.textContent;
     }


### PR DESCRIPTION
Fixes #2663.

This PR adds a copy button to all standalone code blocks in the documentation. It checks and skips:
1. Console blocks (which already append their own copy buttons).
2. Code blocks that have filenames or captions (which already insert copy buttons in their headers).

The click handler has been updated to read the text content directly from the highlight block when the copy button is nested inside it. The styles have been updated in `_pygments.scss` to absolute position the copy button in the top-right corner of standard code blocks.