### PR TITLE
Added a reCAPTCHA to the account registration form.

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -2,8 +2,22 @@ from django import forms
 from django.db import transaction
 from django.db.models import ProtectedError
 from django.utils.translation import gettext_lazy as _
+from django_recaptcha.fields import ReCaptchaField
+from django_recaptcha.widgets import ReCaptchaV3
+from registration.forms import RegistrationFormUniqueEmail
 
 from .models import Profile
+
+
+class RegistrationFormWithCaptcha(RegistrationFormUniqueEmail):
+    """Signup form with a reCAPTCHA field.
+
+    This is required to keep bots/spam/automated requests from using the
+    activation email as a way to send mail to arbitrary addresses.
+
+    """
+
+    captcha = ReCaptchaField(widget=ReCaptchaV3)
 
 
 class ProfileForm(forms.ModelForm):

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,12 +1,13 @@
 import hashlib
 
 from django.contrib.auth.models import AnonymousUser, User
+from django.core import mail
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django_hosts.resolvers import reverse
 
-from accounts.forms import DeleteProfileForm
-from djangoproject.tests import ReleaseMixin
+from accounts.forms import DeleteProfileForm, RegistrationFormWithCaptcha
+from djangoproject.tests import ReleaseMixin, patch_captcha
 from foundation import models as foundationmodels
 from tracdb.models import Revision, Ticket, TicketChange
 from tracdb.testutils import TracDBCreateDatabaseMixin
@@ -240,3 +241,83 @@ class UserDeletionTests(ReleaseMixin, TestCase):
         self.client.force_login(user)
         self.client.post(reverse("delete_profile"))
         self.assertEqual(self.client.cookies["sessionid"].value, "")
+
+
+class RegistrationTests(ReleaseMixin, TestCase):
+    data = {
+        "username": "newuser",
+        "email": "newuser@example.com",
+        "password1": "a-very-secret-password",
+        "password2": "a-very-secret-password",
+        "captcha": "TESTING",
+    }
+
+    def test_valid_captcha_accepted(self):
+        form = RegistrationFormWithCaptcha(data=self.data)
+        with patch_captcha():
+            self.assertIs(form.is_valid(), True)
+
+    def test_invalid_captcha_rejected(self):
+        form = RegistrationFormWithCaptcha(data=self.data)
+        with (
+            self.assertLogs("django_recaptcha", "WARNING") as logs,
+            patch_captcha(is_valid=False),
+        ):
+            self.assertIs(form.is_valid(), False)
+        self.assertIn("captcha", form.errors)
+        self.assertEqual(
+            logs.output,
+            ["WARNING:django_recaptcha.fields:ReCAPTCHA validation failed due to: []"],
+        )
+
+    def test_low_score_rejected(self):
+        form = RegistrationFormWithCaptcha(data=self.data)
+        # The widget reads its threshold from the settings when it is created,
+        # so set it here to assert on the score check itself and not on the
+        # value that the current environment happens to configure.
+        form.fields["captcha"].widget.required_score = 0.9
+        with (
+            self.assertLogs("django_recaptcha", "WARNING") as logs,
+            patch_captcha(score=0.1),
+        ):
+            self.assertIs(form.is_valid(), False)
+        self.assertIn("captcha", form.errors)
+        self.assertEqual(
+            logs.output,
+            [
+                "WARNING:django_recaptcha.fields:ReCAPTCHA validation failed due to "
+                "its score of 0.1 being lower than the required amount."
+            ],
+        )
+
+    def test_missing_captcha_rejected(self):
+        form = RegistrationFormWithCaptcha(data=dict(self.data, captcha=""))
+        self.assertIs(form.is_valid(), False)
+        self.assertIn("captcha", form.errors)
+
+    def test_view_sends_activation_email(self):
+        # The activation email is sent from a transaction.on_commit() callback.
+        with (
+            self.captureOnCommitCallbacks(execute=True),
+            patch_captcha(),
+        ):
+            response = self.client.post(
+                reverse("registration_register"), data=self.data
+            )
+        self.assertRedirects(response, "/accounts/register/complete/")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIs(User.objects.filter(username="newuser").exists(), True)
+
+    def test_view_sends_no_email_when_captcha_fails(self):
+        with (
+            self.assertLogs("django_recaptcha", "WARNING"),
+            self.captureOnCommitCallbacks(execute=True),
+            patch_captcha(is_valid=False),
+        ):
+            self.client.post(reverse("registration_register"), data=self.data)
+        self.assertEqual(mail.outbox, [])
+        self.assertIs(User.objects.filter(username="newuser").exists(), False)
+
+    def test_captcha_widget_is_rendered(self):
+        response = self.client.get(reverse("registration_register"))
+        self.assertContains(response, "g-recaptcha")

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,13 +1,13 @@
 from django.urls import include, path
 from registration.backends.default.views import RegistrationView
-from registration.forms import RegistrationFormUniqueEmail
 
 from . import views as account_views
+from .forms import RegistrationFormWithCaptcha
 
 urlpatterns = [
     path(
         "register/",
-        RegistrationView.as_view(form_class=RegistrationFormUniqueEmail),
+        RegistrationView.as_view(form_class=RegistrationFormWithCaptcha),
         name="registration_register",
     ),
     path(

--- a/contact/tests.py
+++ b/contact/tests.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from djangoproject.tests import ReleaseMixin
+from djangoproject.tests import ReleaseMixin, patch_captcha
 
 from .views import FoundationContactForm
 
@@ -45,16 +45,17 @@ class ContactFormTests(ReleaseMixin, TestCase):
 
     @override_settings(AKISMET_API_KEY="")  # Disable Akismet in tests
     def test_without_akismet(self):
-        response = self.client.post(
-            self.url,
-            {
-                "name": "A. Random Hacker",
-                "email": "a.random@example.com",
-                "message_subject": "Hello",
-                "body": "Hello, World!",
-                "captcha": "TESTING",
-            },
-        )
+        with patch_captcha():
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "A. Random Hacker",
+                    "email": "a.random@example.com",
+                    "message_subject": "Hello",
+                    "body": "Hello, World!",
+                    "captcha": "TESTING",
+                },
+            )
         self.assertRedirects(response, "/contact/sent/")
         self.assertEqual(mail.outbox[-1].subject, "[Contact form] Hello")
 
@@ -90,16 +91,17 @@ class ContactFormTests(ReleaseMixin, TestCase):
 
     @skipIf(not has_network_connection, "Requires a network connection")
     def test_akismet_not_spam(self):
-        response = self.client.post(
-            self.url,
-            {
-                "name": "administrator",
-                "email": "a.random@example.com",
-                "message_subject": "Hello",
-                "body": "Hello, World!",
-                "captcha": "TESTING",
-            },
-        )
+        with patch_captcha():
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "administrator",
+                    "email": "a.random@example.com",
+                    "message_subject": "Hello",
+                    "body": "Hello, World!",
+                    "captcha": "TESTING",
+                },
+            )
         self.assertRedirects(response, "/contact/sent/")
         self.assertEqual(mail.outbox[-1].subject, "[Contact form] Hello")
 

--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -1408,7 +1408,12 @@ label[for] {
   font-weight: bold;
 }
 
-.errorlist {
+// .errorlist is used by Django
+// .errors and .error are used by manually written forms
+.errorlist,
+.errors,
+p.error,
+span.error {
   color: var(--error-fg);
   background-color: var(--error-light-l10);
   border-radius: .3em;

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -246,6 +246,12 @@ HOST_SITE_TIMEOUT = 3600
 
 ROOT_HOSTCONF = "djangoproject.hosts"
 
+# django-recaptcha settings
+
+# The keys themselves are only set in production, but the score threshold
+# belongs here so that reCAPTCHA behaves the same way in every environment.
+RECAPTCHA_REQUIRED_SCORE = 0.9
+
 # django-registration settings
 
 ACCOUNT_ACTIVATION_DAYS = 3

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -66,3 +66,8 @@ SILENCED_SYSTEM_CHECKS = SILENCED_SYSTEM_CHECKS + [
     # Default test keys for development.
     "django_recaptcha.recaptcha_test_key_error"
 ]
+
+# Google's default test keys always verify successfully but return no score,
+# which would be read as a zero and rejected by the production threshold. Turn
+# the score check off so that captcha protected forms can be submitted locally.
+RECAPTCHA_REQUIRED_SCORE = 0

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -100,8 +100,6 @@ if "recaptcha_public_key" in SECRETS:
     RECAPTCHA_PUBLIC_KEY = SECRETS.get("recaptcha_public_key")
     RECAPTCHA_PRIVATE_KEY = SECRETS.get("recaptcha_private_key")
 
-RECAPTCHA_REQUIRED_SCORE = 0.9
-
 # Release artifacts are uploaded via the admin and are about 10Mb each
 # The nginx configuration still restricts the upload size on most pages.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 50 * 1024 * 1024  # 50 Mb

--- a/djangoproject/templates/registration/registration_form.html
+++ b/djangoproject/templates/registration/registration_form.html
@@ -40,6 +40,12 @@
       {% endif %}
       {{ form.password2 }}
     </div>
+    <div>
+      {% if form.captcha.errors %}
+        <p class="errors">{{ form.captcha.errors.as_text }}</p>
+      {% endif %}
+      {{ form.captcha }}
+    </div>
     <p class="submit">
       <input type="submit" class="cta" value="{% translate 'Register' %}">
     </p>

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -1,6 +1,7 @@
 import os
 from http import HTTPStatus
 from io import StringIO
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -9,9 +10,27 @@ from django.test import TestCase
 from django.urls import NoReverseMatch, get_resolver
 from django.utils.translation import activate, gettext as _
 from django_hosts.resolvers import reverse
+from django_recaptcha.client import RecaptchaResponse
 from playwright.sync_api import expect, sync_playwright
 
 from docs.models import DocumentRelease, Release
+
+
+def patch_captcha(is_valid=True, score=1.0, extra_data=None, **response_kwargs):
+    """Patch the only reCAPTCHA call that would otherwise reach Google's servers.
+
+    The score defaults to a passing one, so tests that do not care about
+    reCAPTCHA can just wrap their form submission in this context manager.
+    Forms whose widget declares an action must pass a matching ``action``.
+    """
+    extra_data = dict(extra_data or {})
+    extra_data.setdefault("score", score)
+    return patch(
+        "django_recaptcha.fields.client.submit",
+        return_value=RecaptchaResponse(
+            is_valid=is_valid, extra_data=extra_data, **response_kwargs
+        ),
+    )
 
 
 class ReleaseMixin:

--- a/fundraising/tests/test_forms.py
+++ b/fundraising/tests/test_forms.py
@@ -1,16 +1,15 @@
 from unittest.mock import patch
 
 from django.test import TestCase
-from django_recaptcha.client import RecaptchaResponse
+
+from djangoproject.tests import patch_captcha
 
 from ..forms import DonationForm, PaymentForm
 from ..models import DjangoHero, Donation
 
 
 class TestPaymentForm(TestCase):
-    @patch("django_recaptcha.fields.client.submit")
-    def test_basics(self, client_submit):
-        client_submit.return_value = RecaptchaResponse(is_valid=True, action="form")
+    def test_basics(self):
         form = PaymentForm(
             data={
                 "amount": 100,
@@ -18,11 +17,10 @@ class TestPaymentForm(TestCase):
                 "captcha": "TESTING",
             }
         )
-        self.assertTrue(form.is_valid(), form.errors)
+        with patch_captcha(action="form"):
+            self.assertTrue(form.is_valid(), form.errors)
 
-    @patch("django_recaptcha.fields.client.submit")
-    def test_max_value_validation(self, client_submit):
-        client_submit.return_value = RecaptchaResponse(is_valid=True, action="form")
+    def test_max_value_validation(self):
         """
         Reject unrealistic values greater than $1,000,000.
         """
@@ -33,7 +31,8 @@ class TestPaymentForm(TestCase):
                 "captcha": "TESTING",
             }
         )
-        self.assertFalse(form.is_valid())
+        with patch_captcha(action="form"):
+            self.assertFalse(form.is_valid())
         self.assertIn("amount", form.errors)
 
     def test_captcha_token_required(self):

--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -10,9 +10,8 @@ from django.template.defaultfilters import date as date_filter
 from django.test import TestCase
 from django.urls import reverse
 from django_hosts.resolvers import reverse as django_hosts_reverse
-from django_recaptcha.client import RecaptchaResponse
 
-from djangoproject.tests import ReleaseMixin
+from djangoproject.tests import ReleaseMixin, patch_captcha
 from members.models import CorporateMember, Invoice
 
 from ..models import DjangoHero, Donation
@@ -157,18 +156,17 @@ class TestCampaign(ReleaseMixin, TemporaryMediaRootMixin, TestCase):
         self.assertFalse(content["success"])
 
     @patch("stripe.checkout.Session.create")
-    @patch("django_recaptcha.fields.client.submit")
-    def test_submitting_donation_form_valid(self, client_submit, session_create):
+    def test_submitting_donation_form_valid(self, session_create):
         session_create.return_value = {"id": "TEST_ID"}
-        client_submit.return_value = RecaptchaResponse(is_valid=True, action="form")
-        response = self.client.post(
-            reverse("fundraising:donation-session"),
-            {
-                "amount": 100,
-                "interval": "onetime",
-                "captcha": "TESTING",
-            },
-        )
+        with patch_captcha(action="form"):
+            response = self.client.post(
+                reverse("fundraising:donation-session"),
+                {
+                    "amount": 100,
+                    "interval": "onetime",
+                    "captcha": "TESTING",
+                },
+            )
         content = json.loads(response.content.decode())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(content["success"])


### PR DESCRIPTION
Self-serve registration was the only public form on the site that sent mail without any protection, so automated signups turned directly into activation emails to nonexistent addresses. The resulting hard multiple re-occurring bounces lowering email sending reputation scores.

`RegistrationForm` now carries the same ReCaptchaV3 field already used by the contact and fundraising forms.