### PR TITLE
Break code block lines on any character

### DIFF
--- a/djangoproject/scss/_pygments.scss
+++ b/djangoproject/scss/_pygments.scss
@@ -6,6 +6,7 @@
     overflow: auto;
     border-radius: 4px;
     margin: 25px 0;
+    word-break: break-all;
 
     pre {
         margin: 15px 20px;


### PR DESCRIPTION
This change prevents highlighted code blocks from breaking in awkward places and possibly losing visual indentation.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/word-break#break-all

Closes #662

Before:

<img width="553" height="580" alt="djp-before" src="https://github.com/user-attachments/assets/3fcd4687-1d83-4d32-ae23-64610730d638" />

After (Chromium):

<img width="555" height="563" alt="djp-after-chromium" src="https://github.com/user-attachments/assets/3ec4fca8-810a-4d1e-b7db-5ac8282f61b4" />

After (Firefox):

<img width="558" height="560" alt="djp-after-firefox" src="https://github.com/user-attachments/assets/d1a806b9-2466-4d2b-ba5a-73fde0257adf" />

After (Safari):

<img width="558" height="561" alt="djp-after-safari" src="https://github.com/user-attachments/assets/d1325a72-98ea-4967-afd0-5108d04b288a" />