### PR TITLE
Refs #2685 -- Fixed build_doc_release subprocess call failing under "-m django".

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -186,7 +186,8 @@ class Command(BaseCommand):
         """
         command = [
             sys.executable,
-            sys.argv[0],
+            "-m",
+            "django",
             "build_doc_release",
             release.version,
             "--language",

--- a/docs/tests/test_commands.py
+++ b/docs/tests/test_commands.py
@@ -1,6 +1,7 @@
+import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.management import CommandError
 from django.test import TestCase, override_settings
@@ -73,6 +74,31 @@ class BuildDocReleaseSphinxErrorTests(TestCase):
                     self.command.build_doc_release(self.release)
 
         mock_capture.assert_called_once_with(error, flush=True)
+
+
+class BuildReleaseSubprocessInvocationTests(TestCase):
+    def test_invokes_child_via_module_flag_not_sys_argv(self):
+        release = DocumentRelease.objects.create(lang="en", release=None)
+        command = UpdateDocsCommand()
+        command.verbosity = 2
+
+        with patch("docs.management.commands.update_docs.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            command._build_release_in_subprocess(release)
+
+        mock_run.assert_called_once_with(
+            [
+                sys.executable,
+                "-m",
+                "django",
+                "build_doc_release",
+                "dev",
+                "--language",
+                "en",
+                "--verbosity",
+                "2",
+            ]
+        )
 
 
 class UpdateDocsResilienceTests(TestCase):


### PR DESCRIPTION
When `update_docs` run was launched via `python -m django update_docs` (as cron does in production), sys.argv[0] resolved to the path of Django's own __main__.py inside site-packages. Running that path directly as a script, rather than via -m, meant Python prepended that script's own directory to sys.path instead of the cwd, so the child process couldn't import the project's `djangoproject` settings package, failing with "ModuleNotFoundError: No module named 'djangoproject'".

Local testing never caught this because `python manage.py update_docs` is used, where sys.argv[0] is a project-local script that works fine when re-invoked directly.

The fix is to invoke the child via `-m django` explicitly instead of reusing sys.argv[0], matching how update_docs itself is actually invoked in production and restoring the sys.path behavior the child needs.