### PR TITLE
Fixed #1764 -- Made the completed checkout webhook write atomically

### DIFF
--- a/fundraising/tests/test_views.py
+++ b/fundraising/tests/test_views.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import stripe
 from django.conf import settings
 from django.core import mail
+from django.db import DatabaseError
 from django.template.defaultfilters import date as date_filter
 from django.test import TestCase
 from django.urls import reverse
@@ -17,7 +18,8 @@ from django_hosts.resolvers import reverse as django_hosts_reverse
 from djangoproject.tests import ReleaseMixin, patch_captcha
 from members.models import CorporateMember, Invoice
 
-from ..models import DjangoHero, Donation
+from ..models import DjangoHero, Donation, Payment
+from ..views import WebhookHandler
 from .utils import ImageFileFactory, TemporaryMediaRootMixin
 
 
@@ -497,3 +499,46 @@ class TestWebhooks(ReleaseMixin, TestCase):
         data["type"] = "unknown"
         response = self.post_event(data)
         self.assertEqual(response.status_code, 422)
+
+    @patch("stripe.PaymentIntent.retrieve")
+    @patch("stripe.Customer.retrieve")
+    def test_checkout_session_completed_is_atomic(
+        self, retrieve_customer, retrieve_payment_intent
+    ):
+        """A failed write leaves no half-recorded donation behind."""
+        retrieve_customer.return_value = stripe.Customer.construct_from(
+            {"id": "cus_atomic", "email": "atomic@djangoproject.com"}, "sk_test"
+        )
+        retrieve_payment_intent.return_value = stripe.PaymentIntent.construct_from(
+            {"id": "pi_atomic", "latest_charge": "ch_atomic"}, "sk_test"
+        )
+        event = stripe.Event.construct_from(
+            {
+                "id": "evt_atomic",
+                "type": "checkout.session.completed",
+                "data": {
+                    "object": {
+                        "id": "cs_atomic",
+                        "customer": "cus_atomic",
+                        "mode": "payment",
+                        "amount_total": 5000,
+                        "subscription": None,
+                        "payment_intent": "pi_atomic",
+                    }
+                },
+            },
+            "sk_test",
+        )
+
+        with patch.object(Payment, "save", side_effect=DatabaseError):
+            with self.assertRaises(DatabaseError):
+                WebhookHandler(event).handle()
+
+        self.assertFalse(
+            DjangoHero.objects.filter(stripe_customer_id="cus_atomic").exists()
+        )
+        self.assertFalse(
+            Donation.objects.filter(stripe_customer_id="cus_atomic").exists()
+        )
+        self.assertEqual(Payment.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)

--- a/fundraising/views.py
+++ b/fundraising/views.py
@@ -5,6 +5,7 @@ import stripe
 from django.conf import settings
 from django.contrib import messages
 from django.core.mail import send_mail
+from django.db import transaction
 from django.forms.models import modelformset_factory
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -306,30 +307,41 @@ class WebhookHandler:
         customer = stripe.Customer.retrieve(
             session.customer, stripe_version="2020-08-27"
         )
-        hero, _created = DjangoHero.objects.get_or_create(
-            stripe_customer_id=customer.id,
-            defaults={
-                "email": customer.email,
-            },
-        )
         interval = self.get_donation_interval(session)
         dollar_amount = decimal.Decimal(session.amount_total / 100).quantize(
             decimal.Decimal(".01"), rounding=decimal.ROUND_HALF_UP
         )
-        donation = Donation.objects.create(
-            donor=hero,
-            stripe_customer_id=customer.id,
-            receipt_email=customer.email,
-            subscription_amount=dollar_amount,
-            interval=interval,
-            stripe_subscription_id=session.subscription or "",
+        # Query Stripe before opening the transaction, so that no database
+        # transaction is held open while waiting on the network.
+        payment_intent = (
+            stripe.PaymentIntent.retrieve(session.payment_intent)
+            if interval == "onetime"
+            else None
         )
-        if interval == "onetime":
-            payment_intent = stripe.PaymentIntent.retrieve(session.payment_intent)
-            donation.payment_set.create(
-                amount=dollar_amount,
-                stripe_charge_id=payment_intent.latest_charge,
+
+        # The donor, the donation and its payment describe a single donation,
+        # so a failure part way through must not leave the earlier writes
+        # behind.
+        with transaction.atomic():
+            hero, _created = DjangoHero.objects.get_or_create(
+                stripe_customer_id=customer.id,
+                defaults={
+                    "email": customer.email,
+                },
             )
+            donation = Donation.objects.create(
+                donor=hero,
+                stripe_customer_id=customer.id,
+                receipt_email=customer.email,
+                subscription_amount=dollar_amount,
+                interval=interval,
+                stripe_subscription_id=session.subscription or "",
+            )
+            if payment_intent is not None:
+                donation.payment_set.create(
+                    amount=dollar_amount,
+                    stripe_charge_id=payment_intent.latest_charge,
+                )
 
         # Send an email message about managing your donation
         message = render_to_string(


### PR DESCRIPTION
Fixed #1764 -- Made the completed checkout webhook write atomically.

`WebhookHandler.checkout_session_completed()` writes three related rows: the
`DjangoHero`, the `Donation`, and, for one-time donations, the `Payment`. Each
was committed on its own, so a failure part way through left the earlier rows
behind and recorded a donor or a donation with no payment attached to it.

This wraps the three writes in a single `transaction.atomic()` block, as
suggested in #1768. The `stripe.PaymentIntent` lookup moves just above the block:
it was the only Stripe call still made between two writes, so hoisting it keeps
the transaction from staying open while an API call is in flight. The thank-you
email stays outside the block, so it is only sent for a donation that committed.

The new test lives in the existing `TestWebhooks` class. It forces `Payment.save`
to raise, and asserts that no donor, donation, payment or email survives the
failure.

Tests: `fundraising` goes from 54 to 55 tests, all passing before and after; the
full suite goes from 548 to 549 with the same three pre-existing
`LocaleSmokeTests` failures on either side. Reverting only `fundraising/views.py`
and keeping the new test fails that test alone.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

Claude Code (Claude Opus) was used to draft the `transaction.atomic()` block, the
`PaymentIntent` hoist and the regression test. I ran the `fundraising` suite and
the full test suite before and after (54 → 55 and 548 → 549, same three
pre-existing `LocaleSmokeTests` failures on both sides), and confirmed that
reverting only `fundraising/views.py` makes the new test, and only that test,
fail. No manual or browser testing was performed.
