### PR TITLE
Fixed #2784 -- Add fenced_code extension for Markdown entries

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -114,6 +114,7 @@ class ContentFormat(models.TextChoices):
                     # BLOG_DOCUTILS_SETTINGS because rst always starts from heading
                     # level 1, but markdown can have specific heading levels so
                     # starting from 1 makes sense.
+                    "fenced_code",
                     "tables",
                     TocExtension(baselevel=1, slugify=_md_slugify),
                 ],

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -196,6 +196,26 @@ class EntryTestCase(DateTimeMixin, TestCase):
         )
         self.assertInHTML(expected_html, entry.body_html)
 
+    def test_markdown_code_block(self):
+        body = (
+            "```text\n"
+            "* @django/coc-committee\n"
+            "CODE_OF_CONDUCT.md @django/coc-committee @django/dsf-board\n"
+            "```"
+        )
+        entry = Entry.objects.create(
+            pub_date=self.now,
+            slug="markdown-code-block",
+            body=body,
+            content_format=ContentFormat.MARKDOWN,
+        )
+        expected_html = (
+            '<pre><code class="language-text">* @django/coc-committee\n'
+            "CODE_OF_CONDUCT.md @django/coc-committee @django/dsf-board\n"
+            "</code></pre>"
+        )
+        self.assertInHTML(expected_html, entry.body_html)
+
 
 class EventTestCase(DateTimeMixin, TestCase):
     def test_manager_past_future(self):


### PR DESCRIPTION
### Summary

Fixes #2784.

Adds the `fenced_code` extension to Python-Markdown in `blog/models.py`. Without this extension, fenced code blocks (```) in Markdown entries were treated as inline text rather than block `<pre><code>` elements, causing line breaks within code blocks to be collapsed onto a single line.

### Changes
- Added `"fenced_code"` to `extensions` in `ContentFormat.to_html()`.
- Added test `test_markdown_code_block` in `blog/tests.py`.

---

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

*Assisted with rebase formatting, test verification, and PR summary drafting.*
