### PR TITLE
Fix general index hierarchy styling on docs pages.

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2606,7 +2606,8 @@ dl.classmethod,
 dl.staticmethod,
 dl.attribute,
 dl.exception,
-dl.data {
+dl.data,
+dl.index {
     dt {
         font-weight: 700;
     }


### PR DESCRIPTION
Add dl.index to the definition list styles so sub-entries are indented and main entries are bold, matching other Sphinx doc lists.

Fixes #2769.