### PR TITLE
Migrate email configuration to MAILERS

### DIFF
--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -54,6 +54,13 @@ DATABASE_ROUTERS = ["tracdb.db_router.TracRouter"]
 DEFAULT_FROM_EMAIL = "noreply@djangoproject.com"
 FUNDRAISING_DEFAULT_FROM_EMAIL = "fundraising@djangoproject.com"
 
+MAILERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+    },
+}
+
+
 FIXTURE_DIRS = [PROJECT_PACKAGE / "fixtures"]
 
 INSTALLED_APPS = [

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -57,6 +57,9 @@ FUNDRAISING_DEFAULT_FROM_EMAIL = "fundraising@djangoproject.com"
 MAILERS = {
     "default": {
         "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "OPTIONS": {
+            "host": "localhost",
+        },
     },
 }
 

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -25,7 +25,12 @@ CACHES = {
 
 CSRF_COOKIE_SECURE = False
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+MAILERS = {
+    "default": {
+        "BACKEND": "django.core.mail.backends.console.EmailBackend",
+    },
+}
+
 
 MEDIA_ROOT = DATA_DIR / "media_root"
 


### PR DESCRIPTION
## Description

Migrates the project's email configuration from the deprecated `EMAIL_BACKEND` setting to Django's `MAILERS` configuration for Django 7.

### Changes

- Explicitly configure the default SMTP email backend through `MAILERS`.
- Migrate the development console email backend from `EMAIL_BACKEND` to `MAILERS`.
- Preserve the existing email backend behavior.

### Testing

- Targeted pre-commit checks pass for all modified files.
- `git diff --check` passes.

Fixes #2768