### PR TITLE
Fixed `stable/` docs symlink.

### DIFF
--- a/docs/management/commands/build_doc_release.py
+++ b/docs/management/commands/build_doc_release.py
@@ -185,22 +185,9 @@ class Command(BaseCommand):
             ]
         )
 
-        if release.is_default:
-            self._setup_stable_symlink(release, built_dir)
-
         json_built_dir = parent_build_dir / "_built" / "json"
         documents = gen_decoded_documents(json_built_dir)
         release.sync_to_db(documents)
-
-    def _setup_stable_symlink(self, release, built_dir):
-        """
-        Setup a symbolic link called "stable" pointing to the given release build
-        """
-        stable = built_dir / "stable"
-        target = built_dir / release.version
-        if stable.resolve() != target:  # Symlink is either missing or has changed
-            stable.unlink(missing_ok=True)
-            stable.symlink_to(target, target_is_directory=True)
 
 
 def gen_decoded_documents(directory):

--- a/docs/management/commands/update_docs.py
+++ b/docs/management/commands/update_docs.py
@@ -13,7 +13,7 @@ from django.core.management import BaseCommand, call_command
 from django.db.models import Q
 
 from ...models import DocumentRelease
-from ...utils import capture_sentry_exception
+from ...utils import capture_sentry_exception, setup_stable_symlink
 
 
 class Command(BaseCommand):
@@ -98,6 +98,12 @@ class Command(BaseCommand):
                 self.stderr.write(
                     f"build_doc_release failed for {release}, skipping: {e}"
                 )
+                continue
+            if release.is_default:
+                # Re-point the <lang>/stable symlink even on no-change runs,
+                # when build_doc_release returns early and the link could
+                # still be stale (e.g. after is_default changed).
+                setup_stable_symlink(release.lang, release.version)
 
         if self.purge_cache:
             changed_versions = {

--- a/docs/tests/test_commands.py
+++ b/docs/tests/test_commands.py
@@ -10,6 +10,7 @@ from sphinx.errors import SphinxError
 from ..management.commands.build_doc_release import Command
 from ..management.commands.update_docs import Command as UpdateDocsCommand
 from ..models import DocumentRelease
+from ..utils import setup_stable_symlink
 
 
 class HtmlBuilderNameTests(TestCase):
@@ -99,6 +100,62 @@ class BuildReleaseSubprocessInvocationTests(TestCase):
                 "2",
             ]
         )
+
+
+class StableSymlinkTests(TestCase):
+    """The web server serves pot files from <lang>/stable/_built/gettext/,
+    so the <lang>/stable link must track the is_default release."""
+
+    def setUp(self):
+        self.lang = "en"
+        self.version = "dev"
+
+    def test_creates_stable_link_pointing_at_version_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / self.lang / self.version).mkdir(parents=True)
+            with override_settings(DOCS_BUILD_ROOT=root):
+                setup_stable_symlink(self.lang, self.version)
+            stable = root / self.lang / "stable"
+            self.assertTrue(stable.is_symlink())
+            self.assertEqual(
+                stable.resolve(), (root / self.lang / self.version).resolve()
+            )
+
+    def test_repoints_stale_stable_link(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / self.lang / self.version).mkdir(parents=True)
+            (root / self.lang / "6.0").mkdir()
+            stale = root / self.lang / "stable"
+            stale.symlink_to(root / self.lang / "6.0", target_is_directory=True)
+            with override_settings(DOCS_BUILD_ROOT=root):
+                setup_stable_symlink(self.lang, self.version)
+            self.assertEqual(
+                stale.resolve(), (root / self.lang / self.version).resolve()
+            )
+
+    def test_existing_correct_link_is_kept(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / self.lang / self.version).mkdir(parents=True)
+            stale = root / self.lang / "stable"
+            with override_settings(DOCS_BUILD_ROOT=root):
+                setup_stable_symlink(self.lang, self.version)
+                mtime = stale.lstat().st_mtime_ns
+                setup_stable_symlink(self.lang, self.version)
+            self.assertEqual(mtime, stale.lstat().st_mtime_ns)
+
+    def test_refuses_to_replace_non_symlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / self.lang / self.version).mkdir(parents=True)
+            (root / self.lang / "stable").mkdir()
+            with (
+                override_settings(DOCS_BUILD_ROOT=root),
+                self.assertRaisesMessage(RuntimeError, "stable"),
+            ):
+                setup_stable_symlink(self.lang, self.version)
 
 
 class UpdateDocsResilienceTests(TestCase):

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -27,6 +27,35 @@ def capture_sentry_exception(error, flush=False):
     return True
 
 
+def setup_stable_symlink(lang, version):
+    """
+    Keep the <lang>/stable symlink pointing at the default release's build
+    directory (e.g. docbuilds/en/stable -> docbuilds/en/6.1).
+
+    The web server serves Transifex's source pot files directly from
+    docbuilds/en/stable/_built/gettext/, so this link must always track the
+    release flagged as DocumentRelease.is_default. No-op if the link is
+    already correct.
+    """
+    lang_dir = settings.DOCS_BUILD_ROOT / lang
+    stable = lang_dir / "stable"
+    target = lang_dir / version
+    if stable.is_symlink():
+        # Resolve both sides so parents that are themselves symlinks
+        # (e.g. /var on macOS) don't cause needless relinking.
+        if stable.resolve() == target.resolve():
+            return
+        stable.unlink()
+    elif stable.exists():
+        # A plain file or directory at this path would break symlink
+        # creation; fail loudly rather than deleting it.
+        raise RuntimeError(
+            f"Refusing to replace {stable} with a symlink; it exists and is "
+            "not a symlink. Investigate manually."
+        )
+    stable.symlink_to(target, target_is_directory=True)
+
+
 def get_doc_root(lang, version, builder="json"):
     return settings.DOCS_BUILD_ROOT / lang / version / "_built" / builder
 


### PR DESCRIPTION
Fixes #2373

The current `main` branch creates a broken symlink in the wrong place:

```sh
$ cd ~/.djangoproject/djangodocs/en

$ ls -al 6.0/_built    
total 0
drwxr-xr-x   6 tobias  staff  192 Aug 28 14:43 .
drwxr-xr-x   4 tobias  staff  128 Jul  1 14:01 ..
drwxr-xr-x  24 tobias  staff  768 Aug 28 14:43 djangohtml
drwxr-xr-x  14 tobias  staff  448 Aug 28 14:43 gettext
drwxr-xr-x  26 tobias  staff  832 Aug 28 14:43 json
lrwxr-xr-x   1 tobias  staff   57 Aug 28 14:43 stable -> /Users/tobias/.djangoproject/djangodocs/en/6.0/_built/6.0

$ ls /Users/tobias/.djangoproject/djangodocs/en/6.0/_built/6.0    
ls: /Users/tobias/.djangoproject/djangodocs/en/6.0/_built/6.0: No such file or directory
```

This PR creates a working symlink in the `en/` directory instead of `en/6.0/_built/`:
```sh
$ python -m manage update_docs

<snip>

The message catalogs are in ../../.djangoproject/djangodocs/en/6.0/_build/gettext.

$ cd ../../.djangoproject/djangodocs              

$ ls -al
total 0
drwxr-xr-x  5 tobias  staff  160 Aug 28 14:30 .
drwxr-xr-x  5 tobias  staff  160 Jul  1 11:52 ..
drwxr-xr-x  4 tobias  staff  128 Jul  1 14:01 6.0
drwxr-xr-x  4 tobias  staff  128 Jul  1 11:57 dev
lrwxr-xr-x  1 tobias  staff   46 Aug 28 14:30 stable -> /Users/tobias/.djangoproject/djangodocs/en/6.0
```
#### AI Assistance Disclosure (REQUIRED)

<!-- Select exactly ONE of the following: -->

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

<!-- If AI tools were used, provide which tools were used below. -->

A local model (Qwen3.8 27B) was used to find the source of the problem and draft the proposed fix.