### PR TITLE
Improve search performance

### DIFF
--- a/docs/models.py
+++ b/docs/models.py
@@ -361,7 +361,7 @@ class DocumentQuerySet(models.QuerySet):
             vector_qs = (
                 base_qs.alias(rank=search_rank)
                 .filter(search_vector=search_query)
-                .order_by("-rank")
+                .order_by("-rank", "pk")
             )
             if not vector_qs:
                 return (
@@ -371,7 +371,7 @@ class DocumentQuerySet(models.QuerySet):
                         )
                     )
                     .filter(similarity__gt=0.3)
-                    .order_by("-similarity")
+                    .order_by("-similarity", "pk")
                 )
             else:
                 return vector_qs
@@ -421,7 +421,7 @@ class DocumentQuerySet(models.QuerySet):
                 "release__lang",
                 "release__release__version",
             )
-            .order_by("-rank")
+            .order_by("-rank", "pk")
         )
 
 

--- a/docs/models.py
+++ b/docs/models.py
@@ -322,20 +322,24 @@ class DocumentQuerySet(models.QuerySet):
         else:
             return self.none()
 
+    @property
+    def uses_trigram(self):
+        return "-similarity" in self.query.order_by
+
     def search(self, query_text, release, document_category=None):
         """Use full-text search to return documents matching query_text."""
+        ranked_ids = self.rank(query_text, release, document_category=document_category)
+        return self.annotate_search_results(
+            ranked_ids, query_text, uses_trigram=ranked_ids.uses_trigram
+        )
+
+    def rank(self, query_text, release, document_category=None):
         query_text = query_text.strip()
         if query_text:
             search_query = SearchQuery(
                 query_text, config=models.F("config"), search_type="websearch"
             )
             search_rank = SearchRank(models.F("search_vector"), search_query)
-            search = partial(
-                SearchHeadline,
-                start_sel=START_SEL,
-                stop_sel=STOP_SEL,
-                config=models.F("config"),
-            )
             base_filter = Q(release_id=release.id)
             if release.lang == settings.DEFAULT_LANGUAGE_CODE and not release.is_dev:
                 # Fetch the "dev" release explicitly so we can filter by release_id.
@@ -353,29 +357,7 @@ class DocumentQuerySet(models.QuerySet):
                 )
             if document_category:
                 base_filter &= Q(metadata__parents__startswith=document_category)
-            base_qs = (
-                self.select_related("release__release")
-                .filter(base_filter)
-                .annotate(
-                    headline=search("title", search_query),
-                    highlight=search(
-                        KeyTextTransform("body", "metadata"),
-                        search_query,
-                    ),
-                    searched_python_objects=search(
-                        KeyTextTransform("python_objects_search", "metadata"),
-                        search_query,
-                        highlight_all=True,
-                    ),
-                    breadcrumbs=models.F("metadata__breadcrumbs"),
-                    python_objects=models.F("metadata__python_objects"),
-                )
-                .only(
-                    "path",
-                    "release__lang",
-                    "release__release__version",
-                )
-            )
+            base_qs = self.filter(base_filter).values_list("pk", flat=True)
             vector_qs = (
                 base_qs.alias(rank=search_rank)
                 .filter(search_vector=search_query)
@@ -395,6 +377,52 @@ class DocumentQuerySet(models.QuerySet):
                 return vector_qs
         else:
             return self.none()
+
+    def annotate_search_results(self, ranked_ids, query_text, uses_trigram=False):
+        query_text = query_text.strip()
+        search_query = SearchQuery(
+            query_text, config=models.F("config"), search_type="websearch"
+        )
+        # Repeating the search rank is cheap. When CompositeFields merge, we
+        # will be able to pass through .values("similarity", "pk") from the
+        # subquery and reference it in the outer query.
+        search_rank = (
+            TrigramSimilarity("title", utils.sanitize_for_trigram(query_text))
+            if uses_trigram
+            else SearchRank(models.F("search_vector"), search_query)
+        )
+        search = partial(
+            SearchHeadline,
+            start_sel=START_SEL,
+            stop_sel=STOP_SEL,
+            config=models.F("config"),
+        )
+        return (
+            self.filter(id__in=ranked_ids)
+            .alias(rank=search_rank)
+            .annotate(
+                headline=search("title", search_query),
+                highlight=search(
+                    KeyTextTransform("body", "metadata"),
+                    search_query,
+                ),
+                searched_python_objects=search(
+                    KeyTextTransform("python_objects_search", "metadata"),
+                    search_query,
+                    highlight_all=True,
+                ),
+                breadcrumbs=models.F("metadata__breadcrumbs"),
+                python_objects=models.F("metadata__python_objects"),
+            )
+            .select_related("release__release")
+            .only(
+                "metadata",
+                "path",
+                "release__lang",
+                "release__release__version",
+            )
+            .order_by("-rank")
+        )
 
 
 class Document(models.Model):

--- a/docs/templates/docs/search_results.html
+++ b/docs/templates/docs/search_results.html
@@ -38,7 +38,7 @@
   {% if query %}
     <div id="docs-content">
       <dl class="search-links">
-        {% for result in page.object_list %}
+        {% for result in page_results %}
           <dt>
             <h2 class="result-title">
               <a href="{{ result.get_absolute_url }}{% if not start_sel in result.headline %}{{ result.highlight|fragment }}{% endif %}">{{ result.headline|safe }}</a>

--- a/docs/tests/test_models.py
+++ b/docs/tests/test_models.py
@@ -1,8 +1,9 @@
 import datetime
 from operator import attrgetter
+from unittest.mock import patch
 
 from django.conf import settings
-from django.db import connection
+from django.db import connection, models
 from django.test import TestCase
 from django.utils import timezone
 
@@ -302,35 +303,8 @@ class DocumentManagerTest(TestCase):
                 "release": cls.release_fr,
                 "title": "Vues génériques",
             },
-            {
-                "metadata": {
-                    "body": (
-                        '<div class="section" id="s-django-1-2-1-release-notes">\n<span'
-                        ' id="django-1-2-1-release-notes"></span><h1>Notes de '
-                        'publication de Django 1.2.1<a class="headerlink" href="#django'
-                        '-1-2-1-release-notes" title="Lien permanent vers ce titre">¶'
-                        "</a></h1>\n<p>Django 1.2.1 was released almost immediately "
-                        "after 1.2.0 to correct two small\nbugs: one was in the "
-                        "documentation packaging script, the other was a <a class="
-                        '"reference external" href="https://code.djangoproject.com/'
-                        'ticket/13560">bug</a> that\naffected datetime form field '
-                        "widgets when localization was enabled.</p>\n</div>\n"
-                    ),
-                    "breadcrumbs": [
-                        {"path": "releases", "title": "Release notes"},
-                    ],
-                    "parents": "releases",
-                    "slug": "1.2.1",
-                    "title": "Notes de publication de Django 1.2.1",
-                    "toc": (
-                        '<ul>\n<li><a class="reference internal" href="#">Notes de '
-                        "publication de Django 1.2.1</a></li>\n</ul>\n"
-                    ),
-                },
-                "path": "releases/1.2.1",
-                "release": cls.release_fr,
-                "title": "Notes de publication de Django 1.2.1",
-            },
+            # Create these entries out of chronological order so that ordering
+            # assertions can prove that ordering by PK breaks ties.
             {
                 "metadata": {
                     "body": (
@@ -359,6 +333,35 @@ class DocumentManagerTest(TestCase):
                 "path": "releases/1.9.4",
                 "release": cls.release_fr,
                 "title": "Notes de publication de Django 1.9.4",
+            },
+            {
+                "metadata": {
+                    "body": (
+                        '<div class="section" id="s-django-1-2-1-release-notes">\n<span'
+                        ' id="django-1-2-1-release-notes"></span><h1>Notes de '
+                        'publication de Django 1.2.1<a class="headerlink" href="#django'
+                        '-1-2-1-release-notes" title="Lien permanent vers ce titre">¶'
+                        "</a></h1>\n<p>Django 1.2.1 was released almost immediately "
+                        "after 1.2.0 to correct two small\nbugs: one was in the "
+                        "documentation packaging script, the other was a <a class="
+                        '"reference external" href="https://code.djangoproject.com/'
+                        'ticket/13560">bug</a> that\naffected datetime form field '
+                        "widgets when localization was enabled.</p>\n</div>\n"
+                    ),
+                    "breadcrumbs": [
+                        {"path": "releases", "title": "Release notes"},
+                    ],
+                    "parents": "releases",
+                    "slug": "1.2.1",
+                    "title": "Notes de publication de Django 1.2.1",
+                    "toc": (
+                        '<ul>\n<li><a class="reference internal" href="#">Notes de '
+                        "publication de Django 1.2.1</a></li>\n</ul>\n"
+                    ),
+                },
+                "path": "releases/1.2.1",
+                "release": cls.release_fr,
+                "title": "Notes de publication de Django 1.2.1",
             },
             {
                 "metadata": {
@@ -414,10 +417,22 @@ class DocumentManagerTest(TestCase):
 
     def test_multilingual_search(self):
         self.assertQuerySetEqual(
-            Document.objects.search("publication", self.release_fr),
+            Document.objects.search("Django OR 1.2.1", self.release_fr),
             [
-                "Notes de publication de Django 1.2.1",  # Ranked: 1.0693262.
-                "Notes de publication de Django 1.9.4",  # Ranked: 1.0458658.
+                "Notes de publication de Django 1.2.1",  # Ranked: 0.7446094.
+                "Notes de publication de Django 1.9.4",  # Ranked: 0.3449142.
+            ],
+            transform=attrgetter("title"),
+        )
+
+    @patch("docs.models.SearchRank", lambda *args: models.Value(1))
+    def test_search_rank_tie(self):
+        """Tied search rank results are still ordered by pk."""
+        self.assertQuerySetEqual(
+            Document.objects.search("Notes de publication", self.release_fr),
+            [
+                "Notes de publication de Django 1.9.4",
+                "Notes de publication de Django 1.2.1",
             ],
             transform=attrgetter("title"),
         )

--- a/docs/tests/test_views.py
+++ b/docs/tests/test_views.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from operator import attrgetter
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -89,6 +90,18 @@ class SearchFormTestCase(TestCase):
         self.assertNotContains(response, '<li class="active">')
         # The search result page does not have the Documentation banner.
         self.assertNotContains(response, '<div class="copy-banner">')
+
+    def test_search_paginator_includes_pks_only(self):
+        response = self.client.get(
+            "/en/5.1/search/?q=generic",
+            headers={"host": "docs.djangoproject.localhost:8000"},
+        )
+        self.assertTrue(response.context["page"].object_list)
+        self.assertQuerySetEqual(
+            response.context["page_results"],
+            response.context["page"].object_list,
+            transform=attrgetter("pk"),
+        )
 
     def test_search_type_filter_all(self):
         response = self.client.get(

--- a/docs/views.py
+++ b/docs/views.py
@@ -171,36 +171,46 @@ def search_results(request, lang, version, per_page=10, orphans=3):
             if exact is not None:
                 return redirect(exact)
 
-            results = Document.objects.search(
-                q, release, document_category=doc_category
-            )
-
+            ranked = Document.objects.rank(q, release, document_category=doc_category)
             page_number = request.GET.get("page") or 1
-            paginator = Paginator(results, per_page=per_page, orphans=orphans)
 
             try:
                 page_number = int(page_number)
             except ValueError:
-                if page_number == "last":
-                    page_number = paginator.num_pages
-                else:
+                if page_number != "last":
                     raise Http404(
                         _("Page is not 'last', " "nor can it be converted to an int.")
                     )
-
-            try:
-                page = paginator.page(page_number)
-            except InvalidPage as e:
-                raise Http404(
-                    _("Invalid page (%(page_number)s): %(message)s")
-                    % {"page_number": page_number, "message": str(e)}
+                page_results = Document.objects.annotate_search_results(
+                    ranked, q, uses_trigram=ranked.uses_trigram
                 )
+            else:
+                # Make the offset & limit calculation so that it can be used to
+                # limit the number of annotations.
+                start = (page_number - 1) * per_page
+                stop = start + per_page
+                page_results = Document.objects.annotate_search_results(
+                    ranked[start:stop], q, uses_trigram=ranked.uses_trigram
+                )
+            paginator = Paginator(ranked, per_page=per_page, orphans=orphans)
+
+            if page_number == "last":
+                page = paginator.page(paginator.num_pages)
+            else:
+                try:
+                    page = paginator.page(page_number)
+                except InvalidPage as e:
+                    raise Http404(
+                        _("Invalid page (%(page_number)s): %(message)s")
+                        % {"page_number": page_number, "message": str(e)}
+                    )
 
             context.update(
                 {
                     "query": q,
                     "page": page,
                     "paginator": paginator,
+                    "page_results": page_results,
                     "start_sel": START_SEL,
                     "DocumentationCategory": DocumentationCategory,
                 }


### PR DESCRIPTION
I noticed we had reports in Sentry for slow database queries in search. You can see this with searches that return about ~200 results, e.g "Model"

Before: 850ms
After: 250ms

I traced it to the relatively expensive headline annotations being calculated on all search results before the limit was taken.

I pushed the ranking into a subquery, and applied the same ordering to the outer query. This had to be factored a little delicately in order to continue using the `Paginator`, so I'm happy to iterate to make any of this clearer.

While here:
- I spotted that we didn't have a "pk" fallback sort to break ties.
- Added a missing `"metadata"` to the `only()` call, since it's used in `get_absolute_url()`.