### PR TITLE
Updated download page as per DEP-20.

### DIFF
--- a/djangoproject/static/img/release-roadmap.svg
+++ b/djangoproject/static/img/release-roadmap.svg
@@ -1,4 +1,4 @@
-<svg width="930" height="376" version="1.1" xmlns="http://www.w3.org/2000/svg" profile="tiny">
+<svg width="1050" height="334" version="1.1" xmlns="http://www.w3.org/2000/svg" profile="tiny">
     <style>
         .version-text {
             font-family: 'Segoe UI', 'Arial';
@@ -46,7 +46,7 @@
 
     
 
-        <line x1="980.0" y1="20" x2="980.0" y2="356"
+        <line x1="1090.0" y1="20" x2="1090.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -54,7 +54,7 @@
 
     
 
-        <line x1="940.0" y1="20" x2="940.0" y2="356"
+        <line x1="1050.0" y1="20" x2="1050.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -62,7 +62,7 @@
 
     
 
-        <line x1="900.0" y1="20" x2="900.0" y2="356"
+        <line x1="1010.0" y1="20" x2="1010.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -70,11 +70,122 @@
 
     
 
-        <line x1="860.0" y1="20" x2="860.0" y2="356"
+        <line x1="980.0" y1="20" x2="980.0" y2="314"
+              stroke="#000000" stroke-width="3" />
+        
+            <!-- Year label (top) -->
+            <text x="970.0" y="15" class="year-text">
+                2033
+            </text>
+        
+
+         
+
+    
+
+        <line x1="970.0" y1="20" x2="970.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="930.0" y1="20" x2="930.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="890.0" y1="20" x2="890.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="860.0" y1="20" x2="860.0" y2="314"
               stroke="#000000" stroke-width="3" />
         
             <!-- Year label (top) -->
             <text x="850.0" y="15" class="year-text">
+                2032
+            </text>
+        
+
+         
+
+    
+
+        <line x1="850.0" y1="20" x2="850.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="810.0" y1="20" x2="810.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="770.0" y1="20" x2="770.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="740.0" y1="20" x2="740.0" y2="314"
+              stroke="#000000" stroke-width="3" />
+        
+            <!-- Year label (top) -->
+            <text x="730.0" y="15" class="year-text">
+                2031
+            </text>
+        
+
+         
+
+    
+
+        <line x1="730.0" y1="20" x2="730.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="690.0" y1="20" x2="690.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="650.0" y1="20" x2="650.0" y2="314"
+              stroke="#000000" stroke-width="1" />
+        
+
+         
+
+    
+
+        <line x1="620.0" y1="20" x2="620.0" y2="314"
+              stroke="#000000" stroke-width="3" />
+        
+            <!-- Year label (top) -->
+            <text x="610.0" y="15" class="year-text">
                 2030
             </text>
         
@@ -83,7 +194,7 @@
 
     
 
-        <line x1="860.0" y1="20" x2="860.0" y2="356"
+        <line x1="610.0" y1="20" x2="610.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -91,7 +202,7 @@
 
     
 
-        <line x1="820.0" y1="20" x2="820.0" y2="356"
+        <line x1="570.0" y1="20" x2="570.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -99,7 +210,7 @@
 
     
 
-        <line x1="780.0" y1="20" x2="780.0" y2="356"
+        <line x1="530.0" y1="20" x2="530.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -107,11 +218,11 @@
 
     
 
-        <line x1="740.0" y1="20" x2="740.0" y2="356"
+        <line x1="500.0" y1="20" x2="500.0" y2="314"
               stroke="#000000" stroke-width="3" />
         
             <!-- Year label (top) -->
-            <text x="730.0" y="15" class="year-text">
+            <text x="490.0" y="15" class="year-text">
                 2029
             </text>
         
@@ -120,7 +231,7 @@
 
     
 
-        <line x1="740.0" y1="20" x2="740.0" y2="356"
+        <line x1="490.0" y1="20" x2="490.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -128,7 +239,7 @@
 
     
 
-        <line x1="700.0" y1="20" x2="700.0" y2="356"
+        <line x1="450.0" y1="20" x2="450.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -136,7 +247,7 @@
 
     
 
-        <line x1="660.0" y1="20" x2="660.0" y2="356"
+        <line x1="410.0" y1="20" x2="410.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -144,11 +255,11 @@
 
     
 
-        <line x1="620.0" y1="20" x2="620.0" y2="356"
+        <line x1="380.0" y1="20" x2="380.0" y2="314"
               stroke="#000000" stroke-width="3" />
         
             <!-- Year label (top) -->
-            <text x="610.0" y="15" class="year-text">
+            <text x="370.0" y="15" class="year-text">
                 2028
             </text>
         
@@ -157,7 +268,7 @@
 
     
 
-        <line x1="620.0" y1="20" x2="620.0" y2="356"
+        <line x1="370.0" y1="20" x2="370.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -165,7 +276,7 @@
 
     
 
-        <line x1="580.0" y1="20" x2="580.0" y2="356"
+        <line x1="330.0" y1="20" x2="330.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -173,7 +284,7 @@
 
     
 
-        <line x1="540.0" y1="20" x2="540.0" y2="356"
+        <line x1="290.0" y1="20" x2="290.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -181,11 +292,11 @@
 
     
 
-        <line x1="500.0" y1="20" x2="500.0" y2="356"
+        <line x1="260.0" y1="20" x2="260.0" y2="314"
               stroke="#000000" stroke-width="3" />
         
             <!-- Year label (top) -->
-            <text x="490.0" y="15" class="year-text">
+            <text x="250.0" y="15" class="year-text">
                 2027
             </text>
         
@@ -194,7 +305,7 @@
 
     
 
-        <line x1="500.0" y1="20" x2="500.0" y2="356"
+        <line x1="250.0" y1="20" x2="250.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -202,7 +313,7 @@
 
     
 
-        <line x1="460.0" y1="20" x2="460.0" y2="356"
+        <line x1="210.0" y1="20" x2="210.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -210,7 +321,7 @@
 
     
 
-        <line x1="420.0" y1="20" x2="420.0" y2="356"
+        <line x1="170.0" y1="20" x2="170.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
@@ -218,11 +329,11 @@
 
     
 
-        <line x1="380.0" y1="20" x2="380.0" y2="356"
+        <line x1="140.0" y1="20" x2="140.0" y2="314"
               stroke="#000000" stroke-width="3" />
         
             <!-- Year label (top) -->
-            <text x="370.0" y="15" class="year-text">
+            <text x="130.0" y="15" class="year-text">
                 2026
             </text>
         
@@ -231,90 +342,16 @@
 
     
 
-        <line x1="380.0" y1="20" x2="380.0" y2="356"
-              stroke="#000000" stroke-width="1" />
-        
-
-         
-
-    
-
-        <line x1="340.0" y1="20" x2="340.0" y2="356"
-              stroke="#000000" stroke-width="1" />
-        
-
-         
-
-    
-
-        <line x1="300.0" y1="20" x2="300.0" y2="356"
-              stroke="#000000" stroke-width="1" />
-        
-
-         
-
-    
-
-        <line x1="260.0" y1="20" x2="260.0" y2="356"
-              stroke="#000000" stroke-width="3" />
-        
-            <!-- Year label (top) -->
-            <text x="250.0" y="15" class="year-text">
-                2025
-            </text>
-        
-
-         
-
-    
-
-        <line x1="260.0" y1="20" x2="260.0" y2="356"
-              stroke="#000000" stroke-width="1" />
-        
-
-         
-
-    
-
-        <line x1="220.0" y1="20" x2="220.0" y2="356"
-              stroke="#000000" stroke-width="1" />
-        
-
-         
-
-    
-
-        <line x1="180.0" y1="20" x2="180.0" y2="356"
-              stroke="#000000" stroke-width="1" />
-        
-
-         
-
-    
-
-        <line x1="140.0" y1="20" x2="140.0" y2="356"
-              stroke="#000000" stroke-width="3" />
-        
-            <!-- Year label (top) -->
-            <text x="130.0" y="15" class="year-text">
-                2024
-            </text>
-        
-
-         
-
-    
-
-        <line x1="140.0" y1="20" x2="140.0" y2="356"
+        <line x1="130.0" y1="20" x2="130.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
          
             <!-- Month label -->
             <text
-                x="134.0"
-                y="194.0"
-                transform="rotate(-90, 134.0, 188.0)"
+                x="124.0"
+                y="173.0"
+                transform="rotate(-90, 124.0, 167.0)"
                 class="month-text"
                 text-anchor="middle"
                 dominant-baseline="middle"
@@ -325,16 +362,16 @@
 
     
 
-        <line x1="100.0" y1="20" x2="100.0" y2="356"
+        <line x1="90.0" y1="20" x2="90.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
          
             <!-- Month label -->
             <text
-                x="94.0"
-                y="194.0"
-                transform="rotate(-90, 94.0, 188.0)"
+                x="84.0"
+                y="173.0"
+                transform="rotate(-90, 84.0, 167.0)"
                 class="month-text"
                 text-anchor="middle"
                 dominant-baseline="middle"
@@ -345,16 +382,16 @@
 
     
 
-        <line x1="60.0" y1="20" x2="60.0" y2="356"
+        <line x1="50.0" y1="20" x2="50.0" y2="314"
               stroke="#000000" stroke-width="1" />
         
 
          
             <!-- Month label -->
             <text
-                x="54.0"
-                y="194.0"
-                transform="rotate(-90, 54.0, 188.0)"
+                x="44.0"
+                y="173.0"
+                transform="rotate(-90, 44.0, 167.0)"
                 class="month-text"
                 text-anchor="middle"
                 dominant-baseline="middle"
@@ -365,12 +402,12 @@
 
     
 
-        <line x1="20.0" y1="20" x2="20.0" y2="356"
+        <line x1="20.0" y1="20" x2="20.0" y2="314"
               stroke="#000000" stroke-width="3" />
         
             <!-- Year label (top) -->
             <text x="10.0" y="15" class="year-text">
-                2023
+                2025
             </text>
         
 
@@ -381,7 +418,7 @@
     
         
              <rect
-                x="60.0"
+                x="50.0"
                 y="30"
                 width="80.0"
                 height="32"
@@ -393,7 +430,7 @@
 
         
             <rect
-                x="140.0"
+                x="130.0"
                 y="30"
                 width="280.0"
                 height="32"
@@ -403,114 +440,20 @@
             />
         
 
-        <text x="70.0" y="52.0" class="version-text">
-            4.2
-        </text>
-
-        
-            <text x="150.0" y="52.0" class="lts-text">
-                LTS
-            </text>
-        
-    
-        
-             <rect
-                x="140.0"
-                y="72"
-                width="80.0"
-                height="32"
-                fill="#0C4B33"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        
-            <rect
-                x="220.0"
-                y="72"
-                width="80.0"
-                height="32"
-                fill="#CBFDE9"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        <text x="150.0" y="94.0" class="version-text">
-            5.0
-        </text>
-
-        
-    
-        
-             <rect
-                x="220.0"
-                y="114"
-                width="80.0"
-                height="32"
-                fill="#0C4B33"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        
-            <rect
-                x="300.0"
-                y="114"
-                width="80.0"
-                height="32"
-                fill="#CBFDE9"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        <text x="230.0" y="136.0" class="version-text">
-            5.1
-        </text>
-
-        
-    
-        
-             <rect
-                x="300.0"
-                y="156"
-                width="80.0"
-                height="32"
-                fill="#0C4B33"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        
-            <rect
-                x="380.0"
-                y="156"
-                width="280.0"
-                height="32"
-                fill="#CBFDE9"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        <text x="310.0" y="178.0" class="version-text">
+        <text x="60.0" y="52.0" class="version-text">
             5.2
         </text>
 
         
-            <text x="390.0" y="178.0" class="lts-text">
+            <text x="140.0" y="52.0" class="lts-text">
                 LTS
             </text>
         
     
         
              <rect
-                x="380.0"
-                y="198"
+                x="130.0"
+                y="72"
                 width="80.0"
                 height="32"
                 fill="#0C4B33"
@@ -521,9 +464,103 @@
 
         
             <rect
-                x="460.0"
-                y="198"
+                x="210.0"
+                y="72"
                 width="80.0"
+                height="32"
+                fill="#CBFDE9"
+                stroke="#0C4B33"
+                stroke-width="2"
+            />
+        
+
+        <text x="140.0" y="94.0" class="version-text">
+            6.0
+        </text>
+
+        
+    
+        
+             <rect
+                x="210.0"
+                y="114"
+                width="80.0"
+                height="32"
+                fill="#0C4B33"
+                stroke="#0C4B33"
+                stroke-width="2"
+            />
+        
+
+        
+            <rect
+                x="290.0"
+                y="114"
+                width="80.0"
+                height="32"
+                fill="#CBFDE9"
+                stroke="#0C4B33"
+                stroke-width="2"
+            />
+        
+
+        <text x="220.0" y="136.0" class="version-text">
+            6.1
+        </text>
+
+        
+    
+        
+             <rect
+                x="290.0"
+                y="156"
+                width="80.0"
+                height="32"
+                fill="#0C4B33"
+                stroke="#0C4B33"
+                stroke-width="2"
+            />
+        
+
+        
+            <rect
+                x="370.0"
+                y="156"
+                width="280.0"
+                height="32"
+                fill="#CBFDE9"
+                stroke="#0C4B33"
+                stroke-width="2"
+            />
+        
+
+        <text x="300.0" y="178.0" class="version-text">
+            6.2
+        </text>
+
+        
+            <text x="380.0" y="178.0" class="lts-text">
+                LTS
+            </text>
+        
+    
+        
+             <rect
+                x="380.0"
+                y="198"
+                width="120.0"
+                height="32"
+                fill="#0C4B33"
+                stroke="#0C4B33"
+                stroke-width="2"
+            />
+        
+
+        
+            <rect
+                x="500.0"
+                y="198"
+                width="240.0"
                 height="32"
                 fill="#CBFDE9"
                 stroke="#0C4B33"
@@ -532,46 +569,16 @@
         
 
         <text x="390.0" y="220.0" class="version-text">
-            6.0
+            2028
         </text>
 
         
     
         
              <rect
-                x="460.0"
+                x="500.0"
                 y="240"
-                width="80.0"
-                height="32"
-                fill="#0C4B33"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        
-            <rect
-                x="540.0"
-                y="240"
-                width="80.0"
-                height="32"
-                fill="#CBFDE9"
-                stroke="#0C4B33"
-                stroke-width="2"
-            />
-        
-
-        <text x="470.0" y="262.0" class="version-text">
-            6.1
-        </text>
-
-        
-    
-        
-             <rect
-                x="540.0"
-                y="282"
-                width="80.0"
+                width="120.0"
                 height="32"
                 fill="#0C4B33"
                 stroke="#0C4B33"
@@ -582,8 +589,8 @@
         
             <rect
                 x="620.0"
-                y="282"
-                width="280.0"
+                y="240"
+                width="240.0"
                 height="32"
                 fill="#CBFDE9"
                 stroke="#0C4B33"
@@ -591,21 +598,17 @@
             />
         
 
-        <text x="550.0" y="304.0" class="version-text">
-            6.2
+        <text x="510.0" y="262.0" class="version-text">
+            2029
         </text>
 
-        
-            <text x="630.0" y="304.0" class="lts-text">
-                LTS
-            </text>
         
     
         
              <rect
                 x="620.0"
-                y="324"
-                width="80.0"
+                y="282"
+                width="120.0"
                 height="32"
                 fill="#0C4B33"
                 stroke="#0C4B33"
@@ -615,9 +618,9 @@
 
         
             <rect
-                x="700.0"
-                y="324"
-                width="80.0"
+                x="740.0"
+                y="282"
+                width="240.0"
                 height="32"
                 fill="#CBFDE9"
                 stroke="#0C4B33"
@@ -625,8 +628,8 @@
             />
         
 
-        <text x="630.0" y="346.0" class="version-text">
-            7.0
+        <text x="630.0" y="304.0" class="version-text">
+            2030
         </text>
 
         
@@ -696,7 +699,7 @@
 
     <!--fade-->
     <rect
-        x="870"
+        x="990"
         y="0"
         width="120"
         height="100%"

--- a/djangoproject/templates/releases/download.html
+++ b/djangoproject/templates/releases/download.html
@@ -44,14 +44,14 @@
   <pre class="literal-block"><code>py -m pip install Django=={{ current.version }}</code></pre>
 
   {% if preview %}
-    {% with major_version=preview.version|slice:":3" %}
-      <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ major_version }}</h2>
+    {% with feature_version=preview.feature_version %}
+      <h2>Option {% cycle options %}: Get the {{ preview.get_status_display }} for {{ feature_version }}</h2>
       <p>As part of the
-        <a href="{% url 'roadmap' major_version %}">
-          Django {{ major_version }} development process</a>, Django
+        <a href="{% url 'roadmap' feature_version %}">
+          Django {{ feature_version }} development process</a>, Django
         {{ preview.version }} is available. This release is only for users who
         want to try the new version and help identify remaining bugs before the
-        {{ major_version }} release. Please read the
+        {{ feature_version }} release. Please read the
         {% release_notes preview.version show_version=True %} before using this package.
         <p>Install the {{ preview.get_status_display }} with <a href="https://pip.pypa.io/">pip</a>:</p>
       <pre class="literal-block"><code>pip install --pre django</code></pre>
@@ -70,16 +70,20 @@
   <p>And be sure to sign up to the <a href="https://forum.djangoproject.com">Django Forum</a>, where other Django users and the Django developers themselves all hang out to help each other.</p>
 
   <h2 id="supported-versions">Supported Versions</h2>
-  <p><strong>Feature releases</strong> (A.B, A.B+1, etc.) will happen roughly every eight months.
-    These releases will contain new features, improvements to existing features, and such.</p>
-  <p><strong>Patch releases</strong> (A.B.C, etc.) will be issued as needed, to
-    fix bugs and/or security issues. These releases will be 100% compatible with
+  <p><strong>Feature releases</strong> contain new features, improvements to existing
+    features, and other enhancements. Beginning with Django 2028, feature releases will
+    use the version format YYYY and will be released every January. Earlier feature
+    releases used the version format A.B and were released roughly every eight months.</p>
+  <p><strong>Patch releases</strong> (for example, 6.1.2 or 2028.3) are issued as
+    needed, to fix bugs and/or security issues. These releases are 100% compatible with
     the associated feature release, unless this is impossible for security
     reasons or to prevent data loss. So the answer to "should I upgrade to the
     latest patch release?” will always be "yes."</p>
-  <p>Certain feature releases will be designated as <strong>long-term support
-    (LTS) releases</strong>. These releases will get security and data loss
-    fixes applied for a guaranteed period of time, typically three years.</p>
+  <p>Django 6.2 is the final release under the previous versioning and support policy.
+    Under that policy, only designated long-term support (LTS) releases received the
+    full three-year support period. Starting with Django 2028, every feature release
+    receives the same three-year support period. Refer to the tables below for the
+    support periods.</p>
   <p>See the <a href="{% url 'document-detail' lang='en' version='dev' url='internals/release-process' host 'docs' %}#supported-versions">
     supported versions policy</a> for detailed guidelines about what fixes will be backported.</p>
 
@@ -95,19 +99,19 @@
     </tr>
     <tr>
       <td>5.2 LTS</td>
-      <td>{% get_latest_micro_release '5.2' %}</td>
+      <td>{% get_latest_release_version '5.2' %}</td>
       <td>December 3, 2025</td>
       <td>April 2028</td>
     </tr>
     <tr>
       <td>6.0</td>
-      <td>{% get_latest_micro_release '6.0' %}</td>
+      <td>{% get_latest_release_version '6.0' %}</td>
       <td>August 4, 2026</td>
       <td>April 2027</td>
     </tr>
     <tr>
       <td>6.1</td>
-      <td>{% get_latest_micro_release '6.1' %}</td>
+      <td>{% get_latest_release_version '6.1' %}</td>
       <td>April 2027</td>
       <td>December 2027</td>
     </tr>
@@ -129,22 +133,16 @@
       <td>April 2030</td>
     </tr>
     <tr>
-      <td><a href="{% url 'roadmap' '7.0' %}">7.0</a></td>
-      <td>December 2027</td>
-      <td>August 2028</td>
-      <td>April 2029</td>
+      <td><a href="{% url 'roadmap' '2028' %}">2028</a></td>
+      <td>January 2028</td>
+      <td>January 2029</td>
+      <td>January 2031</td>
     </tr>
     <tr>
-      <td><a href="{% url 'roadmap' '7.1' %}">7.1</a></td>
-      <td>August 2028</td>
-      <td>April 2029</td>
-      <td>December 2029</td>
-    </tr>
-    <tr>
-      <td><a href="{% url 'roadmap' '7.2' %}">7.2 LTS</a></td>
-      <td>April 2029</td>
-      <td>December 2029</td>
-      <td>April 2032</td>
+      <td><a href="{% url 'roadmap' '2029' %}">2029</a></td>
+      <td>January 2029</td>
+      <td>January 2030</td>
+      <td>January 2032</td>
     </tr>
   </table>
 
@@ -160,121 +158,121 @@
     </tr>
     <tr>
       <td>5.1</td>
-      <td>{% get_latest_micro_release '5.1' %}</td>
+      <td>{% get_latest_release_version '5.1' %}</td>
       <td>April 2, 2025</td>
       <td>December 3, 2025</td>
     </tr>
     <tr>
       <td>5.0</td>
-      <td>{% get_latest_micro_release '5.0' %}</td>
+      <td>{% get_latest_release_version '5.0' %}</td>
       <td>August 7, 2024</td>
       <td>April 2, 2025</td>
     </tr>
     <tr>
       <td>4.2 LTS</td>
-      <td>{% get_latest_micro_release '4.2' %}</td>
+      <td>{% get_latest_release_version '4.2' %}</td>
       <td>December 4, 2023</td>
       <td>April 7, 2026</td>
     </tr>
     <tr>
       <td>4.1</td>
-      <td>{% get_latest_micro_release '4.1' %}</td>
+      <td>{% get_latest_release_version '4.1' %}</td>
       <td>April 5, 2023</td>
       <td>December 1, 2023</td>
     </tr>
     <tr>
       <td>4.0</td>
-      <td>{% get_latest_micro_release '4.0' %}</td>
+      <td>{% get_latest_release_version '4.0' %}</td>
       <td>August 3, 2022</td>
       <td>April 1, 2023</td>
     </tr>
     <tr>
       <td>3.2 LTS</td>
-      <td>{% get_latest_micro_release '3.2' %}</td>
+      <td>{% get_latest_release_version '3.2' %}</td>
       <td>December 7, 2021</td>
       <td>April 1, 2024</td>
     </tr>
     <tr>
       <td>3.1</td>
-      <td>{% get_latest_micro_release '3.1' %}</td>
+      <td>{% get_latest_release_version '3.1' %}</td>
       <td>April 6, 2021</td>
       <td>December 7, 2021</td>
     </tr>
     <tr>
       <td>3.0</td>
-      <td>{% get_latest_micro_release '3.0' %}</td>
+      <td>{% get_latest_release_version '3.0' %}</td>
       <td>August 3, 2020</td>
       <td>April 6, 2021</td>
     </tr>
     <tr>
       <td>2.2 LTS</td>
-      <td>{% get_latest_micro_release '2.2' %}</td>
+      <td>{% get_latest_release_version '2.2' %}</td>
       <td>December 2, 2019</td>
       <td>April 11, 2022</td>
     </tr>
     <tr>
       <td>2.1</td>
-      <td>{% get_latest_micro_release '2.1' %}</td>
+      <td>{% get_latest_release_version '2.1' %}</td>
       <td>April 1, 2019</td>
       <td>December 2, 2019</td>
     </tr>
     <tr>
       <td>2.0</td>
-      <td>{% get_latest_micro_release '2.0' %}</td>
+      <td>{% get_latest_release_version '2.0' %}</td>
       <td>August 1, 2018</td>
       <td>April 1, 2019</td>
     </tr>
     <tr>
       <td>1.11 LTS <sup><a href="#ft3">3</a></sup></td>
-      <td>{% get_latest_micro_release '1.11' %}</td>
+      <td>{% get_latest_release_version '1.11' %}</td>
       <td>December 2, 2017</td>
       <td>April 1, 2020</td>
     </tr>
     <tr>
       <td>1.10</td>
-      <td>{% get_latest_micro_release '1.10' %}</td>
+      <td>{% get_latest_release_version '1.10' %}</td>
       <td>April 4, 2017</td>
       <td>December 2, 2017</td>
     </tr>
     <tr>
       <td>1.9</td>
-      <td>{% get_latest_micro_release '1.9' %}</td>
+      <td>{% get_latest_release_version '1.9' %}</td>
       <td>August 1, 2016</td>
       <td>April 4, 2017</td>
     </tr>
     <tr>
       <td>1.8 LTS</td>
-      <td>{% get_latest_micro_release '1.8' %}</td>
+      <td>{% get_latest_release_version '1.8' %}</td>
       <td>December 1, 2015</td>
       <td>April 1, 2018</td>
     </tr>
     <tr>
       <td>1.7</td>
-      <td>{% get_latest_micro_release '1.7' %}</td>
+      <td>{% get_latest_release_version '1.7' %}</td>
       <td>April 1, 2015</td>
       <td>December 1, 2015</td>
     </tr>
     <tr>
       <td>1.6</td>
-      <td>{% get_latest_micro_release '1.6' %}</td>
+      <td>{% get_latest_release_version '1.6' %}</td>
       <td>September 2, 2014</td>
       <td>April 1, 2015</td>
     </tr>
     <tr>
       <td>1.5</td>
-      <td>{% get_latest_micro_release '1.5' %}</td>
+      <td>{% get_latest_release_version '1.5' %}</td>
       <td>November 6, 2013</td>
       <td>September 2, 2014</td>
     </tr>
     <tr>
       <td>1.4 LTS</td>
-      <td>{% get_latest_micro_release '1.4' %}</td>
+      <td>{% get_latest_release_version '1.4' %}</td>
       <td>February 26, 2013</td>
       <td>October 1, 2015</td>
     </tr>
     <tr>
       <td>1.3</td>
-      <td>{% get_latest_micro_release '1.3' %}</td>
+      <td>{% get_latest_release_version '1.3' %}</td>
       <td>March 23, 2012</td>
       <td>February 26, 2013</td>
     </tr>

--- a/djangoproject/templates/releases/roadmap.html
+++ b/djangoproject/templates/releases/roadmap.html
@@ -111,9 +111,9 @@
 
       <section id="final">
         <h4>Final</h4>
-        <p>Django {{ series }} final will ideally ship two weeks after the last RC. If no major bugs
-          are found by then, {{ series }} final will be issued; otherwise, the timeline will be
-          adjusted as needed.</p>
+        <p>Django {{ series }} final will ideally ship {% if is_calendar_version %}in January{% else %}two weeks after the last RC{% endif %}.
+          If no major bugs are found by then, {{ series }} final will be issued;
+          otherwise, the timeline will be adjusted as needed.</p>
       </section>
     </section>
   </section>

--- a/releases/management/commands/generate_release_roadmap.py
+++ b/releases/management/commands/generate_release_roadmap.py
@@ -1,28 +1,16 @@
 """
-Generates an SVG roadmap of Django releases,
-showing mainstream and extended support periods.
+Generates an SVG roadmap of Django releases, showing mainstream and extended
+support periods based on the hardcoded release schedule in RELEASES.
 
 Usage:
-  python -m manage generate_release_roadmap.py --first-release <VERSION> --date <YYYY-MM>
+  python -m manage generate_release_roadmap
 
-Arguments:
-    --first-release   First release number in Django versioning style, e.g.,"4.2"
-    --date            Release date of first release in YYYY-MM format, e.g.,"2023-04"
-
-Behavior:
-    - Automatically generates 8 consecutive Django releases:
-        X.0, X.1, X.2 (LTS), X+1.0, X+1.1, X+1.2 (LTS), X+2.0, X+2.1
-    - Mainstream support: 8 months per release
-    - Extended support:
-        - LTS releases (*.2) have 28 months of extended support beyond mainstream
-        - Non-LTS releases have 8 months of extended support beyond mainstream
-    - Produces an SVG at: ../djangoproject/static/img/release-roadmap.svg
+Produces an SVG at: ../djangoproject/static/img/release-roadmap.svg.
 """
 
 import datetime as dtime
 from pathlib import Path
 
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from jinja2 import Environment, FileSystemLoader
@@ -64,24 +52,68 @@ CONFIG = {
     "month_line_width": 1,
 }
 
+# TODO: Once the annual release cycle is established, consider generating
+# future releases dynamically instead of maintaining this list manually.
+# The annual schedule should make future release and support dates predictable.
+RELEASES = [
+    {
+        "name": "5.2",
+        "is_lts": True,
+        "release_date": dtime.date(2025, 4, 1),
+        "mainstream_end": dtime.date(2025, 12, 1),
+        "extended_end": dtime.date(2028, 4, 1),
+    },
+    {
+        "name": "6.0",
+        "is_lts": False,
+        "release_date": dtime.date(2025, 12, 1),
+        "mainstream_end": dtime.date(2026, 8, 1),
+        "extended_end": dtime.date(2027, 4, 1),
+    },
+    {
+        "name": "6.1",
+        "is_lts": False,
+        "release_date": dtime.date(2026, 8, 1),
+        "mainstream_end": dtime.date(2027, 4, 1),
+        "extended_end": dtime.date(2027, 12, 1),
+    },
+    {
+        "name": "6.2",
+        "is_lts": True,
+        "release_date": dtime.date(2027, 4, 1),
+        "mainstream_end": dtime.date(2027, 12, 1),
+        "extended_end": dtime.date(2030, 4, 1),
+    },
+    {
+        "name": "2028",
+        "is_lts": False,
+        "release_date": dtime.date(2028, 1, 1),
+        "mainstream_end": dtime.date(2029, 1, 1),
+        "extended_end": dtime.date(2031, 1, 1),
+    },
+    {
+        "name": "2029",
+        "is_lts": False,
+        "release_date": dtime.date(2029, 1, 1),
+        "mainstream_end": dtime.date(2030, 1, 1),
+        "extended_end": dtime.date(2032, 1, 1),
+    },
+    {
+        "name": "2030",
+        "is_lts": False,
+        "release_date": dtime.date(2030, 1, 1),
+        "mainstream_end": dtime.date(2031, 1, 1),
+        "extended_end": dtime.date(2033, 1, 1),
+    },
+]
+
 
 class Command(BaseCommand):
 
     help = "Generate Django release roadmap SVG."
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--first-release", required=True, help="First release number, e.g., 4.2"
-        )
-        parser.add_argument(
-            "--date",
-            type=lambda str: dtime.datetime.strptime(str, "%Y-%m").date(),
-            required=True,
-            help="Release date in YYYY-MM format, e.g., 2023-04",
-        )
-
     def handle(self, *args, **options):
-        render_svg(options["first_release"], options["date"])
+        render_svg()
 
 
 def get_chart_timeline(data: list, config: dict):
@@ -111,107 +143,48 @@ def calculate_dimensions(config: dict, num_releases: int) -> int:
 
 
 def date_to_x(date: dtime.date, start_year: int, config: dict) -> float:
-
-    pixels_per_year = config["pixels_per_year"]
-    pixels_per_block = pixels_per_year / 3.0
-    start_x = config["padding_left"]
-
-    year_offset = (date.year - start_year) * pixels_per_year
-
-    if 1 <= date.month <= 4:
-
-        block_num = 0
-    elif 5 <= date.month <= 8:
-
-        block_num = 1
-    else:
-
-        block_num = 2
-
-    block_x_end = year_offset + ((block_num + 1) * pixels_per_block)
-
-    return start_x + block_x_end
+    year_offset = (date.year - start_year) * config["pixels_per_year"]
+    month_offset = (date.month - 1) / 12 * config["pixels_per_year"]
+    return config["padding_left"] + year_offset + month_offset
 
 
 def generate_grids(start_year: int, end_year: int, config: dict) -> list:
 
     grid_lines = []
     pixels_per_year = config["pixels_per_year"]
-    pixels_per_block = pixels_per_year / 3.0
 
-    # Month labels only for the VERY FIRST set of lines
-    FIRST_YEAR_MONTH_LABELS = {
-        0: None,
-        1: "April",
-        2: "August",
-        3: "December",
-    }
+    # TODO: Simplify the grid once the pre-annual release cadence is no longer
+    # relevant. Django 6.2 is the last release whose support dates require an
+    # April marker. Once 6.2 is no longer shown, the roadmap only needs year lines.
+    month_lines = (
+        (1, None),
+        (4, "April"),
+        (8, "August"),
+        (12, "December"),
+    )
     for year_index, year in enumerate(range(start_year, end_year)):
         year_x_start = config["padding_left"] + (year_index * pixels_per_year)
 
-        for line_index in range(4):
-            x = year_x_start + (line_index * pixels_per_block)
-            # Year label always on first line of each year
-            top_label = str(year) if line_index == 0 else None
-            # Month labels ONLY for the first year block
-            if year_index == 0:
-                bottom_label = FIRST_YEAR_MONTH_LABELS[line_index]
-            else:
-                bottom_label = None
+        for month, month_label in month_lines:
+            is_january = month == 1
+            x = year_x_start + ((month - 1) / 12 * pixels_per_year)
+
             grid_lines.append(
                 {
                     "x": x,
                     "width": (
                         config["year_line_width"]
-                        if line_index == 0
+                        if is_january
                         else config["month_line_width"]
                     ),
-                    "top_label": top_label,
-                    "bottom_label": bottom_label,
+                    "top_label": str(year) if is_january else None,
+                    "bottom_label": month_label if year_index == 0 else None,
                     "line-color": (
-                        COLORS["grid"] if line_index == 0 else COLORS["month-grid"]
+                        COLORS["grid"] if is_january else COLORS["month-grid"]
                     ),
                 }
             )
     return grid_lines
-
-
-def generate_release_data(first_release: str, release_date: dtime.date) -> list:
-    """
-    Generate 8 Django-style releases starting from a given first release.
-    first_release: "4.2"
-    first_release_ym: "2023-04"
-    """
-    major, minor = map(int, first_release.split("."))
-    # Parse YYYY-MM → date
-
-    releases = []
-    for i in range(8):
-        curr_major = major + ((minor + i) // 3)
-        curr_minor = (minor + i) % 3
-        version = f"{curr_major}.{curr_minor}"
-        is_lts = curr_minor == 2
-        # Mainstream support lasts 8 months
-        mainstream_end = release_date + relativedelta(months=8)
-        # Extended support
-        if is_lts:
-            # LTS = 28 months after mainstream ends
-            extended_end = mainstream_end + relativedelta(months=28)
-        else:
-            # Non-LTS = 8 months after mainstream ends
-            extended_end = mainstream_end + relativedelta(months=8)
-        releases.append(
-            {
-                "name": version,
-                "is_lts": is_lts,
-                "release_date": release_date,
-                "mainstream_end": mainstream_end,
-                "extended_end": extended_end,
-            }
-        )
-        # Next release starts 8 months later
-        release_date = release_date + relativedelta(months=8)
-    return releases
 
 
 def generate_releases(data: list, start_year: int, config: dict) -> list:
@@ -311,9 +284,9 @@ def generate_legend(config: dict) -> dict:
     return legend
 
 
-def render_svg(first_release: str, date: dtime.date):
+def render_svg():
 
-    data = generate_release_data(first_release, date)
+    data = RELEASES
 
     start_year, end_year, svg_width = get_chart_timeline(data, CONFIG)
     svg_height = calculate_dimensions(CONFIG, len(data))

--- a/releases/models.py
+++ b/releases/models.py
@@ -10,22 +10,26 @@ from django.core.files.storage import FileSystemStorage
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.version import get_complete_version, get_main_version
+from django.utils.version import get_complete_version
 
-from .utils import get_loose_version_tuple
+from .utils import (
+    FIRST_CALENDAR_VERSION_YEAR,
+    get_feature_version,
+    get_main_version,
+    get_version_tuple,
+)
 
 
-# A version of django.utils.version.get_version() which maps "rc" to "rc"
-# (packages generated using setuptools 8+) instead of "c" (older versions of
-# setuptools). This naming schemes starts with Django 1.9 and we don't care
-# about older release candidates. Safe to use Django's copy of get_version()
-# when upgrading this website to use Django 1.10.
+# A version of django.utils.version.get_version() which doesn't append a
+# ".devN" suffix to alpha releases, as that inspects the local git repository,
+# which is this website rather than Django, and which builds the main version
+# with the local get_main_version(), aware of calendar versions (DEP 20).
 def get_version(version=None):
-    """Return a PEP 386-compliant version number from VERSION."""
+    """Return a PEP 440-compliant version number from VERSION."""
     version = get_complete_version(version)
 
     # Now build the two parts of the version number:
-    # main = X.Y[.Z]
+    # main = A.B[.C] or YYYY[.N]
     # sub = {a|b|rc}N - for alpha, beta and rc releases
     main = get_main_version(version)
 
@@ -152,8 +156,7 @@ def get_storage():
 
 
 def upload_to_artifact(release, filename):
-    major, minor = release.version_tuple[:2]
-    return f"releases/{major}.{minor}/{filename}"
+    return f"releases/{release.feature_version}/{filename}"
 
 
 def upload_to_checksum(release, filename):
@@ -261,19 +264,7 @@ class Release(models.Model):
     @cached_property
     def version_tuple(self):
         """Return a tuple in the format of django.VERSION."""
-        version = self.version.replace("-", "").replace("_", "")
-        version = list(get_loose_version_tuple(version))
-        if len(version) == 2:
-            version.append(0)
-        if not isinstance(version[2], int):
-            version.insert(2, 0)
-        if len(version) == 3:
-            version.append("final")
-        if version[3] not in ("alpha", "beta", "rc", "final"):
-            version[3] = {"a": "alpha", "b": "beta", "c": "rc"}[version[3]]
-        if len(version) == 4:
-            version.append(0)
-        return tuple(version)
+        return get_version_tuple(self.version)
 
     @cached_property
     def version_verbose(self):
@@ -285,7 +276,7 @@ class Release(models.Model):
 
     @cached_property
     def feature_version(self):
-        return f"{self.major}.{self.minor}"
+        return get_feature_version(self.version)
 
     @cached_property
     def feature_release(self):
@@ -309,9 +300,18 @@ class Release(models.Model):
         return self.status != "f"
 
     @cached_property
+    def is_calendar_version(self):
+        """Return True if this release is calendar versioned (YYYY[.N])."""
+        return self.major >= FIRST_CALENDAR_VERSION_YEAR
+
+    @cached_property
     def is_dot_zero(self):
-        """Return True if this is a final X.Y.0 release."""
-        return self.status == "f" and self.micro == 0
+        """Return True if this is a final feature release (X.Y or YYYY)."""
+        return (
+            self.status == "f"
+            and self.micro == 0
+            and (not self.is_calendar_version or self.minor == 0)
+        )
 
     def __lt__(self, other):
         return self.version_tuple < other.version_tuple
@@ -367,6 +367,8 @@ class Release(models.Model):
             previous_release_kwargs["status"] = "a"
         elif self.status == "c":
             previous_release_kwargs["status"] = "b"
+        elif self.status == "f" and self.is_calendar_version and self.minor > 0:
+            previous_release_kwargs["minor"] = self.minor - 1
         elif self.status == "f" and self.micro == 0:
             previous_release_kwargs["status"] = "c"
         elif self.status == "f" and self.micro > 0:

--- a/releases/models.py
+++ b/releases/models.py
@@ -145,6 +145,16 @@ class ReleaseManager(models.Manager):
         return current_version
 
 
+# Artifact file names are Django-<version><suffix>, where the suffix is
+# .tar.gz for tarballs and -py3-none-any.whl for wheels. Release.clean()
+# validates the whole name; this only extracts the version, so that an
+# artifact is never filed under a release it doesn't belong to.
+artifact_name_re = re.compile(
+    r"^[^-]+-(?P<version>[^-]+?)(?:\.tar\.[a-z]+|-py3-none(?:-any)?\.whl)$",
+    re.IGNORECASE,
+)
+
+
 def get_storage():
     """
     Return a FileSystemStorage that allows file name overwrites.
@@ -156,6 +166,13 @@ def get_storage():
 
 
 def upload_to_artifact(release, filename):
+    name = Path(filename).name
+    version = get_version(release.version_tuple)
+    match = artifact_name_re.match(name)
+    if match is None or match["version"] != version:
+        raise ValidationError(
+            f"Filename {name} does not belong to the {version} release."
+        )
     return f"releases/{release.feature_version}/{filename}"
 
 

--- a/releases/templatetags/release_notes.py
+++ b/releases/templatetags/release_notes.py
@@ -5,17 +5,17 @@ from django.utils.translation import gettext as _
 from django_hosts.resolvers import reverse
 
 from ..models import Release
-from ..utils import get_loose_version_tuple
+from ..utils import get_feature_version
 
 register = template.Library()
 
 
 @register.simple_tag()
 def release_notes(version, show_version=False):
-    version_x_dot_y = ".".join(str(x) for x in get_loose_version_tuple(version)[:2])
+    feature_version = get_feature_version(version)
     is_pre_release = any(c in version for c in ("a", "b", "c"))
     # links for prereleases don't have their own release notes
-    display_version = version_x_dot_y if is_pre_release else version
+    display_version = feature_version if is_pre_release else version
     if show_version:
         anchor_text = _("%(version)s release notes") % {"version": display_version}
     else:
@@ -28,7 +28,7 @@ def release_notes(version, show_version=False):
             host="docs",
             kwargs={
                 "lang": settings.DEFAULT_LANGUAGE_CODE,
-                "version": version_x_dot_y,
+                "version": feature_version,
                 "url": release_notes_path,
             },
         ),
@@ -37,15 +37,18 @@ def release_notes(version, show_version=False):
 
 
 @register.simple_tag()
-def get_latest_micro_release(version):
+def get_latest_release_version(version):
     """
-    Given an X.Y version number, return the latest X.Y.Z version.
+    Given an X.Y or YYYY version number, return the latest version of that release.
     """
-    major, minor = version.split(".")
-    release = (
-        Release.objects.filter(major=major, minor=minor, status="f", is_active=True)
-        .order_by("-micro")
-        .first()
-    )
-    if release:
-        return release.version
+    major, separator, minor = version.partition(".")
+    filters = {
+        "major": major,
+        "status": "f",
+        "is_active": True,
+    }
+    if separator:
+        filters["minor"] = minor
+    ordering = "-micro" if separator else "-minor"
+    release = Release.objects.filter(**filters).order_by(ordering).first()
+    return release.version if release else None

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -646,6 +646,25 @@ class ReleaseUploadToTestCase(SimpleTestCase):
                     expected,
                 )
 
+    def test_upload_to_artifact_wrong_release(self):
+        for version, filename in [
+            # A patch release artifact filed under its feature release.
+            ("2028", "django-2028.1.tar.gz"),
+            ("5.2", "django-5.2.1.tar.gz"),
+            # A feature release artifact filed under a patch release.
+            ("2028.1", "django-2028.tar.gz"),
+            ("5.2.1", "django-5.2-py3-none-any.whl"),
+            # A pre-release artifact filed under the final release.
+            ("2028", "django-2028a1.tar.gz"),
+            # Names which don't identify a version at all.
+            ("2028", "tarball.tar.gz"),
+            ("2028", "django-2028.zip"),
+        ]:
+            with self.subTest(version=version, filename=filename):
+                msg = f"Filename {filename} does not belong to the {version} release."
+                with self.assertRaisesMessage(ValidationError, msg):
+                    upload_to_artifact(Release(version=version), filename=filename)
+
     def test_upload_to_checksum(self):
         for version, expected in [
             ("5.2", "pgp/Django-5.2.checksum.txt"),

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -15,44 +15,69 @@ from django.utils.safestring import SafeString
 from djangoproject.tests import ReleaseMixin
 from members.models import MEMBERSHIP_LEVELS, PLATINUM_MEMBERSHIP, CorporateMember
 
-from .models import Release, upload_to_artifact, upload_to_checksum
+from .models import Release, get_version, upload_to_artifact, upload_to_checksum
 from .templatetags.date_format import isodate
-from .templatetags.release_notes import get_latest_micro_release, release_notes
+from .templatetags.release_notes import get_latest_release_version, release_notes
+from .utils import get_feature_version, get_version_tuple
 
 
 class TestTemplateTags(TestCase):
-    def test_get_latest_micro_release(self):
+    def test_get_latest_release_version(self):
         Release.objects.create(
             major=1, minor=8, micro=0, is_lts=True, version="1.8", is_active=True
         )
         Release.objects.create(
             major=1, minor=8, micro=1, is_lts=True, version="1.8.1", is_active=True
         )
+        Release.objects.create(
+            major=2028, minor=0, micro=0, is_lts=False, version="2028", is_active=True
+        )
+        Release.objects.create(
+            major=2028, minor=1, micro=0, is_lts=False, version="2028.1", is_active=True
+        )
 
-        self.assertEqual(get_latest_micro_release("1.8"), "1.8.1")
-        self.assertEqual(get_latest_micro_release("1.4"), None)
+        self.assertEqual(get_latest_release_version("1.8"), "1.8.1")
+        self.assertEqual(get_latest_release_version("1.4"), None)
+        self.assertEqual(get_latest_release_version("2028"), "2028.1")
 
-    def test_get_latest_micro_release_excludes_inactive(self):
+    def test_get_latest_release_version_excludes_inactive(self):
         Release.objects.create(major=5, minor=2, micro=0, version="5.2", is_active=True)
         Release.objects.create(
             major=5, minor=2, micro=1, version="5.2.1", is_active=True
+        )
+        Release.objects.create(
+            major=2028, minor=0, micro=0, version="2028", is_active=True
+        )
+        Release.objects.create(
+            major=2028, minor=1, micro=0, version="2028.1", is_active=True
         )
         # Create a newer release that is not yet active.
         Release.objects.create(
             major=5, minor=2, micro=2, version="5.2.2", is_active=False
         )
+        Release.objects.create(
+            major=2028, minor=2, micro=0, version="2028.2", is_active=False
+        )
 
-        self.assertEqual(get_latest_micro_release("5.2"), "5.2.1")
+        self.assertEqual(get_latest_release_version("5.2"), "5.2.1")
+        self.assertEqual(get_latest_release_version("2028"), "2028.1")
 
-    def test_get_latest_micro_release_no_active_releases(self):
+    def test_get_latest_release_version_no_active_releases(self):
         Release.objects.create(
             major=4, minor=1, micro=0, version="4.1", is_active=False
         )
         Release.objects.create(
             major=4, minor=1, micro=1, version="4.1.1", is_active=False
         )
+        Release.objects.create(
+            major=2028, minor=0, micro=0, version="2028", is_active=False
+        )
+        Release.objects.create(
+            major=2028, minor=1, micro=0, version="2028.1", is_active=False
+        )
 
-        self.assertIsNone(get_latest_micro_release("4.1"))
+        self.assertIsNone(get_latest_release_version("4.1"))
+        self.assertIsNone(get_latest_release_version("2028"))
 
     def test_release_notes(self):
         output = release_notes("1.8")
@@ -81,6 +106,30 @@ class TestTemplateTags(TestCase):
             '<a href="http://docs.djangoproject.localhost:8000/en/1.10/releases/1.10/">'
             "1.10 release notes</a>",
         )
+
+    def test_release_notes_calendar_versions(self):
+        cases = [
+            # Version, documentation version, release notes version.
+            ("2028", "2028", "2028"),
+            ("2028.1", "2028", "2028.1"),
+            ("2028.15", "2028", "2028.15"),
+            # Pre-releases don't have their own release notes.
+            ("2028a1", "2028", "2028"),
+            ("2028rc1", "2028", "2028"),
+        ]
+        for version, docs_version, notes_version in cases:
+            with self.subTest(version=version):
+                url = (
+                    f"http://docs.djangoproject.localhost:8000/en/{docs_version}"
+                    f"/releases/{notes_version}/"
+                )
+                output = release_notes(version)
+                self.assertIsInstance(output, SafeString)
+                self.assertEqual(output, f'<a href="{url}">Online documentation</a>')
+                self.assertEqual(
+                    release_notes(version, show_version=True),
+                    f'<a href="{url}">{notes_version} release notes</a>',
+                )
 
     def test_isodate(self):
         self.assertEqual(isodate("2005-07-21"), "July 21, 2005")
@@ -253,6 +302,12 @@ class ReleaseTestCase(TestCase):
             ("5.2b1", "5.2rc1"),
             ("5.2rc1", "5.2"),
             ("5.2", "5.2.1"),
+            ("6.2.6", "2028a1"),
+            ("2028a1", "2028a2"),
+            ("2028a2", "2028b1"),
+            ("2028b1", "2028rc1"),
+            ("2028rc1", "2028"),
+            ("2028", "2028.1"),
         ]
         for previous_version, next_version in cases:
             with self.subTest(msg=f"{previous_version} -> {next_version}"):
@@ -281,11 +336,27 @@ class ReleaseTestCase(TestCase):
             ("1.8rc1", (1, 8, 0, "rc", 1)),
             ("5.2", (5, 2, 0, "final", 0)),
             ("5.2a1", (5, 2, 0, "alpha", 1)),
+            ("2028a1", (2028, 0, 0, "alpha", 1)),
+            ("2028", (2028, 0, 0, "final", 0)),
+            ("2028.1", (2028, 1, 0, "final", 0)),
         ]
         for version, expected in cases:
             with self.subTest(version=version):
                 release = Release.objects.create(version=version)
                 self.assertEqual(release.version_tuple, expected)
+
+    def test_invalid_version(self):
+        # Malformed versions are rejected when saving rather than when parsing,
+        # as get_version_tuple() passes unknown statuses and extra numeric
+        # components through.
+        cases = [
+            ("5.2dev1", KeyError),
+            ("1.2.3.4", ValueError),
+        ]
+        for version, exception in cases:
+            with self.subTest(version=version):
+                with self.assertRaises(exception):
+                    Release.objects.create(version=version)
 
     def test_version_verbose(self):
         cases = [
@@ -295,6 +366,9 @@ class ReleaseTestCase(TestCase):
             ("5.2rc1", "5.2 release candidate 1"),
             ("5.2", "5.2"),
             ("5.2.1", "5.2.1"),
+            ("2028a1", "2028 alpha 1"),
+            ("2028", "2028"),
+            ("2028.1", "2028.1"),
         ]
         for version, expected in cases:
             with self.subTest(version=version):
@@ -308,6 +382,9 @@ class ReleaseTestCase(TestCase):
             ("5.2.1", "5.2"),
             ("5.2.15", "5.2"),
             ("4.1rc1", "4.1"),
+            ("2028rc1", "2028"),
+            ("2028", "2028"),
+            ("2028.1", "2028"),
         ]
         for version, expected in cases:
             with self.subTest(version=version):
@@ -376,6 +453,22 @@ class ReleaseTestCase(TestCase):
                 release = Release.objects.create(version=version)
                 self.assertIs(release.is_pre_release, expected)
 
+    def test_is_calendar_version(self):
+        cases = [
+            ("5.2", False),
+            ("5.2.1", False),
+            ("6.2rc1", False),
+            ("20.0", False),
+            ("2028", True),
+            ("2028a1", True),
+            ("2028.1", True),
+            ("2029.3", True),
+        ]
+        for version, expected in cases:
+            with self.subTest(version=version):
+                release = Release.objects.create(version=version)
+                self.assertIs(release.is_calendar_version, expected)
+
     def test_is_dot_zero(self):
         cases = [
             ("5.2", True),
@@ -384,6 +477,10 @@ class ReleaseTestCase(TestCase):
             ("5.2.15", False),
             ("5.2a1", False),
             ("5.2rc1", False),
+            ("2028", True),
+            ("2030", True),
+            ("2028a1", False),
+            ("2028.1", False),
         ]
         for version, expected in cases:
             with self.subTest(version=version):
@@ -427,6 +524,79 @@ class ReleaseTestCase(TestCase):
         self.assertEqual(hash(r1), hash(r1))
 
 
+class VersionUtilsTestCase(SimpleTestCase):
+    # Every version string Django publishes, and its django.VERSION tuple.
+    # Feature releases from 2028 on are calendar versioned, YYYY[.N], where N
+    # is the patch number and is omitted when zero, as A.B[.C] omits C.
+    cases = [
+        ("1.11", (1, 11, 0, "final", 0)),
+        ("1.11.29", (1, 11, 29, "final", 0)),
+        ("5.2a1", (5, 2, 0, "alpha", 1)),
+        ("5.2b1", (5, 2, 0, "beta", 1)),
+        ("5.2rc1", (5, 2, 0, "rc", 1)),
+        ("5.2", (5, 2, 0, "final", 0)),
+        ("5.2.1", (5, 2, 1, "final", 0)),
+        ("5.2.15", (5, 2, 15, "final", 0)),
+        ("2028a1", (2028, 0, 0, "alpha", 1)),
+        ("2028a2", (2028, 0, 0, "alpha", 2)),
+        ("2028b1", (2028, 0, 0, "beta", 1)),
+        ("2028rc1", (2028, 0, 0, "rc", 1)),
+        ("2028", (2028, 0, 0, "final", 0)),
+        ("2028.1", (2028, 1, 0, "final", 0)),
+        ("2028.15", (2028, 15, 0, "final", 0)),
+        ("2030.2", (2030, 2, 0, "final", 0)),
+    ]
+
+    def test_get_version_tuple(self):
+        for version, expected in self.cases:
+            with self.subTest(version=version):
+                self.assertEqual(get_version_tuple(version), expected)
+
+    def test_get_version(self):
+        for expected, version_tuple in self.cases:
+            with self.subTest(version=expected):
+                self.assertEqual(get_version(version_tuple), expected)
+
+    def test_version_string_round_trip(self):
+        for version, _ in self.cases:
+            with self.subTest(version=version):
+                self.assertEqual(get_version(get_version_tuple(version)), version)
+
+    def test_get_version_tuple_equivalent_spellings(self):
+        # 2028 and 2028.0 are the same version under PEP 440 (the shorter
+        # release segment is zero padded), so both parse to the same tuple.
+        # Only the shorter spelling is published.
+        for shorter, longer in [("2028", "2028.0"), ("2028a1", "2028.0a1")]:
+            with self.subTest(version=longer):
+                self.assertEqual(get_version_tuple(longer), get_version_tuple(shorter))
+
+    def test_get_version_tuple_invalid_versions(self):
+        # Unknown statuses and extra numeric components are passed through
+        # instead of being rejected here, so it's Release.save() which fails
+        # for them, see ReleaseTestCase.test_invalid_version().
+        cases = [
+            ("5.2dev1", (5, 2, 0, "dev", 1)),
+            ("1.2.3.4", (1, 2, 3, 4, "final", 0)),
+        ]
+        for version, expected in cases:
+            with self.subTest(version=version):
+                self.assertEqual(get_version_tuple(version), expected)
+
+    def test_get_feature_version(self):
+        cases = [
+            ("5.2", "5.2"),
+            ("5.2a1", "5.2"),
+            ("5.2.15", "5.2"),
+            ("1.11.29", "1.11"),
+            ("2028", "2028"),
+            ("2028a1", "2028"),
+            ("2028.15", "2028"),
+        ]
+        for version, expected in cases:
+            with self.subTest(version=version):
+                self.assertEqual(get_feature_version(version), expected)
+
+
 class ReleaseUploadToTestCase(SimpleTestCase):
     def test_upload_to_artifact(self):
         for version, filename, expected in [
@@ -456,6 +626,19 @@ class ReleaseUploadToTestCase(SimpleTestCase):
                 "django-5.2b2-py3-none.whl",
                 "releases/5.2/django-5.2b2-py3-none.whl",
             ),
+            # All the releases in a calendar series share a directory.
+            ("2028", "django-2028.tar.gz", "releases/2028/django-2028.tar.gz"),
+            ("2028.1", "django-2028.1.tar.gz", "releases/2028/django-2028.1.tar.gz"),
+            (
+                "2028a1",
+                "django-2028a1.tar.gz",
+                "releases/2028/django-2028a1.tar.gz",
+            ),
+            (
+                "2028.1",
+                "django-2028.1-py3-none.whl",
+                "releases/2028/django-2028.1-py3-none.whl",
+            ),
         ]:
             with self.subTest(version=version, filename=filename):
                 self.assertEqual(
@@ -469,6 +652,9 @@ class ReleaseUploadToTestCase(SimpleTestCase):
             ("5.2.1", "pgp/Django-5.2.1.checksum.txt"),
             ("5.2a1", "pgp/Django-5.2a1.checksum.txt"),
             ("5.2b2", "pgp/Django-5.2b2.checksum.txt"),
+            ("2028", "pgp/Django-2028.checksum.txt"),
+            ("2028a1", "pgp/Django-2028a1.checksum.txt"),
+            ("2028.15", "pgp/Django-2028.15.checksum.txt"),
         ]:
             with self.subTest(version=version):
                 self.assertEqual(
@@ -552,6 +738,11 @@ class ReleaseAdminFormTestCase(TestCase):
             ("wheel", "1.0a1", "django-1.0a1-py3-none-any.whl"),
             ("wheel", "1.0b1", "django-1.0b1-py3-none-any.whl"),
             ("wheel", "1.0rc1", "django-1.0rc1-py3-none-any.whl"),
+            ("tarball", "2028", "django-2028.tar.gz"),
+            ("tarball", "2028a1", "django-2028a1.tar.gz"),
+            ("tarball", "2028.15", "django-2028.15.tar.gz"),
+            ("wheel", "2028", "django-2028-py3-none-any.whl"),
+            ("wheel", "2028.15", "django-2028.15-py3-none-any.whl"),
         ]:
             form = self.form_class(
                 data={"version": version},
@@ -671,6 +862,51 @@ class ReleaseAdminFormTestCase(TestCase):
 
     def test_clearing_also_deletes_file_commit_false(self):
         self.test_clearing_also_deletes_file(commit_save=False)
+
+
+class DownloadViewTestCase(ReleaseMixin, TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        today = datetime.date.today()
+        day = datetime.timedelta(1)
+        # The last release of the previous scheme, still supported.
+        cls.previous = Release.objects.create(
+            version="6.2", is_active=True, is_lts=True, date=today - 400 * day
+        )
+        # The feature release, superseded by its first patch release.
+        Release.objects.create(version="2028", is_active=True, date=today - 60 * day)
+        cls.current = Release.objects.create(
+            version="2028.1", is_active=True, date=today - 30 * day
+        )
+        cls.preview = Release.objects.create(
+            version="2029a1", is_active=True, date=today - day
+        )
+
+    def test_current_release(self):
+        response = self.client.get(reverse("download"))
+        self.assertContains(response, "The latest official version is 2028.1.")
+        self.assertContains(
+            response,
+            '<a href="http://docs.djangoproject.localhost:8000/en/2028'
+            '/releases/2028.1/">2028.1 release notes</a>',
+            html=True,
+        )
+
+    def test_preview_release(self):
+        response = self.client.get(reverse("download"))
+        self.assertContains(response, "Get the alpha for 2029")
+        self.assertContains(
+            response,
+            'href="http://www.djangoproject.localhost:8000/download/2029/roadmap/"',
+        )
+        self.assertContains(
+            response,
+            '<a href="http://docs.djangoproject.localhost:8000/en/2029'
+            '/releases/2029/">2029 release notes</a>',
+            html=True,
+        )
 
 
 class RedirectViewTestCase(TestCase):
@@ -817,6 +1053,12 @@ class RoadmapViewTestCase(ReleaseMixin, TestCase):
                 ("rc1", datetime.date(2026, 7, 22)),
                 ("", datetime.date(2026, 8, 5)),  # final
             ],
+            "2028": [
+                ("a1", datetime.date(2027, 10, 10)),
+                ("b1", datetime.date(2027, 11, 10)),
+                ("rc1", datetime.date(2027, 12, 10)),
+                ("", datetime.date(2028, 1, 10)),  # final
+            ],
         }
         for series, milestones in cls.release_schedule.items():
             for milestone, date in milestones:
@@ -860,6 +1102,13 @@ class RoadmapViewTestCase(ReleaseMixin, TestCase):
                 response = self.client.get(f"/download/{series}/roadmap/")
                 self.assertEqual(response.status_code, 404)
 
+    def test_series_invalid_format(self):
+        # Only A.B and YYYY series have a roadmap page.
+        for series in ("2028.0", "2028.1", "202", "20280", "1.2.3"):
+            with self.subTest(series=series):
+                response = self.client.get(f"/download/{series}/roadmap/")
+                self.assertEqual(response.status_code, 404)
+
     def test_major_lower_bound(self):
         for minor in (0, 1, 2, 3, 11):
             with self.subTest(minor=minor):
@@ -871,3 +1120,31 @@ class RoadmapViewTestCase(ReleaseMixin, TestCase):
         response = self.client.get(url)
         self.assertContains(response, 'en/dev/internals/contributing/"')
         self.assertContains(response, 'en/dev/internals/release-process/"')
+
+    def test_release_candidate_description_calendar_version(self):
+        url = reverse("roadmap", kwargs={"series": "2028"})
+        response = self.client.get(url)
+        self.assertContains(
+            response,
+            "Django 2028 final will ideally ship in January.",
+        )
+        self.assertNotContains(response, "two weeks after the last RC.")
+
+    def test_release_candidate_description_calendar_version_without_releases(self):
+        # The roadmap is published before any release in the series exists.
+        url = reverse("roadmap", kwargs={"series": "2029"})
+        response = self.client.get(url)
+        self.assertContains(
+            response,
+            "Django 2029 final will ideally ship in January.",
+        )
+        self.assertNotContains(response, "two weeks after the last RC.")
+
+    def test_release_candidate_description_non_calendar_version(self):
+        url = reverse("roadmap", kwargs={"series": "5.2"})
+        response = self.client.get(url)
+        self.assertContains(
+            response,
+            "Django 5.2 final will ideally ship two weeks after the last RC.",
+        )
+        self.assertNotContains(response, "ship in January.")

--- a/releases/urls.py
+++ b/releases/urls.py
@@ -7,5 +7,7 @@ urlpatterns = [
     re_path(
         "^([0-9a-z_.-]+)/(tarball|wheel|checksum)/$", redirect, name="download-redirect"
     ),
-    re_path(r"^(?P<series>\d{1,2}\.[0-2])/roadmap/$", roadmap, name="roadmap"),
+    re_path(
+        r"^(?P<series>(?:\d{1,2}\.[0-2]|\d{4}))/roadmap/$", roadmap, name="roadmap"
+    ),
 ]

--- a/releases/utils.py
+++ b/releases/utils.py
@@ -1,6 +1,17 @@
+"""
+Parsing and formatting of Django release numbers, in both the A.B[.C] and the
+calendar (YYYY[.N]) schemes.
+"""
+
 from django.utils.regex_helper import _lazy_re_compile
 
 version_component_re = _lazy_re_compile(r"(\d+|[a-z]+|\.)")
+
+# Feature releases from this year on are calendar versioned, YYYY[.N], where N
+# is the patch number. Earlier releases use A.B[.C]. See DEP 20.
+FIRST_CALENDAR_VERSION_YEAR = 2028
+
+STATUS_ALIASES = {"a": "alpha", "b": "beta", "c": "rc"}
 
 
 def get_loose_version_tuple(version):
@@ -17,3 +28,47 @@ def get_loose_version_tuple(version):
                 component = item
             version_numbers.append(component)
     return tuple(version_numbers)
+
+
+def get_version_tuple(version):
+    """Return a tuple in the format of django.VERSION from a version string.
+
+    Examples: (5, 2, 1, 'final', 0) for "5.2.1" and (2028, 0, 0, 'alpha', 1)
+    for "2028a1".
+    """
+    version = version.replace("-", "").replace("_", "")
+    components = list(get_loose_version_tuple(version))
+    # The numeric components come first, optionally followed by the release
+    # status and its iteration, as in "5.2a1" or "2028rc1".
+    numbers = []
+    for component in components:
+        if not isinstance(component, int):
+            break
+        numbers.append(component)
+    numbers_len = len(numbers)
+    status, *iteration = components[numbers_len:] or ["final"]
+    numbers += [0] * (3 - len(numbers))
+    return (*numbers, STATUS_ALIASES.get(status, status), *(iteration or [0]))
+
+
+def is_calendar_version(version):
+    """Return True if the version tuple uses calendar versioning (YYYY[.N])."""
+    return version[0] >= FIRST_CALENDAR_VERSION_YEAR
+
+
+def get_main_version(version):
+    """Return the main version (A.B[.C] or YYYY[.N]) from a version tuple."""
+    # The patch number is the last component of the main version and is
+    # omitted when zero. It's the second component for calendar versions
+    # (YYYY[.N]) and the third one for the earlier scheme (A.B[.C]).
+    patch_index = 1 if is_calendar_version(version) else 2
+    parts = patch_index if version[patch_index] == 0 else patch_index + 1
+    return ".".join(str(x) for x in version[:parts])
+
+
+def get_feature_version(version):
+    """Return the feature release version for a given version string."""
+    components = get_loose_version_tuple(version)
+    if is_calendar_version(components):
+        return str(components[0])
+    return ".".join(str(component) for component in components[:2])

--- a/releases/views.py
+++ b/releases/views.py
@@ -2,6 +2,7 @@ from django.http import Http404, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
 
 from .models import Release
+from .utils import FIRST_CALENDAR_VERSION_YEAR
 
 
 def index(request):
@@ -32,14 +33,18 @@ def index(request):
 
 
 def roadmap(request, series):
-    major, minor = series.split(".")
+    major, _, minor = series.partition(".")
     major = int(major)
+    minor = int(minor or 0)
     if major < 2:
         raise Http404
 
     releases = Release.objects.filter(major=major, minor=minor, micro=0)
     context = {
         "series": series,
+        # Do not rely on the final release existing yet, roadmap pages are
+        # published before any release in the series is created.
+        "is_calendar_version": major >= FIRST_CALENDAR_VERSION_YEAR,
         "releases": {r.status: r for r in releases},
     }
     return render(request, "releases/roadmap.html", context)


### PR DESCRIPTION
See newly approved DEP-20: https://github.com/django/deps/pull/109

New download page:

<img width="1066" height="915" alt="Screenshot from 2026-08-07 12-48-32" src="https://github.com/user-attachments/assets/1cee407d-0cbc-4b35-abc9-0c415856d270" />

Sample roadmap page:

<img width="1151" height="979" alt="Screenshot from 2026-08-07 12-52-13" src="https://github.com/user-attachments/assets/eacfa01d-abec-4d45-89f8-5beb81231d97" />


As we may announce with a blog post, it would be nice if this page is updated accordingly

We perhaps want to time the updates alongside the following docs that need updating:
- https://docs.djangoproject.com/en/6.1/faq/install/#faq-python-version-support
- https://docs.djangoproject.com/en/6.1/internals/release-process/