### PR TITLE
Updated description for django-async-backend

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -187,7 +187,7 @@
     <li>
       <a href="https://github.com/Arfey/django-async-backend">django-async-backend</a>
       &mdash; A database backend for PostgreSQL allowing the use of async cursors and transactions.
-      An alternative approach to making async ORM queries via sync to async in threads.
+      An alternative approach to making async ORM queries.
     </li>
   </ul>
 

--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -186,7 +186,7 @@
     </li>
     <li>
       <a href="https://github.com/Arfey/django-async-backend">django-async-backend</a>
-      &mdash; A database backend for PostgreSQL allowing the use of async cursors and transactions. 
+      &mdash; A database backend for PostgreSQL allowing the use of async cursors and transactions.
       An alternative approach to making async ORM queries via sync to async in threads.
     </li>
   </ul>

--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -186,9 +186,8 @@
     </li>
     <li>
       <a href="https://github.com/Arfey/django-async-backend">django-async-backend</a>
-      &mdash; A database backend for PostgreSQL allowing the use of async cursors and transactions. The next major
-      stepping
-      stone towards a fully async ORM.
+      &mdash; A database backend for PostgreSQL allowing the use of async cursors and transactions. 
+      An alternative approach to making async ORM queries via sync to async in threads.
     </li>
   </ul>
 


### PR DESCRIPTION
Revised description of django-async-backend to clarify that it's an alternative approach, rather than a necessary _next step_. 

With free-threading on the horizon, Django's original bet on moving sync work to threads becomes much more compelling. (GIL contention will no longer be a throughput limiting issue.) At that point, the API limitations of a native async approach, and the maintenance issues of separate code paths, either written or generated, mean that it may never be the case that the ORM goes fully async (by default/in core etc). 

Since these are genuinely open questions, adjust the wording accordingly.