### PR TITLE
Fixed #2819 -- Skipped stub release notes when mainstream support ends

### DIFF
--- a/checklists/models.py
+++ b/checklists/models.py
@@ -159,6 +159,19 @@ class ReleaseChecklist(models.Model):
         return False
 
     @cached_property
+    def is_eom_release(self):
+        """Return True if this release ends mainstream support for its series.
+
+        The feature release that supersedes a series records the last bugfix
+        release of that series as its ``eom_release``, so when this release is
+        pointed at by such a checklist, no further scheduled bugfix release is
+        planned for the series.
+        """
+        if (release := getattr(self, "release", None)) is None:
+            return False
+        return FeatureRelease.objects.filter(eom_release=release).exists()
+
+    @cached_property
     def is_security_release(self):
         return "security" in self.slug
 

--- a/checklists/templates/checklists/release-skeleton.md
+++ b/checklists/templates/checklists/release-skeleton.md
@@ -77,7 +77,7 @@ At this point, most of the larger features planned for {{ release.feature_versio
 
 ### Final tasks
 
-{% if not release.is_pre_release %}{% include "checklists/_stub_release_notes.md" %}{% endif %}
+{% if not release.is_pre_release and not instance.is_eom_release %}{% include "checklists/_stub_release_notes.md" %}{% endif %}
 
 {% include "checklists/_push_changes_and_announce.md" %}
 

--- a/checklists/tests/test_models.py
+++ b/checklists/tests/test_models.py
@@ -68,6 +68,12 @@ class BaseChecklistTestCaseMixin:
         )
         self.assertIn(expected, content)
 
+    def assertStubReleaseNotesNotAdded(self, release, content):
+        unexpected = render_to_string(
+            "checklists/_stub_release_notes.md", {"release": release}
+        )
+        self.assertNotInChecklistContent(unexpected, content)
+
     def assertMakeReleasePublicAdded(self, release, content):
         expected = render_to_string(
             "checklists/_make_release_public.md", {"release": release}
@@ -159,6 +165,35 @@ class BugFixReleaseChecklistTestCase(BaseChecklistTestCaseMixin, TestCase):
         checklist_content = self.do_render_checklist(checklist_instance)
         self.assertPushAndAnnouncesAdded(checklist_instance, checklist_content)
         self.assertStubReleaseNotesAdded(release, checklist_content)
+        self.assertMakeReleasePublicAdded(release, checklist_content)
+
+    def test_is_eom_release(self):
+        release = self.factory.make_release(version="5.2.4")
+        checklist_instance = self.make_checklist(release=release)
+        self.assertIs(checklist_instance.is_eom_release, False)
+
+        self.factory.make_feature_release_checklist(version="6.0")
+        FeatureRelease.objects.update(eom_release=release)
+        del checklist_instance.is_eom_release  # Clear the cached property.
+        self.assertIs(checklist_instance.is_eom_release, True)
+
+    def test_render_checklist_for_eom_release(self):
+        """The last bugfix release of a series gets no stub release notes.
+
+        Once mainstream support ends, the next patch version is only released
+        if a security or data loss fix requires it, so the checklist should not
+        prompt for release notes that may never exist (see #2819).
+        """
+        release = self.factory.make_release(version="5.2.4")
+        self.factory.make_feature_release_checklist(version="6.0")
+        FeatureRelease.objects.update(eom_release=release)
+
+        checklist_instance = self.make_checklist(release=release)
+        checklist_content = self.do_render_checklist(checklist_instance)
+
+        self.assertStubReleaseNotesNotAdded(release, checklist_content)
+        # The rest of the "Final tasks" section is unaffected.
+        self.assertPushAndAnnouncesAdded(checklist_instance, checklist_content)
         self.assertMakeReleasePublicAdded(release, checklist_content)
 
 


### PR DESCRIPTION
Fixed #2819 -- Skipped stub release notes when mainstream support ends.

When a bugfix release is the last one of its series, the feature release that
supersedes the series records it as its `eom_release`. No further patch version
is scheduled after that point: the next one is only issued if a security or data
loss fix requires it, and its release notes are written then. The release
checklist nonetheless prompted the releaser to create a stub release notes file
for a version that may never be released.

This adds `ReleaseChecklist.is_eom_release`, which looks for a feature release
checklist pointing at this release as its end-of-mainstream-support release, and
uses it to omit the stub release notes section from the checklist.

The security release skeleton is left unchanged: a security release is what
brings the extra patch version into existence, so its stub release notes are
still needed at that point.

Tests: `checklists` goes from 125 to 127 tests, all passing before and after; the
full suite goes from 548 to 550 with the same three pre-existing
`LocaleSmokeTests` failures on either side. Reverting only the model property and
the template guard, while keeping the new tests, fails exactly the two new tests
and nothing else.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

Claude Code (Claude Opus) was used to locate `FeatureRelease.eom_release` as the
existing source of truth, draft the property, the template guard and the two
tests. I ran the `checklists` suite and the full test suite before and after
(125 → 127 and 548 → 550, same three pre-existing `LocaleSmokeTests` failures on
both sides), and confirmed that reverting only the two source files makes exactly
the two new tests fail. I also read the open PR #2825 diff to confirm it does not
touch this part of the skeleton. No manual or browser testing was performed.
