### PR TITLE
Fixed #1954 -- Corrected scroll-to-text fragments in docs search results

### DIFF
--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -1,4 +1,5 @@
 import re
+from html import unescape
 from urllib.parse import quote
 
 from django import template
@@ -131,11 +132,22 @@ def generate_scroll_to_text_fragment(highlighted_text):
     line_without_highlight = re.sub(
         rf"{START_SEL}|{STOP_SEL}|¶", "", first_non_empty_line
     )
-    line_without_highlight = line_without_highlight.replace("&quot;", '"')
+    line_without_highlight = unescape(line_without_highlight)
     # Remove excess spacing.
     single_spaced = re.sub(r"\s+", " ", line_without_highlight).strip()
+    # Pygments splits string literals into several tokens (e.g. the "%s"
+    # placeholder in "WHERE baz = %s"), which adds spacing that is not in the
+    # rendered page. Remove the spacing just inside a pair of double quotes.
+    single_spaced = re.sub(r'"\s*([^"]*?)\s*"', r'"\1"', single_spaced)
+    # Attribute access is also split into separate tokens, so "self . baz" needs
+    # to become "self.baz". A dot which is followed by a capitalised word ends a
+    # sentence in prose, e.g. "reach gettext . This means", so it is left alone.
+    single_spaced = re.sub(r"(?<=[\w)\]]) \. (?![A-Z][a-z])(?=\w)", ".", single_spaced)
     # Handle punctuation spacing.
-    single_spaced = re.sub(r"\s([.,;:!?)(\]\[])", r"\1", single_spaced)
+    single_spaced = re.sub(r"\s([.,;:!?)\]])", r"\1", single_spaced)
+    # An opening bracket only binds to the preceding token when it is a call or a
+    # subscript, e.g. "foo (x)" is "foo(x)" but ", [self.baz]" keeps its space.
+    single_spaced = re.sub(r"(?<=[\w)\]])\s([(\[])", r"\1", single_spaced)
     # Due to Python code such as timezone.now(), remove the space after a bracket.
     single_spaced = re.sub(r"([(\[])\s", r"\1", single_spaced)
     return f"#:~:text={quote(single_spaced)}"

--- a/docs/tests/test_templates.py
+++ b/docs/tests/test_templates.py
@@ -157,6 +157,39 @@ def band_listing(request):
                 See   Built-in class-based <mark>views</mark> API  . """,
                 "#:~:text=Generic%20views",
             ),
+            # execute("UPDATE bar SET foo = 1 WHERE baz = %s", [self.baz])
+            (
+                "<mark>execute</mark>  (  &quot;UPDATE bar SET foo = 1 WHERE baz = "
+                "  %s  &quot;  ,   [  self  .  baz  ]) \n"
+                "         cursor  .  <mark>execute</mark>",
+                "#:~:text=execute%28%22UPDATE%20bar%20SET%20foo%20%3D%201%20WHERE"
+                "%20baz%20%3D%20%25s%22%2C%20%5Bself.baz%5D%29",
+            ),
+            # urlpatterns = [
+            (
+                "<mark>urlpatterns</mark>   =   [ \n     # some generic view\n",
+                "#:~:text=urlpatterns%20%3D%20%5B",
+            ),
+            # model)._meta.fields]
+            (
+                "<mark>model</mark>  )  .  _<mark>meta</mark>  .  fields  ] \n"
+                "              header   =   &quot;,&quot;  .  join  (  fields  )",
+                "#:~:text=model%29._meta.fields%5D",
+            ),
+            # cursor.execute("SELECT foo FROM bar WHERE baz = '30%'")
+            (
+                "<mark>cursor</mark>  .  execute  (  &quot;SELECT foo FROM bar WHERE "
+                "baz = &#39;30%&#39;&quot;  ) \n\n # Parameters passed",
+                "#:~:text=cursor.execute%28%22SELECT%20foo%20FROM%20bar%20WHERE%20"
+                "baz%20%3D%20%2730%25%27%22%29",
+            ),
+            # A full stop ending a sentence must not be joined to the next word.
+            (
+                "<mark>f</mark>-string <mark>expressions</mark> are evaluated before "
+                "they reach   gettext  . This means\n  _(<mark>f</mark>&quot;Welcome",
+                "#:~:text=f-string%20expressions%20are%20evaluated%20before%20they"
+                "%20reach%20gettext.%20This%20means",
+            ),
         ]
         for text, url_text_fragment in cases:
             with self.subTest(url_text_fragment=url_text_fragment):


### PR DESCRIPTION
Fixes #1954.

Search result links carry a scroll-to-text fragment built from the PostgreSQL
search headline. Because Pygments splits code into separate tokens, the text the
fragment is built from contains spacing the rendered page does not, so the
browser finds no match and drops the reader at the top of the page instead of at
the result.

Reproduced first against production. `?q=execute` currently emits:

```
#:~:text=execute("UPDATE bar SET foo = 1 WHERE baz = %s ",[self. baz])
```

for a page that renders `execute("UPDATE bar SET foo = 1 WHERE baz = %s", [self.baz])`.

Four things are handled now:

* The headline is HTML, so it is unescaped in full rather than only translating
  `&quot;`. A fragment containing a literal `&#39;` can never match page text.
* Spacing just inside a pair of double quotes is dropped — Pygments splits a
  string literal whenever it contains a placeholder, turning
  `"WHERE baz = %s"` into `"WHERE baz = %s "`.
* A dot with spaces on both sides is attribute access and is joined up, so
  `self . baz` becomes `self.baz`. A dot followed by a capitalised word ends a
  sentence in prose and is left alone — without that guard,
  `reach gettext . This means` collapses to `gettext.This means`.
* An opening bracket only binds to the preceding token when that token is an
  identifier or a closing bracket, i.e. a call or a subscript. Previously
  `, [self.baz]` lost the space after the comma and `urlpatterns = [` became
  `urlpatterns =[`.

### Measurement

I harvested 280 search results across 44 queries from docs.djangoproject.com and
checked that the current code reproduces all 280 production fragments exactly,
so the set is a faithful before-image. Against it:

| | before | after |
|---|---|---|
| fragments unchanged | — | 268 |
| fragments changed | — | 12 |
| changed fragments found in the rendered target page | 0 / 12 | 8 / 12 |

The four still not found are the limitation already noted in the docstring
(`votes = 0` is not narrowed to `votes=0`), which this PR does not attempt.

`docs` is 77 tests, passing before and after. Reverting only
`docs/templatetags/docs.py` while keeping the new tests fails exactly the four
new behaviour cases.

Happy to split this into four commits if that reads better.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

I worked on this with Claude Code, and reviewed every line before opening it.

The evidence above isn't model output. I fetched the corpus from
docs.djangoproject.com myself, confirmed the unmodified code reproduces all 280
production fragments as a before-image, then fetched each of the 12 changed
target pages to check the fragments against the real rendered text. The corpus
also caught a regression in an earlier attempt of mine, where the dot rule
mangled ordinary prose — that's now guarded by a test.

