### PR TITLE
Fixed #2714 -- Made the Django Core Developers page discoverable.

### DIFF
--- a/djangoproject/sitemaps.py
+++ b/djangoproject/sitemaps.py
@@ -60,6 +60,7 @@ class TemplateViewSitemap(LocationAbsoluteUrlMixin, sitemaps.Sitemap):
             URLObject("diversity_changes"),
             # foundation
             URLObject("foundation_meeting_archive_index"),
+            URLObject("foundation_core_developers"),
             # fundraising
             URLObject("fundraising:index"),
             # members

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -233,6 +233,10 @@ class SiteMapTests(TestCase):
         response = self.client.get(reverse("sitemap"))
         self.assertEqual(response.status_code, 200)
 
+    def test_sitemap_contains_core_developers_page(self):
+        response = self.client.get(reverse("sitemap"))
+        self.assertContains(response, "/foundation/django_core/")
+
 
 class EndToEndTests(ReleaseMixin, StaticLiveServerTestCase):
     @classmethod

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -233,10 +233,6 @@ class SiteMapTests(TestCase):
         response = self.client.get(reverse("sitemap"))
         self.assertEqual(response.status_code, 200)
 
-    def test_sitemap_contains_core_developers_page(self):
-        response = self.client.get(reverse("sitemap"))
-        self.assertContains(response, "/foundation/django_core/")
-
 
 class EndToEndTests(ReleaseMixin, StaticLiveServerTestCase):
     @classmethod

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -110,7 +110,11 @@ urlpatterns = [
         BannerPreview.as_view(),
         name="foundation_banner_preview",
     ),
-    path("foundation/django_core/", CoreDevelopers.as_view()),
+    path(
+        "foundation/django_core/",
+        CoreDevelopers.as_view(),
+        name="foundation_core_developers",
+    ),
     path("foundation/minutes/", include("foundation.urls.meetings")),
     path("foundation/", include("members.urls")),
     path("fundraising/", include("fundraising.urls")),


### PR DESCRIPTION
Fixes #2714.

The `/foundation/django_core/` page has no route name, no `sitemap.xml` entry, and no inbound links that I could find — see the issue for the full background.

Changes:

- Add `name="foundation_core_developers"` to the route
- Add the page to `TemplateViewSitemap`, next to the other people-listing pages (`members:individual-members`, `members:teams`), which are already there

The sitemap's `URLObject` inventory is name-based, which is probably how the unnamed `django_core` route got skipped when the sitemap was introduced in #2284.

Verified locally: the full test suite passes (`make ci`), and pre-commit is clean on the changed files; after the change, `sitemap.xml` contains the page URL and the page renders with a single `<h1>`. Naming the route also brings the page under the existing `test_single_h1_per_page` coverage, which iterates over the named top-level URLs.

This PR deliberately does **not** add a navigation link — where to put one is a call I'd rather leave to the maintainers (options in the issue).

In line with the [AI-assisted contributions policy](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#ai-assisted-contributions), I used Claude Code while preparing this patch; I reviewed and tested the change myself and take full responsibility for it.
