### PR TITLE
Add SuperSend TX to Email & Notifications ecosystem

### DIFF
--- a/djangoproject/templates/aggregator/ecosystem.html
+++ b/djangoproject/templates/aggregator/ecosystem.html
@@ -460,6 +460,10 @@
       <a href="https://github.com/ambient-innovation/django-pony-express/">Django Pony Express</a>
       &mdash; A simple email queuing and sending system for Django applications.
     </li>
+    <li>
+      <a href="https://docs.supersendtx.com/sdks/python">supersendtx</a>
+      &mdash; Django email backend for SuperSend TX transactional email (<code>EMAIL_BACKEND = &quot;supersendtx.django.EmailBackend&quot;</code>).
+    </li>
   </ul>
 
   <h3 id="utilities-miscellaneous">


### PR DESCRIPTION
## Summary

Adds [supersendtx](https://pypi.org/project/supersendtx/) under **Email & Notifications** on the [Community Ecosystem](https://www.djangoproject.com/community/ecosystem/#email-notifications) page.

The official [Sending email](https://docs.djangoproject.com/en/stable/topics/email/#third-party-backends) docs point readers at this section for third-party backends. SuperSend TX ships a Django backend:

\`\`\`python
EMAIL_BACKEND = \"supersendtx.django.EmailBackend\"
\`\`\`

## Links

- PyPI: https://pypi.org/project/supersendtx/
- Docs: https://docs.supersendtx.com/sdks/python
- Source: https://github.com/Super-Send/supersendtx-sdks/tree/main/python

Happy to adjust wording or drop if this section is reserved for more established packages only.

Made with [Cursor](https://cursor.com)