### PR TITLE
Resolved ModelAdmin.list_select_related deprecation warning.

### DIFF
--- a/foundation/admin.py
+++ b/foundation/admin.py
@@ -19,7 +19,7 @@ class TermAdmin(admin.ModelAdmin):
 class BoardMemberAdmin(admin.ModelAdmin):
     list_display = ("full_name", "office", "term")
     list_filter = ("office", "term")
-    list_select_related = True
+    list_select_related = ("account", "office", "term")
     raw_id_fields = ("account",)
 
     @admin.display(ordering="account__last_name")


### PR DESCRIPTION
Pulled from https://github.com/django/djangoproject.com/pull/2713
Deprecation: https://docs.djangoproject.com/en/6.1/releases/6.1/#django-contrib-admin:~:text=Item%22%29%5D%29%2C%20%2E%2E%2E%5D%29%2E-,When,many%20foreign%20key%20fields