### PR TITLE
Updates team page to link django core developers

### DIFF
--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -44,4 +44,16 @@
     </div>
   {% endfor %}
 
+  <div class="section">
+    <p>
+      {% url 'foundation_core_developers' as core_developers_url %}
+      {% blocktranslate trimmed %}
+        <a href="{{ core_developers_url }}">Django Core Developers</a>
+        &mdash; a historical title awarded to individuals who made significant,
+        sustained contributions to Django. This title was retired in 2020, and
+        is not an active team.
+      {% endblocktranslate %}
+    </p>
+  </div>
+
 {% endblock content %}

--- a/djangoproject/templates/members/team_list.html
+++ b/djangoproject/templates/members/team_list.html
@@ -50,7 +50,7 @@
       {% blocktranslate trimmed %}
         <a href="{{ core_developers_url }}">Django Core Developers</a>
         &mdash; a historical title awarded to individuals who made significant,
-        sustained contributions to Django. This title was retired in 2020, and
+        sustained contributions to Django. This title was retired in 2020 and
         is not an active team.
       {% endblocktranslate %}
     </p>


### PR DESCRIPTION
Addresses https://github.com/django/djangoproject.com/issues/2747 by adding a link to the historical Django Core Developers page.

<img width="962" height="806" alt="Screenshot 2026-08-29 at 11 51 17 PM" src="https://github.com/user-attachments/assets/e1db676f-92df-4ae5-a474-a669800cc4df" />



#### AI Assistance Disclosure (REQUIRED)

<!-- Select exactly ONE of the following: -->

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

<!-- If AI tools were used, provide which tools were used below. -->
I used Claude Code to review my first draft of changes and implemented some of the suggestions.