### PR TITLE
Add huey to Django's tasks ecosystem section

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -336,6 +336,10 @@
       <a href="https://github.com/RealOrangeOne/django-tasks">django-tasks</a>
       &mdash; A backport of <code>django.tasks</code> - Django's built-in <a href="https://docs.djangoproject.com/en/stable/topics/tasks/">Tasks framework</a>.
     </li>
+    <li>
+      <a href="https://github.com/coleifer/huey">huey</a>
+      &mdash; A lightweight task queue with Redis, SQLite and Postgres backends, usable from Django directly or as a backend for the <a href="https://docs.djangoproject.com/en/stable/topics/tasks/">Tasks framework</a>.
+    </li>
   </ul>
 
   <h3 id="upgrade-utilities">


### PR DESCRIPTION
For quite a number of years now, [huey](https://github.com/coleifer/huey) has offered Django integration (management command + settings integration, as well as helpers for db conn mgmt and enqueueing tasks post-commit). I've also added compatibility w/the new `django.tasks` APIs that landed in django 6. Everything in huey still works the same, but now it can speak the django tasks API, basically.

Docs:

* [Django integration](https://huey.readthedocs.io/en/latest/contrib.html#django)
* [django.tasks specifically](https://huey.readthedocs.io/en/latest/contrib.html#django-task-framework)