### PR TITLE
Refs #2685 -- Isolated per-release docs via a separate process to avoid Sphinx module caching.

### DIFF
--- a/docs/management/commands/build_doc_release.py
+++ b/docs/management/commands/build_doc_release.py
@@ -35,6 +35,7 @@ from sphinx.testing.util import _clean_up_global_state
 from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 from ...models import DocumentRelease
+from ...utils import capture_sentry_exception
 
 
 class Command(BaseCommand):
@@ -136,11 +137,11 @@ class Command(BaseCommand):
                 # Clean up global state after building each language.
                 _clean_up_global_state()
             except SphinxError as e:
-                self.stderr.write(
+                capture_sentry_exception(e, flush=True)
+                raise CommandError(
                     "sphinx-build returned an error (release %s, builder %s): %s"
                     % (release, builder, str(e))
-                )
-                return
+                ) from e
 
         #
         # Create a zip file of the HTML build for offline reading.

--- a/docs/management/commands/build_doc_release.py
+++ b/docs/management/commands/build_doc_release.py
@@ -1,0 +1,216 @@
+"""Build the documentation for a single release (version + language).
+
+This command is meant to be invoked as a subprocess by `update_docs`, one
+process per release. `update_docs` builds many releases across Django versions
+in a single run, and in some checkouts, `docs/_ext/djangodocs.py` dynamically
+sys.path-append their own `_ext` directory and import extension modules (e.g.
+"djangodocs", "github_links") by bare name. Building all releases in one Python
+process let a newer checkout's already-imported module get silently reused for
+an older checkout's build later in the same run. A fresh process per release
+avoids that class of bug entirely.
+
+`update_docs` is responsible for syncing the release's git checkout (shared
+across a version's languages) before invoking this command; this command
+assumes the checkout is already up to date and only builds it.
+
+"""
+
+import json
+import multiprocessing
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
+from contextlib import closing
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.utils.translation import to_locale
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.errors import SphinxError
+from sphinx.testing.util import _clean_up_global_state
+from sphinx.util.docutils import docutils_namespace, patch_docutils
+
+from ...models import DocumentRelease
+
+
+class Command(BaseCommand):
+    help = (
+        "Build the docs for a single release (version + language). Intended "
+        "to be invoked as a subprocess by update_docs, one process per "
+        "release, once its git checkout is already up to date."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("version", help="Which version to build (e.g. 6.0, dev)")
+        parser.add_argument(
+            "--language", required=True, help="Language code of the release to build"
+        )
+
+    def handle(self, version, **options):
+        self.verbosity = options["verbosity"]
+        try:
+            release = DocumentRelease.objects.get_by_version_and_lang(
+                version, options["language"]
+            )
+        except DocumentRelease.DoesNotExist:
+            raise CommandError(
+                "No DocumentRelease found for version=%r lang=%r"
+                % (version, options["language"])
+            )
+
+        self.build_doc_release(release)
+
+    def _html_builder_name(self, source_dir):
+        """Return the Sphinx builder name to use for HTML output for a given
+        checkout.
+
+        Older Django versions' docs/_ext/djangodocs.py registers a custom
+        "djangohtml" builder. Django's #37150 cleanup removed it in favor of
+        hooking into any HTML-format builder, including the standard "html"
+        builder, but that cleanup isn't backported to branches that predate
+        it (e.g. 6.0, 5.2), so "djangohtml" must still be requested there.
+        """
+        djangodocs_path = source_dir / "_ext" / "djangodocs.py"
+        if '"djangohtml"' in djangodocs_path.read_text():
+            return "djangohtml"
+        return "html"
+
+    def build_doc_release(self, release):
+        """Build the docs for a single release.
+
+        The release's git checkout is assumed to already be up to date.
+        """
+        # checkout_dir is shared for all languages.
+        checkout_dir = settings.DOCS_BUILD_ROOT / "sources" / release.version
+        parent_build_dir = settings.DOCS_BUILD_ROOT / release.lang / release.version
+        if not parent_build_dir.exists():
+            parent_build_dir.mkdir(parents=True)
+
+        source_dir = checkout_dir / "docs"
+
+        html_builder = self._html_builder_name(source_dir)
+        builders = ["json", html_builder]
+        if release.is_default:
+            # Build the pot files (later retrieved by Transifex)
+            builders.append("gettext")
+
+        #
+        # Use Sphinx to build the release docs into JSON and HTML documents.
+        #
+        for builder in builders:
+            # Wipe and re-create the build directory. See #18930.
+            build_dir = parent_build_dir / "_build" / builder
+            if build_dir.exists():
+                shutil.rmtree(str(build_dir))
+            build_dir.mkdir(parents=True)
+
+            if self.verbosity >= 2:
+                self.stdout.write(f"  building {builder} ({source_dir} -> {build_dir})")
+            # Retrieve the extensions from the conf.py so we can append to them.
+            conf_extensions = Config.read(source_dir.resolve()).extensions
+            extensions = [*conf_extensions, "docs.builder"]
+            try:
+                # Prevent global state persisting between builds
+                # https://github.com/sphinx-doc/sphinx/issues/12130
+                with patch_docutils(source_dir), docutils_namespace():
+                    Sphinx(
+                        srcdir=source_dir,
+                        confdir=source_dir,
+                        outdir=build_dir,
+                        doctreedir=build_dir / ".doctrees",
+                        buildername=builder,
+                        # Translated docs builds generate a lot of warnings, so send
+                        # stderr to stdout to be logged (rather than generating an email)
+                        warning=sys.stdout,
+                        parallel=multiprocessing.cpu_count(),
+                        verbosity=0,
+                        confoverrides={
+                            "language": to_locale(release.lang),
+                            "extensions": extensions,
+                        },
+                    ).build()
+                # Clean up global state after building each language.
+                _clean_up_global_state()
+            except SphinxError as e:
+                self.stderr.write(
+                    "sphinx-build returned an error (release %s, builder %s): %s"
+                    % (release, builder, str(e))
+                )
+                return
+
+        #
+        # Create a zip file of the HTML build for offline reading.
+        # This gets moved into MEDIA_ROOT for downloading.
+        #
+        html_build_dir = parent_build_dir / "_build" / html_builder
+        zipfile_name = f"django-docs-{release.version}-{release.lang}.zip"
+        zipfile_path = settings.MEDIA_ROOT / "docs" / zipfile_name
+        if not zipfile_path.parent.exists():
+            zipfile_path.parent.mkdir(parents=True)
+        if self.verbosity >= 2:
+            self.stdout.write("  build zip (into %s)" % zipfile_path)
+
+        def zipfile_inclusion_filter(file_path):
+            return ".doctrees" not in file_path.parts
+
+        with closing(
+            zipfile.ZipFile(str(zipfile_path), "w", compression=zipfile.ZIP_DEFLATED)
+        ) as zf:
+            for root, dirs, files in os.walk(str(html_build_dir)):
+                for f in files:
+                    file_path = Path(os.path.join(root, f))
+                    if zipfile_inclusion_filter(file_path):
+                        rel_path = str(file_path.relative_to(html_build_dir))
+                        zf.write(str(file_path), rel_path)
+
+        #
+        # Copy the build results to the directory used for serving
+        # the documentation in the least disruptive way possible.
+        #
+        build_dir = parent_build_dir / "_build"
+        built_dir = parent_build_dir / "_built"
+        subprocess.check_call(
+            [
+                "rsync",
+                "--archive",
+                "--delete",
+                f"--link-dest={build_dir}",
+                f"{build_dir}/",
+                str(built_dir),
+            ]
+        )
+
+        if release.is_default:
+            self._setup_stable_symlink(release, built_dir)
+
+        json_built_dir = parent_build_dir / "_built" / "json"
+        documents = gen_decoded_documents(json_built_dir)
+        release.sync_to_db(documents)
+
+    def _setup_stable_symlink(self, release, built_dir):
+        """
+        Setup a symbolic link called "stable" pointing to the given release build
+        """
+        stable = built_dir / "stable"
+        target = built_dir / release.version
+        if stable.resolve() != target:  # Symlink is either missing or has changed
+            stable.unlink(missing_ok=True)
+            stable.symlink_to(target, target_is_directory=True)
+
+
+def gen_decoded_documents(directory):
+    """
+    Walk the given directory looking for fjson files and yield their data.
+    """
+    for root, dirs, files in os.walk(str(directory)):
+        for f in files:
+            f = Path(root, f)
+            if not f.suffix == ".fjson":
+                continue
+
+            with f.open() as fp:
+                yield json.load(fp)

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -13,6 +13,7 @@ from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 
 from ...models import DocumentRelease
+from ...utils import capture_sentry_exception
 
 
 class Command(BaseCommand):
@@ -88,9 +89,15 @@ class Command(BaseCommand):
         self.release_docs_changed = {}
 
         for release in self._get_doc_releases(versions, kwargs):
-            self.build_doc_release(
-                release, force=kwargs["force"], interactive=kwargs["interactive"]
-            )
+            try:
+                self.build_doc_release(
+                    release, force=kwargs["force"], interactive=kwargs["interactive"]
+                )
+            except Exception as e:
+                capture_sentry_exception(e, flush=True)
+                self.stderr.write(
+                    f"build_doc_release failed for {release}, skipping: {e}"
+                )
 
         if self.purge_cache:
             changed_versions = {

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -3,26 +3,14 @@ Update and build the documentation into files for display with the djangodocs
 app.
 """
 
-import json
-import multiprocessing
 import os
-import shutil
 import subprocess
 import sys
-import zipfile
-from contextlib import closing
 from datetime import datetime
-from pathlib import Path
 
 from django.conf import settings
 from django.core.management import BaseCommand, call_command
 from django.db.models import Q
-from django.utils.translation import to_locale
-from sphinx.application import Sphinx
-from sphinx.config import Config
-from sphinx.errors import SphinxError
-from sphinx.testing.util import _clean_up_global_state
-from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 from ...models import DocumentRelease
 
@@ -119,22 +107,6 @@ class Command(BaseCommand):
                 if self.verbosity >= 1:
                     self.stdout.write("No docs changes; skipping cache purge.")
 
-    def _html_builder_name(self, source_dir):
-        """
-        Return the Sphinx builder name to use for HTML output for a given
-        checkout.
-
-        Older Django versions' docs/_ext/djangodocs.py registers a custom
-        "djangohtml" builder. Django's #37150 cleanup removed it in favor of
-        hooking into any HTML-format builder, including the standard "html"
-        builder, but that cleanup isn't backported to branches that predate
-        it (e.g. 6.0, 5.2), so "djangohtml" must still be requested there.
-        """
-        djangodocs_path = source_dir / "_ext" / "djangodocs.py"
-        if '"djangohtml"' in djangodocs_path.read_text():
-            return "djangohtml"
-        return "html"
-
     def build_doc_release(self, release, force=False, interactive=False):
         # Skip not supported releases.
         if not release.is_supported and not force:
@@ -152,11 +124,8 @@ class Command(BaseCommand):
 
         # checkout_dir is shared for all languages.
         checkout_dir = settings.DOCS_BUILD_ROOT / "sources" / release.version
-        parent_build_dir = settings.DOCS_BUILD_ROOT / release.lang / release.version
         if not checkout_dir.exists():
             checkout_dir.mkdir(parents=True)
-        if not parent_build_dir.exists():
-            parent_build_dir.mkdir(parents=True)
 
         #
         # Update the release from SCM.
@@ -195,104 +164,36 @@ class Command(BaseCommand):
                 "cd %s && make translations" % trans_dir, shell=True, **extra_kwargs
             )
 
-        html_builder = self._html_builder_name(source_dir)
-        builders = ["json", html_builder]
-        if release.is_default:
-            # Build the pot files (later retrieved by Transifex)
-            builders.append("gettext")
+        self._build_release_in_subprocess(release)
 
-        #
-        # Use Sphinx to build the release docs into JSON and HTML documents.
-        #
-        for builder in builders:
-            # Wipe and re-create the build directory. See #18930.
-            build_dir = parent_build_dir / "_build" / builder
-            if build_dir.exists():
-                shutil.rmtree(str(build_dir))
-            build_dir.mkdir(parents=True)
+    def _build_release_in_subprocess(self, release):
+        """Build a single release's docs in a fresh subprocess.
 
-            if self.verbosity >= 2:
-                self.stdout.write(f"  building {builder} ({source_dir} -> {build_dir})")
-            # Retrieve the extensions from the conf.py so we can append to them.
-            conf_extensions = Config.read(source_dir.resolve()).extensions
-            extensions = [*conf_extensions, "docs.builder"]
-            try:
-                # Prevent global state persisting between builds
-                # https://github.com/sphinx-doc/sphinx/issues/12130
-                with patch_docutils(source_dir), docutils_namespace():
-                    Sphinx(
-                        srcdir=source_dir,
-                        confdir=source_dir,
-                        outdir=build_dir,
-                        doctreedir=build_dir / ".doctrees",
-                        buildername=builder,
-                        # Translated docs builds generate a lot of warnings, so send
-                        # stderr to stdout to be logged (rather than generating an email)
-                        warning=sys.stdout,
-                        parallel=multiprocessing.cpu_count(),
-                        verbosity=0,
-                        confoverrides={
-                            "language": to_locale(release.lang),
-                            "extensions": extensions,
-                        },
-                    ).build()
-                # Clean up global state after building each language.
-                _clean_up_global_state()
-            except SphinxError as e:
-                self.stderr.write(
-                    "sphinx-build returned an error (release %s, builder %s): %s"
-                    % (release, builder, str(e))
-                )
-                return
+        Each release is built in its own process (rather than in-process,
+        looping over every release here) because docs/_ext/djangodocs.py is
+        loaded by dynamically appending the checkout's docs/_ext directory
+        to sys.path and importing it by bare module name. Building multiple
+        checkouts in one Python process lets a later checkout's import of
+        that same module name silently reuse an earlier, different
+        checkout's already-cached module instead of its own.
+        """
+        command = [
+            sys.executable,
+            sys.argv[0],
+            "build_doc_release",
+            release.version,
+            "--language",
+            release.lang,
+            "--verbosity",
+            str(self.verbosity),
+        ]
 
-        #
-        # Create a zip file of the HTML build for offline reading.
-        # This gets moved into MEDIA_ROOT for downloading.
-        #
-        html_build_dir = parent_build_dir / "_build" / html_builder
-        zipfile_name = f"django-docs-{release.version}-{release.lang}.zip"
-        zipfile_path = settings.MEDIA_ROOT / "docs" / zipfile_name
-        if not zipfile_path.parent.exists():
-            zipfile_path.parent.mkdir(parents=True)
-        if self.verbosity >= 2:
-            self.stdout.write("  build zip (into %s)" % zipfile_path)
-
-        def zipfile_inclusion_filter(file_path):
-            return ".doctrees" not in file_path.parts
-
-        with closing(
-            zipfile.ZipFile(str(zipfile_path), "w", compression=zipfile.ZIP_DEFLATED)
-        ) as zf:
-            for root, dirs, files in os.walk(str(html_build_dir)):
-                for f in files:
-                    file_path = Path(os.path.join(root, f))
-                    if zipfile_inclusion_filter(file_path):
-                        rel_path = str(file_path.relative_to(html_build_dir))
-                        zf.write(str(file_path), rel_path)
-
-        #
-        # Copy the build results to the directory used for serving
-        # the documentation in the least disruptive way possible.
-        #
-        build_dir = parent_build_dir / "_build"
-        built_dir = parent_build_dir / "_built"
-        subprocess.check_call(
-            [
-                "rsync",
-                "--archive",
-                "--delete",
-                f"--link-dest={build_dir}",
-                f"{build_dir}/",
-                str(built_dir),
-            ]
-        )
-
-        if release.is_default:
-            self._setup_stable_symlink(release, built_dir)
-
-        json_built_dir = parent_build_dir / "_built" / "json"
-        documents = gen_decoded_documents(json_built_dir)
-        release.sync_to_db(documents)
+        result = subprocess.run(command)
+        if result.returncode != 0:
+            self.stderr.write(
+                "build_doc_release subprocess failed for %s (exit code %s)"
+                % (release, result.returncode)
+            )
 
     def update_git(self, url, destdir, changed_dir="."):
         """
@@ -365,27 +266,3 @@ class Command(BaseCommand):
                 stderr=sys.stdout,
             )
         return True
-
-    def _setup_stable_symlink(self, release, built_dir):
-        """
-        Setup a symbolic link called "stable" pointing to the given release build
-        """
-        stable = built_dir / "stable"
-        target = built_dir / release.version
-        if stable.resolve() != target:  # Symlink is either missing or has changed
-            stable.unlink(missing_ok=True)
-            stable.symlink_to(target, target_is_directory=True)
-
-
-def gen_decoded_documents(directory):
-    """
-    Walk the given directory looking for fjson files and yield their data.
-    """
-    for root, dirs, files in os.walk(str(directory)):
-        for f in files:
-            f = Path(root, f)
-            if not f.suffix == ".fjson":
-                continue
-
-            with f.open() as fp:
-                yield json.load(fp)

--- a/docs/tests/test_commands.py
+++ b/docs/tests/test_commands.py
@@ -1,0 +1,112 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from django.core.management import CommandError
+from django.test import TestCase, override_settings
+from sphinx.errors import SphinxError
+
+from ..management.commands.build_doc_release import Command
+from ..management.commands.update_docs import Command as UpdateDocsCommand
+from ..models import DocumentRelease
+
+
+class HtmlBuilderNameTests(TestCase):
+    def setUp(self):
+        self.command = Command()
+
+    def test_returns_djangohtml_when_registered_by_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = Path(tmp)
+            ext_dir = source_dir / "_ext"
+            ext_dir.mkdir()
+            (ext_dir / "djangodocs.py").write_text('BUILDER = "djangohtml"\n')
+            self.assertEqual(self.command._html_builder_name(source_dir), "djangohtml")
+
+    def test_returns_html_when_djangohtml_not_registered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source_dir = Path(tmp)
+            ext_dir = source_dir / "_ext"
+            ext_dir.mkdir()
+            (ext_dir / "djangodocs.py").write_text("# nothing special here\n")
+            self.assertEqual(self.command._html_builder_name(source_dir), "html")
+
+
+class BuildDocReleaseSphinxErrorTests(TestCase):
+    def setUp(self):
+        self.release = DocumentRelease.objects.create(lang="en", release=None)
+        self.command = Command()
+        self.command.verbosity = 0
+
+    def test_sphinx_error_raises_command_error_and_reports_to_sentry(self):
+        error = SphinxError("boom")
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                override_settings(DOCS_BUILD_ROOT=Path(tmp)),
+                patch.object(Command, "_html_builder_name", return_value="html"),
+                patch(
+                    "docs.management.commands.build_doc_release.Config"
+                ) as mock_config,
+                patch(
+                    "docs.management.commands.build_doc_release.Sphinx"
+                ) as mock_sphinx,
+                patch(
+                    "docs.management.commands.build_doc_release.patch_docutils"
+                ) as mock_patch_docutils,
+                patch(
+                    "docs.management.commands.build_doc_release.docutils_namespace"
+                ) as mock_docutils_namespace,
+                patch(
+                    "docs.management.commands.build_doc_release."
+                    "capture_sentry_exception"
+                ) as mock_capture,
+            ):
+                mock_config.read.return_value.extensions = []
+                # Mocked context managers must not swallow the SphinxError.
+                mock_patch_docutils.return_value.__exit__.return_value = False
+                mock_docutils_namespace.return_value.__exit__.return_value = False
+                mock_sphinx.return_value.build.side_effect = error
+
+                with self.assertRaisesMessage(
+                    CommandError, "sphinx-build returned an error"
+                ):
+                    self.command.build_doc_release(self.release)
+
+        mock_capture.assert_called_once_with(error, flush=True)
+
+
+class UpdateDocsResilienceTests(TestCase):
+    def test_one_release_failure_does_not_abort_remaining_releases(self):
+        failing_release = DocumentRelease.objects.create(lang="en", release=None)
+        other_release = DocumentRelease.objects.create(lang="fr", release=None)
+        error = RuntimeError("boom")
+        attempted = []
+
+        def fake_build_doc_release(release, force=False, interactive=False):
+            attempted.append(release)
+            if release == failing_release:
+                raise error
+
+        command = UpdateDocsCommand()
+
+        with (
+            patch.object(
+                UpdateDocsCommand,
+                "_get_doc_releases",
+                return_value=[failing_release, other_release],
+            ),
+            patch.object(
+                UpdateDocsCommand,
+                "build_doc_release",
+                side_effect=fake_build_doc_release,
+            ),
+            patch(
+                "docs.management.commands.update_docs.capture_sentry_exception"
+            ) as mock_capture,
+        ):
+            command.handle(
+                force=False, interactive=False, purge_cache=False, verbosity=0
+            )
+
+        self.assertEqual(attempted, [failing_release, other_release])
+        mock_capture.assert_called_once_with(error, flush=True)

--- a/docs/tests/test_utils.py
+++ b/docs/tests/test_utils.py
@@ -1,9 +1,41 @@
 import os
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
-from ..utils import extract_inner_html, get_doc_path, sanitize_for_trigram
+from ..utils import (
+    capture_sentry_exception,
+    extract_inner_html,
+    get_doc_path,
+    sanitize_for_trigram,
+)
+
+
+class CaptureSentryExceptionTests(SimpleTestCase):
+    def test_reports_and_returns_true_when_sentry_available(self):
+        mock_sentry = MagicMock()
+        error = ValueError("something broke")
+        with patch("docs.utils.sentry_sdk", mock_sentry):
+            result = capture_sentry_exception(error)
+        mock_sentry.capture_exception.assert_called_once_with(error)
+        mock_sentry.flush.assert_not_called()
+        self.assertIs(result, True)
+
+    def test_flush_blocks_until_sent(self):
+        mock_sentry = MagicMock()
+        error = ValueError("something broke")
+        with patch("docs.utils.sentry_sdk", mock_sentry):
+            result = capture_sentry_exception(error, flush=True)
+        mock_sentry.capture_exception.assert_called_once_with(error)
+        mock_sentry.flush.assert_called_once()
+        self.assertIs(result, True)
+
+    def test_no_op_and_returns_false_when_sentry_not_installed(self):
+        error = ValueError("something broke")
+        with patch("docs.utils.sentry_sdk", None):
+            result = capture_sentry_exception(error)
+        self.assertIs(result, False)
 
 
 class TestUtils(SimpleTestCase):

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -6,6 +6,26 @@ from pathlib import Path
 from django.conf import settings
 from django.http import Http404
 
+try:
+    import sentry_sdk
+except ImportError:
+    sentry_sdk = None
+
+
+def capture_sentry_exception(error, flush=False):
+    """Report an exception to Sentry if sentry_sdk is available.
+
+    Pass flush=True to block until the event is sent (use before process
+    exit). Returns True if sent to Sentry, False if sentry_sdk is not
+    installed.
+    """
+    if sentry_sdk is None:
+        return False
+    sentry_sdk.capture_exception(error)
+    if flush:
+        sentry_sdk.flush()
+    return True
+
 
 def get_doc_root(lang, version, builder="json"):
     return settings.DOCS_BUILD_ROOT / lang / version / "_built" / builder


### PR DESCRIPTION
`update_docs` builds every release (across all supported Django versions and languages) in a single long-running process. Each checkout's `docs/_ext/djangodocs.py` is loaded by dynamically appending that checkout's own `docs/_ext` directory to `sys.path` and importing it by bare module name ("djangodocs"). Once Python caches that name in `sys.modules`, a later checkout's import of the same name silently reused whichever checkout's module got imported first in the process, regardless of which checkout was actually being built.

In practice this meant a newer branch's djangodocs.py (which no longer registers the "djangohtml" builder) got reused for older branches that still require it, so those older branches failed outright with "Builder name djangohtml not registered", and worse, that failure aborted publishing for that release entirely, including versions whose json build had already succeeded.

Split the actual Sphinx build out into a new `build_doc_release` management command, invoked by `update_docs` as a subprocess, one process per release. `update_docs` now only handles orchestration: which releases need building, syncing their git checkouts (shared across a version's languages) and translations, and dispatching the build. `build_doc_release` does nothing but build an already-synced checkout, in its own fresh interpreter, so no Python state can leak between checkouts regardless of build order.