### PR TITLE
Fixed #2166 -- Removed the dev-version warning from the contributing tutorial

### DIFF
--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -9,7 +9,7 @@
 
 {% block link_rel_tags %}
   {% if docurl %}
-    {% if "internals" in docurl and lang == "en" %} {# The canonical version of "internals" is the dev docs (but only for English, since the dev docs are never translated). #}
+    {% if docurl|is_dev_canonical and lang == "en" %} {# The canonical version of the contributing docs is the dev docs (but only for English, since the dev docs are never translated). #}
       {% url 'document-detail' lang=lang version='dev' url=docurl host 'docs' as canonical_url %}
     {% else %}
       {% url 'document-detail' lang=lang version=canonical_version url=docurl host 'docs' as canonical_url %}
@@ -37,7 +37,7 @@
 
 {% block before_header %}
   {% if release.is_dev %}
-    {% if "internals" not in docurl %}{# The dev version is canonical for internals/. #}
+    {% if not docurl|is_dev_canonical %}{# The dev version is canonical for the contributing docs. #}
       <div id="dev-warning" class="doc-floating-warning">
         {% translate "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
       </div>

--- a/docs/templates/docs/doc.html
+++ b/docs/templates/docs/doc.html
@@ -9,7 +9,7 @@
 
 {% block link_rel_tags %}
   {% if docurl %}
-    {% if docurl|is_dev_canonical and lang == "en" %} {# The canonical version of the contributing docs is the dev docs (but only for English, since the dev docs are never translated). #}
+    {% if docurl|is_dev_canonical and lang == "en" %} {# The canonical version of internals/ and the contributing tutorial is the dev docs (but only for English, since the dev docs are never translated). #}
       {% url 'document-detail' lang=lang version='dev' url=docurl host 'docs' as canonical_url %}
     {% else %}
       {% url 'document-detail' lang=lang version=canonical_version url=docurl host 'docs' as canonical_url %}
@@ -37,7 +37,7 @@
 
 {% block before_header %}
   {% if release.is_dev %}
-    {% if not docurl|is_dev_canonical %}{# The dev version is canonical for the contributing docs. #}
+    {% if not docurl|is_dev_canonical %}{# The dev version is canonical for internals/ and the contributing tutorial. #}
       <div id="dev-warning" class="doc-floating-warning">
         {% translate "This document is for Django's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page." %}
       </div>

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -106,6 +106,25 @@ def do_pygments(parser, token):
     return PygmentsNode(parser.compile_filter(tokens[1]), nodelist)
 
 
+# Documents whose readers are working on Django itself rather than on a project
+# built with a released version. "intro/contributing" is the tutorial that leads
+# into internals/, so it belongs here even though it lives outside that
+# directory.
+DEV_CANONICAL_DOCS = ("internals", "intro/contributing")
+
+
+@register.filter
+@stringfilter
+def is_dev_canonical(docurl):
+    """
+    Return whether the development docs are the canonical version of a document.
+
+    Such documents do not get the "this document is for Django's development
+    version" warning, since the development version is the one to read.
+    """
+    return docurl.startswith(DEV_CANONICAL_DOCS)
+
+
 @register.filter(name="fragment")
 @stringfilter
 def generate_scroll_to_text_fragment(highlighted_text):

--- a/docs/templatetags/docs.py
+++ b/docs/templatetags/docs.py
@@ -122,7 +122,10 @@ def is_dev_canonical(docurl):
     Such documents do not get the "this document is for Django's development
     version" warning, since the development version is the one to read.
     """
-    return docurl.startswith(DEV_CANONICAL_DOCS)
+    return any(
+        docurl == prefix or docurl.startswith(f"{prefix}/")
+        for prefix in DEV_CANONICAL_DOCS
+    )
 
 
 @register.filter(name="fragment")

--- a/docs/tests/test_templates.py
+++ b/docs/tests/test_templates.py
@@ -16,6 +16,7 @@ from ..templatetags.docs import (
     code_links,
     generate_scroll_to_text_fragment,
     get_all_doc_versions,
+    is_dev_canonical,
 )
 
 
@@ -83,6 +84,36 @@ def band_listing(request):
 </pre></div>
             """,
         )
+
+    def test_is_dev_canonical(self):
+        cases = [
+            ("internals", True),
+            ("internals/contributing", True),
+            ("internals/contributing/writing-code/unit-tests", True),
+            # The contributing tutorial leads into internals/, so the dev docs
+            # are canonical for it too. Refs #2166.
+            ("intro/contributing", True),
+            ("intro/tutorial01", False),
+            ("intro/overview", False),
+            ("ref/models/fields", False),
+            ("", False),
+        ]
+        for docurl, expected in cases:
+            with self.subTest(docurl=docurl):
+                self.assertIs(is_dev_canonical(docurl), expected)
+
+    def test_is_dev_canonical_template_filter(self):
+        template = Template(
+            "{% load docs %}"
+            "{% if docurl|is_dev_canonical %}dev{% else %}release{% endif %}"
+        )
+        for docurl, expected in [
+            ("intro/contributing", "dev"),
+            ("internals/contributing", "dev"),
+            ("intro/tutorial01", "release"),
+        ]:
+            with self.subTest(docurl=docurl):
+                self.assertEqual(template.render(Context({"docurl": docurl})), expected)
 
     def test_fragment_template_tag(self):
         highlighted_text = (
@@ -228,6 +259,62 @@ class TemplateTestCase(TestCase):
             doc.title = title
             with self.subTest(title=title):
                 self._assertOGTitleEqual(doc, f"{expected} | Django documentation")
+
+    def _render_dev_doc(self, docurl):
+        release, _ = DocumentRelease.objects.get_or_create(
+            lang=settings.DEFAULT_LANGUAGE_CODE, release=None
+        )
+        doc = Document.objects.create(release=release, path=docurl)
+        doc.title = "Contributing"
+        doc.body = "test body"  # avoids trying to load the underlying physical file
+        return render_to_string(
+            "docs/doc.html",
+            {
+                "doc": doc,
+                "lang": settings.DEFAULT_LANGUAGE_CODE,
+                "version": "dev",
+                "canonical_version": "5.0",
+                "docurl": docurl,
+                "release": release,
+            },
+            request=RequestFactory().get("/"),
+        )
+
+    def test_dev_warning_skipped_for_contributing_docs(self):
+        """
+        The contributing tutorial is read by people working on Django itself,
+        so it does not get the "development version" warning. Refs #2166.
+        """
+        for docurl, expected in [
+            ("internals/contributing", False),
+            ("intro/contributing", False),
+            ("intro/tutorial01", True),
+            ("ref/models/fields", True),
+        ]:
+            with self.subTest(docurl=docurl):
+                output = self._render_dev_doc(docurl)
+                self.assertIs('id="dev-warning"' in output, expected)
+
+    def test_canonical_version_for_contributing_docs(self):
+        for docurl, canonical_version in [
+            ("internals/contributing", "dev"),
+            ("intro/contributing", "dev"),
+            ("intro/tutorial01", "5.0"),
+        ]:
+            with self.subTest(docurl=docurl):
+                canonical_url = reverse_with_host(
+                    "document-detail",
+                    host="docs",
+                    kwargs={
+                        "lang": settings.DEFAULT_LANGUAGE_CODE,
+                        "version": canonical_version,
+                        "url": docurl,
+                    },
+                )
+                self.assertInHTML(
+                    f'<link rel="canonical" href="{canonical_url}">',
+                    self._render_dev_doc(docurl),
+                )
 
 
 class TemplateTagTestCase(TestCase):

--- a/docs/tests/test_templates.py
+++ b/docs/tests/test_templates.py
@@ -97,6 +97,11 @@ def band_listing(request):
             ("intro/overview", False),
             ("ref/models/fields", False),
             ("", False),
+            # Only whole path segments count, so a document whose name merely
+            # starts with one of the prefixes is not included.
+            ("internals-of-something", False),
+            ("internalsomething", False),
+            ("intro/contributing-extra", False),
         ]
         for docurl, expected in cases:
             with self.subTest(docurl=docurl):


### PR DESCRIPTION
Fixes #2166.

`intro/contributing` is the *Writing your first contribution for Django*
tutorial. Its readers are working on Django itself and move straight on into
`internals/`, so the development docs are the version they want. It nonetheless
shows the "this document is for Django's development version, which can be
significantly different from previous releases" warning, and its `rel=canonical`
points at the latest release, because both conditions in `doc.html` tested for
`"internals" in docurl`.

Checked against production before changing anything:

| URL | dev warning | canonical |
|---|---|---|
| `/en/dev/intro/contributing/` | present | `/en/6.1/intro/contributing/` |
| `/en/dev/internals/contributing/` | absent | `/en/dev/internals/contributing/` |

Both conditions now go through an `is_dev_canonical` filter, so the set of
documents the dev docs are canonical for is written down once instead of being
spelled out separately in each branch of the template.

The filter uses a prefix test where the old code used a substring test. I checked
all 912 English document URLs in `sitemap-en.xml`: every URL containing
`internals` also starts with it, so this leaves `internals/` exactly as it was
and adds only `intro/contributing`.

`docs` goes from 77 tests to 81, all passing. Narrowing the tuple back to
`("internals",)` fails exactly the four `intro/contributing` cases and nothing
else, so `internals/` and ordinary pages are demonstrably unaffected.

One thing worth a maintainer's eye: the confirmation @thibaudcolas reported from
Discord was about the warning. This also switches `rel=canonical` to `dev` for
the tutorial, which is the second of the "two lines of custom logic" mentioned in
the issue and follows the same reasoning, but it has SEO consequences. Happy to
drop that half and keep only the warning if you would rather decide it
separately — it is a one-line change.

#### AI Assistance Disclosure (REQUIRED)

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

I used Claude Code while writing the filter, the template edit and the tests, and
read all of it before opening.

The supporting numbers are measured, not asserted: the production behaviour in
the table came from fetching those three URLs, and the "912 URLs, zero
exceptions" figure came from running the filter over the real sitemap rather
than a sample.

