### PR TITLE
Fixed #1766 -- Matched the leadership-level wording to how donations are totalled

### DIFF
--- a/djangoproject/templates/fundraising/includes/display_django_heroes.html
+++ b/djangoproject/templates/fundraising/includes/display_django_heroes.html
@@ -74,8 +74,8 @@
     Leaders (${{ amount }}+){% endblocktranslate %}</h3>
   <p>
     {% blocktranslate trimmed with amount=display_logo_amount|intcomma %}
-      Leadership-level donors contribute at least ${{ amount }}
-      and have donated in the last {{ display_donor_days }} days.
+      Leadership-level donors have contributed at least ${{ amount }}
+      in the last {{ display_donor_days }} days.
     {% endblocktranslate %}
   </p>
   <div>

--- a/fundraising/forms.py
+++ b/fundraising/forms.py
@@ -7,7 +7,13 @@ from django.utils.translation import gettext_lazy as _
 from django_recaptcha.fields import ReCaptchaField
 from django_recaptcha.widgets import ReCaptchaV3
 
-from .models import INTERVAL_CHOICES, LEADERSHIP_LEVEL_AMOUNT, DjangoHero, Donation
+from .models import (
+    DISPLAY_DONOR_DAYS,
+    INTERVAL_CHOICES,
+    LEADERSHIP_LEVEL_AMOUNT,
+    DjangoHero,
+    Donation,
+)
 
 
 class DjangoHeroForm(forms.ModelForm):
@@ -48,10 +54,11 @@ class DjangoHeroForm(forms.ModelForm):
     logo = forms.FileField(
         required=False,
         help_text=_(
-            "If you've donated at least US $%d, you can submit your logo and "
-            "we will display it, too."
+            "If you've donated at least US $%(amount)d in the last "
+            "%(days)d days, you can submit your logo and we will display "
+            "it, too."
         )
-        % LEADERSHIP_LEVEL_AMOUNT,
+        % {"amount": LEADERSHIP_LEVEL_AMOUNT, "days": DISPLAY_DONOR_DAYS},
     )
     is_visible = forms.BooleanField(
         required=False,

--- a/fundraising/tests/test_forms.py
+++ b/fundraising/tests/test_forms.py
@@ -4,8 +4,8 @@ from django.test import TestCase
 
 from djangoproject.tests import patch_captcha
 
-from ..forms import DonationForm, PaymentForm
-from ..models import DjangoHero, Donation
+from ..forms import DjangoHeroForm, DonationForm, PaymentForm
+from ..models import DISPLAY_DONOR_DAYS, LEADERSHIP_LEVEL_AMOUNT, DjangoHero, Donation
 
 
 class TestPaymentForm(TestCase):
@@ -68,3 +68,15 @@ class TestPaymentForm(TestCase):
         donation.refresh_from_db()
         self.assertEqual(donation.interval, "monthly")
         self.assertEqual(donation.subscription_amount, 50)
+
+
+class TestDjangoHeroForm(TestCase):
+    def test_logo_help_text_states_the_display_window(self):
+        """The logo help text matches DjangoHeroManager.for_public_display().
+
+        Only donations from the last DISPLAY_DONOR_DAYS days count towards the
+        leadership level, so the help text has to say so (refs #1766).
+        """
+        help_text = DjangoHeroForm().fields["logo"].help_text
+        self.assertIn(f"US ${LEADERSHIP_LEVEL_AMOUNT:.0f}", help_text)
+        self.assertIn(f"in the last {DISPLAY_DONOR_DAYS} days", help_text)

--- a/fundraising/tests/test_models.py
+++ b/fundraising/tests/test_models.py
@@ -1,8 +1,14 @@
-from datetime import date
+from datetime import date, timedelta
 
 from django.test import TestCase
 
-from ..models import DjangoHero, Donation, InKindDonor
+from ..models import (
+    DISPLAY_DONOR_DAYS,
+    LEADERSHIP_LEVEL_AMOUNT,
+    DjangoHero,
+    Donation,
+    InKindDonor,
+)
 from .utils import ImageFileFactory, TemporaryMediaRootMixin
 
 
@@ -44,6 +50,24 @@ class TestDjangoHero(TemporaryMediaRootMixin, TestCase):
     def test_display_name(self):
         hero = DjangoHero(name="Hero")
         self.assertEqual(hero.display_name, "Hero")
+
+    def test_for_public_display_only_sums_recent_payments(self):
+        """`donated_amount` covers the last DISPLAY_DONOR_DAYS days only.
+
+        The displayed total is what decides who is listed as a leader, so it
+        is a rolling window rather than a lifetime or calendar-year total.
+        """
+        hero = DjangoHero.objects.create(approved=True, is_visible=True)
+        donation = hero.donation_set.create()
+        older_than_window = donation.payment_set.create(
+            amount=LEADERSHIP_LEVEL_AMOUNT, stripe_charge_id="old"
+        )
+        older_than_window.date = self.today - timedelta(days=DISPLAY_DONOR_DAYS + 1)
+        older_than_window.save()
+        donation.payment_set.create(amount="20", stripe_charge_id="recent")
+
+        displayed = DjangoHero.objects.for_public_display().get(pk=hero.pk)
+        self.assertEqual(displayed.donated_amount, 20)
 
 
 class TestDonation(TestCase):


### PR DESCRIPTION
Fixed #1766 -- Matched the leadership-level wording to how donors are picked.

`DjangoHeroManager.for_public_display()` filters payments to the last
`DISPLAY_DONOR_DAYS` days and only then sums them, so the total that decides who
is listed as a leader covers a rolling 365-day window rather than a lifetime or a
calendar year. Neither place that describes the threshold said so: after #2191
the donor roll read "contribute at least $1,000 and have donated in the last 365
days", which suggests a lifetime total plus any recent donation, and the logo
help text on the donor form still gave no period at all.

This states the same rule in both places. It also adds a test for the manager,
pinning the rolling window down as the behaviour the wording describes, and a
test that keeps the form's help text tied to `LEADERSHIP_LEVEL_AMOUNT` and
`DISPLAY_DONOR_DAYS`.

One thing worth a second opinion before merging: in the issue thread the intent
was described as "any donor whose total donations are $1000 and above, regardless
of how many payments that is", which the rolling window does not literally
implement — a donor who gave $600 in each of two consecutive years is never a
leader. This PR only makes the text describe the current query. If the board
would rather the query changed, that is a separate ticket and I'm happy to open
it.

Tests: `fundraising` goes from 54 to 56 tests, all passing before and after; the
full suite goes from 548 to 550 with the same three pre-existing
`LocaleSmokeTests` failures on either side. Reverting only the form and the
template, keeping both tests, fails the help text test; the manager test still
passes, since it documents existing behaviour rather than a change to it.

#### AI Assistance Disclosure (REQUIRED)

- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

Claude Code (Claude Opus) was used to trace the `filter()`-before-`annotate()`
behaviour in `for_public_display()`, draft the two replacement strings and write
the two tests. I confirmed the rolling-window semantics by running a throwaway
test that gave one donor a $1,000 payment older than the window and a $200
payment inside it and read back `donated_amount = 200.00`. I ran the
`fundraising` suite and the full test suite before and after (54 → 56 and
548 → 550, same three pre-existing `LocaleSmokeTests` failures on both sides),
and confirmed that reverting the form and the template fails the help text test.
The manager test passes either way, by design. No manual or browser testing was
performed.
