### PR TITLE
Set up i18n URLs with language chooser

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -184,7 +184,7 @@ class ViewsTests(ReleaseMixin, TestCase):
         User.objects.create_user(**credentials)
 
         response = self.client.post(reverse("login"), credentials)
-        self.assertRedirects(response, "/accounts/edit/")
+        self.assertRedirects(response, "/en/accounts/edit/")
 
     def test_profile_view_reversal(self):
         """
@@ -303,7 +303,7 @@ class RegistrationTests(ReleaseMixin, TestCase):
             response = self.client.post(
                 reverse("registration_register"), data=self.data
             )
-        self.assertRedirects(response, "/accounts/register/complete/")
+        self.assertRedirects(response, "/en/accounts/register/complete/")
         self.assertEqual(len(mail.outbox), 1)
         self.assertIs(User.objects.filter(username="newuser").exists(), True)
 

--- a/contact/tests.py
+++ b/contact/tests.py
@@ -25,7 +25,7 @@ has_network_connection = check_network_connection()
 @override_settings(AKISMET_TESTING=True)
 class ContactFormTests(ReleaseMixin, TestCase):
     def setUp(self):
-        self.url = "/contact/foundation/"
+        self.url = "/en/contact/foundation/"
 
     @override_settings(AKISMET_API_KEY="")  # Disable Akismet in tests
     def test_invalid_email(self):
@@ -56,7 +56,7 @@ class ContactFormTests(ReleaseMixin, TestCase):
                     "captcha": "TESTING",
                 },
             )
-        self.assertRedirects(response, "/contact/sent/")
+        self.assertRedirects(response, "/en/contact/sent/")
         self.assertEqual(mail.outbox[-1].subject, "[Contact form] Hello")
 
     @skipIf(not has_network_connection, "Requires a network connection")
@@ -102,7 +102,7 @@ class ContactFormTests(ReleaseMixin, TestCase):
                     "captcha": "TESTING",
                 },
             )
-        self.assertRedirects(response, "/contact/sent/")
+        self.assertRedirects(response, "/en/contact/sent/")
         self.assertEqual(mail.outbox[-1].subject, "[Contact form] Hello")
 
     @skipIf(not has_network_connection, "Requires a network connection")

--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -22,6 +22,15 @@ class CORSMiddleware:
         return response
 
 
+def _get_host_name(request):
+    """
+    Get the name of the `django-hosts` host that was matched for this request.
+    `django-hosts` sets `request.host`; while this behaviour is not documented, it is
+    not likely to change.
+    """
+    return request.host.name
+
+
 class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
     """
     Locale middleware that lets us exclude requests to certain hosts (e.g.,
@@ -40,11 +49,11 @@ class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
         return host not in self._excluded_hosts
 
     def process_request(self, request):
-        if self._is_host_included(request.host.name):
+        if self._is_host_included(_get_host_name(request)):
             super().process_request(request)
 
     def process_response(self, request, response):
-        if self._is_host_included(request.host.name):
+        if self._is_host_included(_get_host_name(request)):
             return super().process_response(request, response)
         return response
 

--- a/djangoproject/middleware.py
+++ b/djangoproject/middleware.py
@@ -2,11 +2,9 @@ import re
 
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
-from django.http.request import split_domain_port
 from django.middleware.locale import LocaleMiddleware
 from django.urls import Resolver404, resolve
 from django.utils.functional import cached_property
-from django.utils.http import is_same_domain
 
 
 class CORSMiddleware:
@@ -27,7 +25,8 @@ class CORSMiddleware:
 class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
     """
     Locale middleware that lets us exclude requests to certain hosts (e.g.,
-    docs.djangoproject.com) from being processed by LocaleMiddleware.
+    `docs`) from being processed by LocaleMiddleware. Depends on the
+    `django_hosts` middleware having processed the request.
     """
 
     @cached_property
@@ -36,22 +35,16 @@ class ExcludeHostsLocaleMiddleware(LocaleMiddleware):
 
     def _is_host_included(self, host):
         """
-        Mirrors the behavior of django.http.request.validate_host(), but does
-        not match '*' (which would exclude all hosts). To exclude all requests
-        from being processed by LocaleMiddleware one should simply remove this
-        class from settings.MIDDLEWARE.
+        Check whether the host is part of the excluded hosts list.
         """
-        domain, _ = split_domain_port(host)
-        return not any(
-            is_same_domain(domain, pattern) for pattern in self._excluded_hosts
-        )
+        return host not in self._excluded_hosts
 
     def process_request(self, request):
-        if self._is_host_included(request.get_host()):
+        if self._is_host_included(request.host.name):
             super().process_request(request)
 
     def process_response(self, request, response):
-        if self._is_host_included(request.get_host()):
+        if self._is_host_included(request.host.name):
             return super().process_response(request, response)
         return response
 

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -267,6 +267,8 @@ HOST_SITE_TIMEOUT = 3600
 
 ROOT_HOSTCONF = "djangoproject.hosts"
 
+LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs"]
+
 # django-recaptcha settings
 
 # The keys themselves are only set in production, but the score threshold

--- a/djangoproject/settings/common.py
+++ b/djangoproject/settings/common.py
@@ -3,6 +3,12 @@ import json
 import os
 from pathlib import Path
 
+
+def gettext(s):
+    """i18n passthrough"""
+    return s
+
+
 # Utilities
 PROJECT_PACKAGE = Path(__file__).resolve().parent.parent
 
@@ -108,7 +114,12 @@ INSTALLED_APPS = [
 if os.getenv("DJANGO_SPOOKY_MODE"):
     INSTALLED_APPS.insert(0, "django_admin_dracula")  # spooky 👻
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "en"
+
+LANGUAGES = [
+    ("en", gettext("English")),
+    ("fr", gettext("French")),
+]
 
 LOGGING = {
     "version": 1,

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -7,8 +7,6 @@ ALLOWED_HOSTS = [
     "dashboard.djangoproject.localhost",
 ]
 
-LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = ["docs.djangoproject.localhost"]
-
 DEBUG = True
 THUMBNAIL_DEBUG = DEBUG
 

--- a/djangoproject/settings/prod.py
+++ b/djangoproject/settings/prod.py
@@ -12,8 +12,6 @@ ALLOWED_HOSTS = [
     f"dashboard.{DOMAIN_NAME}",
 ] + SECRETS.get("allowed_hosts", [])
 
-LOCALE_MIDDLEWARE_EXCLUDED_HOSTS = [f"docs.{DOMAIN_NAME}"]
-
 DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() == "true"
 THUMBNAIL_DEBUG = DEBUG
 

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -50,7 +50,11 @@
 
     <a href="#main-content" class="skip-link">Skip to main content</a>
     {% include "includes/header.html" %}
-    {% include "includes/language_selector.html" %}
+
+    {% block language_selector %}
+      {% include "includes/language_selector.html" %}
+    {% endblock language_selector %}
+
     {% block banner %}{% endblock %}
 
     <section class="copy-banner">

--- a/djangoproject/templates/base.html
+++ b/djangoproject/templates/base.html
@@ -50,6 +50,7 @@
 
     <a href="#main-content" class="skip-link">Skip to main content</a>
     {% include "includes/header.html" %}
+    {% include "includes/language_selector.html" %}
     {% block banner %}{% endblock %}
 
     <section class="copy-banner">

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+<div id="version-switcher">
+  <ul id="doc-languages" class="language-switcher doc-switcher">
+  {% get_available_languages as languages %}
+  {% for available_lang in languages %}
+  {% if lang != available_lang %}
+  <li class="other">
+    {% url 'change_language' lang_code=available_lang.0 as language_url %}
+    <a href="{{ language_url }}">{{ available_lang.1 }}</a>
+  </li>
+  {% endif %}
+  {% endfor %}
+  {% if LANGUAGE_CODE %}
+  {% get_language_info for LANGUAGE_CODE as lang %}
+    <li class="current"
+        title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
+      <span>{% trans "Language:" %} <strong>{{ lang.name_local }}</strong></span>
+    </li>
+  {% endif %}
+  </ul>
+</div>

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -1,20 +1,20 @@
 {% load i18n %}
 <div id="version-switcher">
   <ul id="doc-languages" class="language-switcher doc-switcher">
-  {% if LANGUAGE_CODE %}
-    <li class="current"
-        title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
-      <button>{% trans "Language:" %} <strong>{{ LANGUAGE_CODE }}</strong></button>
-    </li>
-  {% endif %}
-  {% get_available_languages as available_languages %}
-  {% for available_lang in available_languages reversed %}
-    {% if LANGUAGE_CODE != available_lang.0 %}
-      <li class="other">
-        {% url 'change_language' lang_code=available_lang.0 as language_url %}
-        <a href="{{ language_url }}">{{ available_lang.0 }}</a>
+    {% if LANGUAGE_CODE %}
+      <li class="current"
+          title="{% blocktranslate %}Click on the links on the left to switch to another language.{% endblocktranslate %}">
+        <button>{% translate "Language:" %} <strong>{{ LANGUAGE_CODE }}</strong></button>
       </li>
     {% endif %}
-  {% endfor %}
+    {% get_available_languages as available_languages %}
+    {% for available_lang in available_languages reversed %}
+      {% if LANGUAGE_CODE != available_lang.0 %}
+        <li class="other">
+          {% url 'change_language' lang_code=available_lang.0 as language_url %}
+          <a href="{{ language_url }}">{{ available_lang.0 }}</a>
+        </li>
+      {% endif %}
+    {% endfor %}
   </ul>
 </div>

--- a/djangoproject/templates/includes/language_selector.html
+++ b/djangoproject/templates/includes/language_selector.html
@@ -1,21 +1,20 @@
 {% load i18n %}
 <div id="version-switcher">
   <ul id="doc-languages" class="language-switcher doc-switcher">
-  {% get_available_languages as languages %}
-  {% for available_lang in languages %}
-  {% if lang != available_lang %}
-  <li class="other">
-    {% url 'change_language' lang_code=available_lang.0 as language_url %}
-    <a href="{{ language_url }}">{{ available_lang.1 }}</a>
-  </li>
-  {% endif %}
-  {% endfor %}
   {% if LANGUAGE_CODE %}
-  {% get_language_info for LANGUAGE_CODE as lang %}
     <li class="current"
         title="{% blocktrans %}Click on the links on the left to switch to another language.{% endblocktrans %}">
-      <span>{% trans "Language:" %} <strong>{{ lang.name_local }}</strong></span>
+      <button>{% trans "Language:" %} <strong>{{ LANGUAGE_CODE }}</strong></button>
     </li>
   {% endif %}
+  {% get_available_languages as available_languages %}
+  {% for available_lang in available_languages reversed %}
+    {% if LANGUAGE_CODE != available_lang.0 %}
+      <li class="other">
+        {% url 'change_language' lang_code=available_lang.0 as language_url %}
+        <a href="{{ language_url }}">{{ available_lang.0 }}</a>
+      </li>
+    {% endif %}
+  {% endfor %}
   </ul>
 </div>

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -8,7 +8,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import NoReverseMatch, get_resolver
-from django.utils.translation import activate, gettext as _
+from django.utils.translation import activate, get_language, gettext as _
 from django_hosts.resolvers import reverse
 from django_recaptcha.client import RecaptchaResponse
 from playwright.sync_api import expect, sync_playwright
@@ -251,6 +251,28 @@ class SiteMapTests(TestCase):
     def test_sitemap_renders(self):
         response = self.client.get(reverse("sitemap"))
         self.assertEqual(response.status_code, 200)
+
+
+class ChangeLanguageTests(TestCase):
+    """Test case to verify language changing behaviour"""
+
+    def test_change_language(self):
+        """Verify default language and switching to a new language"""
+        self.client.get(reverse("change_language", kwargs={"lang_code": "fr"}))
+        lang = get_language()
+        self.assertEqual("fr", lang)
+
+        # Change back to default
+        self.client.get(
+            reverse("change_language", kwargs={"lang_code": settings.LANGUAGE_CODE})
+        )
+        lang = get_language()
+        self.assertEqual(settings.LANGUAGE_CODE, lang)
+
+    def test_default_language(self):
+        """Verify default language"""
+        default_lang = get_language()
+        self.assertEqual(settings.LANGUAGE_CODE, default_lang)
 
 
 class EndToEndTests(ReleaseMixin, StaticLiveServerTestCase):

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -125,25 +125,16 @@ class ExcludeHostsLocaleMiddlewareTests(ReleaseMixin, TestCase):
     response.
     """
 
-    docs_host = "docs.djangoproject.localhost"
-    www_host = "www.djangoproject.localhost"
+    docs_host = "docs"
+    www_host = "www"
+    docs_host_header = "docs.djangoproject.localhost:8000"
+    www_host_header = "www.djangoproject.localhost:8000"
 
     def test_docs_host_excluded(self):
         """We get no Content-Language or Vary headers when docs host is excluded"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", headers={"host": self.docs_host})
+            resp = self.client.get("/", headers={"host": self.docs_host_header})
 
-        self.assertEqual(resp.status_code, HTTPStatus.OK)
-        self.assertNotIn("Content-Language", resp)
-        self.assertNotIn("Vary", resp)
-
-    def test_docs_host_with_port_excluded(self):
-        """
-        We get no Content-Language or Vary headers when docs host
-        (with a port) is excluded
-        """
-        with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", headers={"host": "%s:8000" % self.docs_host})
         self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertNotIn("Content-Language", resp)
         self.assertNotIn("Vary", resp)
@@ -156,32 +147,27 @@ class ExcludeHostsLocaleMiddlewareTests(ReleaseMixin, TestCase):
         with self.settings(
             LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host], USE_X_FORWARDED_HOST=True
         ):
-            resp = self.client.get("/", headers={"x-forwarded-host": self.docs_host})
+            resp = self.client.get(
+                "/", headers={"x-forwarded-host": self.docs_host_header}
+            )
 
-        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertNotIn("Content-Language", resp)
         self.assertNotIn("Vary", resp)
 
     def test_docs_host_not_excluded(self):
         """We still get Content-Language when docs host is not excluded"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[]):
-            resp = self.client.get("/", headers={"host": self.docs_host})
+            resp = self.client.get("/", headers={"host": self.docs_host_header})
 
-        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        self.assertEqual(resp.status_code, HTTPStatus.FOUND)
         self.assertIn("Content-Language", resp)
         self.assertIn("Vary", resp)
 
     def test_www_host(self):
         """www should still use LocaleMiddleware"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/en/", headers={"host": self.www_host})
-        self.assertEqual(resp.status_code, HTTPStatus.OK)
-        self.assertIn("Content-Language", resp)
-
-    def test_www_host_with_port(self):
-        """www (with a port) should still use LocaleMiddleware"""
-        with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/en/", headers={"host": "%s:8000" % self.www_host})
+            resp = self.client.get("/en/", headers={"host": self.www_host_header})
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn("Content-Language", resp)
 

--- a/djangoproject/tests.py
+++ b/djangoproject/tests.py
@@ -174,18 +174,16 @@ class ExcludeHostsLocaleMiddlewareTests(ReleaseMixin, TestCase):
     def test_www_host(self):
         """www should still use LocaleMiddleware"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", headers={"host": self.www_host})
+            resp = self.client.get("/en/", headers={"host": self.www_host})
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn("Content-Language", resp)
-        self.assertIn("Vary", resp)
 
     def test_www_host_with_port(self):
         """www (with a port) should still use LocaleMiddleware"""
         with self.settings(LOCALE_MIDDLEWARE_EXCLUDED_HOSTS=[self.docs_host]):
-            resp = self.client.get("/", headers={"host": "%s:8000" % self.www_host})
+            resp = self.client.get("/en/", headers={"host": "%s:8000" % self.www_host})
         self.assertEqual(resp.status_code, HTTPStatus.OK)
         self.assertIn("Content-Language", resp)
-        self.assertIn("Vary", resp)
 
 
 # https://adamj.eu/tech/2024/06/23/django-test-pending-migrations/

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -8,7 +8,6 @@ from django.contrib.sitemaps import views as sitemap_views
 from django.urls import include, path, re_path
 from django.views.decorators.cache import cache_page
 from django.views.generic import RedirectView, TemplateView
-from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
 
 from accounts import views as account_views
@@ -31,7 +30,6 @@ sitemaps = {
 
 urlpatterns = i18n_patterns(
     path("", TemplateView.as_view(template_name="homepage.html"), name="homepage"),
-    path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path(
         "change-language/<str:lang_code>/",
         project_views.change_language,

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -163,12 +163,6 @@ urlpatterns = i18n_patterns(
         {"sitemaps": sitemaps},
         name="sitemap",
     ),
-    path(
-        ".well-known/security.txt",
-        TemplateView.as_view(
-            template_name="well-known/security.txt", content_type="text/plain"
-        ),
-    ),
     path("weblog/", include("blog.urls")),
     path("svntogit/", include("svntogit.urls")),
     path(
@@ -182,6 +176,12 @@ urlpatterns = i18n_patterns(
 
 urlpatterns += [
     path("download/", include("releases.urls")),
+    path(
+        ".well-known/security.txt",
+        TemplateView.as_view(
+            template_name="well-known/security.txt", content_type="text/plain"
+        ),
+    ),
     path("", include("legacy.urls")),  # Exclude from i18n patterns
 ]
 

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -183,7 +183,7 @@ urlpatterns += [
             template_name="well-known/security.txt", content_type="text/plain"
         ),
     ),
-    path("", include("legacy.urls")),  # Exclude from i18n patterns
+    path("", include("legacy.urls")),
 ]
 
 if settings.DEBUG:

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.contenttypes import views as contenttypes_views
@@ -7,12 +8,14 @@ from django.contrib.sitemaps import views as sitemap_views
 from django.urls import include, path, re_path
 from django.views.decorators.cache import cache_page
 from django.views.generic import RedirectView, TemplateView
+from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
 
 from accounts import views as account_views
 from aggregator.feeds import CommunityAggregatorFeed, CommunityAggregatorFirehoseFeed
 from blog.feeds import WeblogEntryFeed
 from blog.sitemaps import WeblogSitemap
+from djangoproject import views as project_views
 from djangoproject.sitemaps import TemplateViewSitemap
 from foundation.feeds import FoundationMinutesFeed
 from foundation.views import BannerPreview, CoreDevelopers
@@ -26,8 +29,14 @@ sitemaps = {
 }
 
 
-urlpatterns = [
+urlpatterns = i18n_patterns(
     path("", TemplateView.as_view(template_name="homepage.html"), name="homepage"),
+    path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
+    path(
+        "change-language/<str:lang_code>/",
+        project_views.change_language,
+        name="change_language",
+    ),
     path(
         "about/",
         RedirectView.as_view(
@@ -163,9 +172,7 @@ urlpatterns = [
         ),
     ),
     path("weblog/", include("blog.urls")),
-    path("download/", include("releases.urls")),
     path("svntogit/", include("svntogit.urls")),
-    path("", include("legacy.urls")),
     path(
         "foundation/individual-membership-nomination/",
         RedirectView.as_view(
@@ -173,6 +180,11 @@ urlpatterns = [
             permanent=False,
         ),
     ),
+)
+
+urlpatterns += [
+    path("download/", include("releases.urls")),
+    path("", include("legacy.urls")),  # Exclude from i18n patterns
 ]
 
 if settings.DEBUG:

--- a/djangoproject/urls/www.py
+++ b/djangoproject/urls/www.py
@@ -164,6 +164,7 @@ urlpatterns = i18n_patterns(
         name="sitemap",
     ),
     path("weblog/", include("blog.urls")),
+    path("download/", include("releases.urls.i18n_paths")),
     path("svntogit/", include("svntogit.urls")),
     path(
         "foundation/individual-membership-nomination/",
@@ -175,7 +176,7 @@ urlpatterns = i18n_patterns(
 )
 
 urlpatterns += [
-    path("download/", include("releases.urls")),
+    path("download/", include("releases.urls.download")),
     path(
         ".well-known/security.txt",
         TemplateView.as_view(

--- a/djangoproject/views.py
+++ b/djangoproject/views.py
@@ -12,7 +12,7 @@ def change_language(request, lang_code):
     Most of this code is taken from django's own `set_language` and the next
     url gets checked if it's an allowed host.
     """
-    next_url = request.META.get("HTTP_REFERER")
+    next_url = request.headers.get("referer")
     if not url_has_allowed_host_and_scheme(
         url=next_url,
         allowed_hosts={request.get_host()},

--- a/djangoproject/views.py
+++ b/djangoproject/views.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from django.urls import translate_url
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.translation import activate, check_for_language
+
+
+def change_language(request, lang_code):
+    """
+    Allow changing of language via GET request so that the docs
+    language selector can be reused.
+    Most of this code is taken from django's own `set_language` and the next
+    url gets checked if it's an allowed host.
+    """
+    next_url = request.META.get("HTTP_REFERER")
+    if not url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_url = "/"
+
+    response = HttpResponseRedirect(next_url)
+
+    if lang_code and check_for_language(lang_code):
+        if next_url:
+            next_trans = translate_url(next_url, lang_code)
+            if next_trans != next_url:
+                response = HttpResponseRedirect(next_trans)
+
+        activate(lang_code)
+        response.set_cookie(
+            settings.LANGUAGE_COOKIE_NAME,
+            lang_code,
+            max_age=settings.LANGUAGE_COOKIE_AGE,
+            path=settings.LANGUAGE_COOKIE_PATH,
+            domain=settings.LANGUAGE_COOKIE_DOMAIN,
+            secure=settings.LANGUAGE_COOKIE_SECURE,
+            httponly=settings.LANGUAGE_COOKIE_HTTPONLY,
+            samesite=settings.LANGUAGE_COOKIE_SAMESITE,
+        )
+
+    return response

--- a/docs/templates/base_docs.html
+++ b/docs/templates/base_docs.html
@@ -5,6 +5,10 @@
 
 {% block title %}{% translate 'Django Documentation' %}{% endblock %}
 
+{% block language_selector %}
+  {# The docs site has a separate language chooser #}
+{% endblock language_selector %}
+
 {% block header-classes %}
   container--flex container--flex--wrap--mobile
 {% endblock header-classes %}

--- a/docs/tests/test_views.py
+++ b/docs/tests/test_views.py
@@ -25,7 +25,7 @@ class RedirectsTests(SimpleTestCase):
     def test_team_url(self):
         # This URL is linked from the docs.
         self.assertEqual(
-            "/foundation/teams/", reverse("members:teams", urlconf=www_urls)
+            "/en/foundation/teams/", reverse("members:teams", urlconf=www_urls)
         )
 
     def test_internals_team(self):

--- a/foundation/tests.py
+++ b/foundation/tests.py
@@ -110,6 +110,7 @@ class BannerTestCase(ReleaseMixin, TestCase):
         self.assertRedirects(
             response,
             f"/accounts/login/?next=/en/foundation/banners/{banner.pk}/preview/",
+            target_status_code=302,
         )
 
     def test_preview_view_requires_permission(self):

--- a/foundation/tests.py
+++ b/foundation/tests.py
@@ -33,7 +33,7 @@ class BannerTestCase(ReleaseMixin, TestCase):
 
     def test_active_banner_tag_no_active_banner(self):
         Banner.objects.create(title="Inactive", is_active=False)
-        response = self.client.get("/")
+        response = self.client.get("/en/")
         self.assertNotContains(response, '<div class="banner">')
 
     def test_active_banner_tag_renders_banner(self):
@@ -44,7 +44,7 @@ class BannerTestCase(ReleaseMixin, TestCase):
             cta_url="https://djangoproject.com/donate/",
             is_active=True,
         )
-        response = self.client.get("/")
+        response = self.client.get("/en/")
         self.assertContains(response, "<h2>Support Django!</h2>", html=True)
         self.assertContains(
             response, '<div class="banner-body">Please donate.</div>', html=True
@@ -88,13 +88,13 @@ class BannerTestCase(ReleaseMixin, TestCase):
 
     def test_active_banner_tag_no_cta_when_fields_blank(self):
         Banner.objects.create(title="No CTA", cta_label="", cta_url="", is_active=True)
-        response = self.client.get("/")
+        response = self.client.get("/en/")
         self.assertContains(response, "No CTA")
         self.assertNotContains(response, '<a id="banner-cta" class="cta"')
 
     def test_inactive_banner_not_shown_on_main_site(self):
         Banner.objects.create(title="Inactive banner", is_active=False)
-        response = self.client.get("/")
+        response = self.client.get("/en/")
         self.assertNotContains(response, "Inactive banner")
 
     def test_banner_get_absolute_url(self):
@@ -108,7 +108,8 @@ class BannerTestCase(ReleaseMixin, TestCase):
         banner = Banner.objects.create(title="Draft banner")
         response = self.client.get(banner.get_absolute_url())
         self.assertRedirects(
-            response, f"/accounts/login/?next=/foundation/banners/{banner.pk}/preview/"
+            response,
+            f"/accounts/login/?next=/en/foundation/banners/{banner.pk}/preview/",
         )
 
     def test_preview_view_requires_permission(self):
@@ -140,7 +141,7 @@ class BannerTestCase(ReleaseMixin, TestCase):
 
     def test_fundraising_page_suppresses_banner(self):
         Banner.objects.create(title="Donate now!", is_active=True)
-        response = self.client.get("/fundraising/")
+        response = self.client.get("/en/fundraising/")
         self.assertNotContains(response, "Donate now!")
 
 

--- a/members/test_admin.py
+++ b/members/test_admin.py
@@ -43,7 +43,7 @@ class CorporateMemberAdminTests(TestCase):
 
     def test_renewal_link(self):
         expected_str = (
-            '<a href="http://www.djangoproject.localhost:8000/foundation/'
+            '<a href="http://www.djangoproject.localhost:8000/en/foundation/'
             "corporate-membership/renew/"
         )
         modeladmin = CorporateMemberAdmin(CorporateMember, admin.site)

--- a/members/test_management.py
+++ b/members/test_management.py
@@ -51,7 +51,7 @@ class CorporateMemberTests(TestCase):
             msg.body,
         )
         self.assertIn(
-            "http://www.djangoproject.localhost:8000/foundation/"
+            "http://www.djangoproject.localhost:8000/en/foundation/"
             "corporate-membership/renew/",
             msg.body,
         )

--- a/releases/urls/download.py
+++ b/releases/urls/download.py
@@ -1,0 +1,12 @@
+from django.urls import re_path
+
+from ..views import redirect, roadmap
+
+urlpatterns = [
+    re_path(
+        "^([0-9a-z_.-]+)/(tarball|wheel|checksum)/$", redirect, name="download-redirect"
+    ),
+    re_path(
+        r"^(?P<series>(?:\d{1,2}\.[0-2]|\d{4}))/roadmap/$", roadmap, name="roadmap"
+    ),
+]

--- a/releases/urls/i18n_paths.py
+++ b/releases/urls/i18n_paths.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from ..views import index
+
+urlpatterns = [
+    path("", index, name="download"),
+]

--- a/svntogit/tests.py
+++ b/svntogit/tests.py
@@ -5,15 +5,15 @@ from djangoproject.tests import ReleaseMixin
 
 class SvnToGitTests(ReleaseMixin, TestCase):
     def test_redirect(self):
-        response = self.client.get("/svntogit/1/", follow=False)
+        response = self.client.get("/en/svntogit/1/", follow=False)
         target = "https://github.com/django/django/commit/d6ded0e91b"
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], target)
 
     def test_redirect_empty_changeset(self):
-        response = self.client.get("/svntogit/7/")
+        response = self.client.get("/en/svntogit/7/")
         self.assertEqual(response.status_code, 404)
 
     def test_redirect_non_existing_changeset(self):
-        response = self.client.get("/svntogit/20000/")
+        response = self.client.get("/en/svntogit/20000/")
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
Fixes https://github.com/django/djangoproject.com/issues/883

Credit for most of the work goes to @marksweb; I merely brought it up to date and refactored `ExcludeHostsLocaleMiddleware` to make it simpler and easier to test.

Open questions:
- Are there any JS strings translated, and are they included in the plan (https://github.com/django/djangoproject.com/issues/1648)? I could find no mention of that.
- What is the right set of languages to add to `settings.LANGUAGES`?

---

#### ToDo
- [x] Cherry-pick the i18n URL setup and language chooser from https://github.com/django/djangoproject.com/pull/1251.
- [x] Update the language chooser markup (looks like the HTML does not match the styles any more).
- [x] See if the "downloads" route needs special handling, like in the old PR.
- [x] Make testsuite pass locally.
- [ ] Check plans for translating JS strings.
- [ ] Decide which languages to include in `settings.LANGUAGES`.
- [x] Address double language menu on docs site.

#### AI Assistance Disclosure (REQUIRED)
- [x] **No AI tools were used** in preparing this PR.
