### PR TITLE
[checklists] Include links to patches in CVE JSON

### DIFF
--- a/checklists/models.py
+++ b/checklists/models.py
@@ -716,6 +716,14 @@ class SecurityIssue(models.Model):
                 "name": "Django releases announcements",
                 "tags": ["mailing-list"],
             },
+            *[
+                {
+                    "tags": ["patch"],
+                    "url": f"https://github.com/django/django/commit/{commit_hash}",
+                }
+                for _, commit_hash in self.hashes_by_branch
+                if commit_hash
+            ],
         ]
         credits = [
             {

--- a/checklists/tests/test_models.py
+++ b/checklists/tests/test_models.py
@@ -648,6 +648,7 @@ class SecurityReleaseChecklistTestCase(BaseChecklistTestCaseMixin, TestCase):
             description=cve_description,
             reporter=reporter,
             discovery="INTERNAL",
+            commit_hash_main="1234567",
         )
         checklist_content = self.do_render_checklist(checklist)
 
@@ -707,6 +708,10 @@ class SecurityReleaseChecklistTestCase(BaseChecklistTestCaseMixin, TestCase):
                 "name": "Django releases announcements",
                 "tags": ["mailing-list"],
                 "url": "https://groups.google.com/g/django-announce",
+            },
+            {
+                "tags": ["patch"],
+                "url": "https://github.com/django/django/commit/1234567",
             },
             {
                 "name": "Django security releases issued: 5.1.8 and 5.0.14",


### PR DESCRIPTION
Proof of concept of including links to patches in the CVE JSON records, like Python [does](https://www.cve.org/CVERecord?id=CVE-2026-4360).

"CNA Scores" are silly, but [here is one](https://cnascorecard.org/cna/cna-detail.html?shortName=DSF&detailFile=DSF__CNA-2025-0057.json) docking us for not including these.