### PR TITLE
Avoid shell-form translation build in update_docs

### DIFF
--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -167,9 +167,7 @@ class Command(BaseCommand):
                 locale_dir.symlink_to(trans_dir / "translations")
 
             extra_kwargs = {"stdout": subprocess.DEVNULL} if self.verbosity == 0 else {}
-            subprocess.check_call(
-                "cd %s && make translations" % trans_dir, shell=True, **extra_kwargs
-            )
+            subprocess.check_call(["make", "translations"], cwd=trans_dir, **extra_kwargs)
 
         self._build_release_in_subprocess(release)
 

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -167,7 +167,9 @@ class Command(BaseCommand):
                 locale_dir.symlink_to(trans_dir / "translations")
 
             extra_kwargs = {"stdout": subprocess.DEVNULL} if self.verbosity == 0 else {}
-            subprocess.check_call(["make", "translations"], cwd=trans_dir, **extra_kwargs)
+            subprocess.check_call(
+                ["make", "translations"], cwd=trans_dir, **extra_kwargs
+            )
 
         self._build_release_in_subprocess(release)
 

--- a/docs/tests/test_commands.py
+++ b/docs/tests/test_commands.py
@@ -125,8 +125,9 @@ class TranslationBuildInvocationTests(SimpleTestCase):
                 override_settings(DOCS_BUILD_ROOT=build_root),
                 patch.object(UpdateDocsCommand, "update_git", return_value=True),
                 patch.object(UpdateDocsCommand, "_build_release_in_subprocess"),
-                patch("docs.management.commands.update_docs.subprocess.check_call")
-                as mock_check_call,
+                patch(
+                    "docs.management.commands.update_docs.subprocess.check_call"
+                ) as mock_check_call,
             ):
                 command.build_doc_release(release)
 

--- a/docs/tests/test_commands.py
+++ b/docs/tests/test_commands.py
@@ -1,10 +1,11 @@
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from django.core.management import CommandError
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from sphinx.errors import SphinxError
 
 from ..management.commands.build_doc_release import Command
@@ -98,6 +99,41 @@ class BuildReleaseSubprocessInvocationTests(TestCase):
                 "--verbosity",
                 "2",
             ]
+        )
+
+
+class TranslationBuildInvocationTests(SimpleTestCase):
+    def test_translation_build_uses_cwd_instead_of_shell_command(self):
+        release = MagicMock(
+            lang="fr",
+            release=None,
+            version="dev",
+            scm_url="https://github.com/django/django.git@stable/dev.x",
+            is_supported=True,
+        )
+        release.sync_from_sitemap = MagicMock()
+        command = UpdateDocsCommand()
+        command.verbosity = 0
+        command.release_docs_changed = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            build_root = Path(tmp)
+            docs_dir = build_root / "sources" / release.version / "docs"
+            docs_dir.mkdir(parents=True)
+
+            with (
+                override_settings(DOCS_BUILD_ROOT=build_root),
+                patch.object(UpdateDocsCommand, "update_git", return_value=True),
+                patch.object(UpdateDocsCommand, "_build_release_in_subprocess"),
+                patch("docs.management.commands.update_docs.subprocess.check_call")
+                as mock_check_call,
+            ):
+                command.build_doc_release(release)
+
+        mock_check_call.assert_called_once_with(
+            ["make", "translations"],
+            cwd=build_root / "sources" / release.version / "django-docs-translation",
+            stdout=subprocess.DEVNULL,
         )
 
 


### PR DESCRIPTION
Use `cwd` with `subprocess.check_call(["make", "translations"])` instead of building a shell command string in `update_docs`. Adds a regression test for the new invocation.

fixes #2691 