### PR TITLE
Fixed duplicate heading in code of conduct

### DIFF
--- a/djangoproject/templates/conduct/index.html
+++ b/djangoproject/templates/conduct/index.html
@@ -303,11 +303,6 @@
     <a class="plink" href="#addressing-repairing-harm">¶</a>
   </h2>
 
-  <h2 id="addressing-repairing-harm">
-    {% translate "Addressing and Repairing Harm" %}
-    <a class="plink" href="#addressing-repairing-harm">¶</a>
-  </h2>
-
   <p>
     {% blocktranslate trimmed %}
       When a Code of Conduct violation occurs, the Code of Conduct Working Group uses an


### PR DESCRIPTION
Removed the duplicated "Addressing and Repairing Harm" heading from the Code of Conduct page.

<img width="632" height="269" alt="image" src="https://github.com/user-attachments/assets/31affaa6-082d-4e66-ab95-440601a57690" />

