### PR TITLE
Fix documentation TOC placement on mobile

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -397,6 +397,25 @@ main {
     }
 }
 
+@media (max-width: 767px) {
+    .container.sidebar-right {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .container.sidebar-right #main-content {
+        order: 0;
+    }
+
+    .container.sidebar-right [role="complementary"] {
+        order: -1;
+        width: 100%;
+        float: none;
+        margin: 0 0 20px;
+        padding: 10px;
+    }
+}
+
 [role="secondary"] {
     margin: 0 10px;
     padding: 40px 0 60px;


### PR DESCRIPTION
On mobile devices (<768px), the documentation sidebar (table of contents, breadcrumbs, download links) appeared at the bottom of the page, requiring users to scroll past the entire article to reach it.

This fix uses flexbox with order: -1 to reorder the sidebar above the main content on narrow screens, making navigation much easier on mobile.

Closes #494