### PR TITLE
Retrieved less document metadata during search.

### DIFF
--- a/docs/models.py
+++ b/docs/models.py
@@ -290,7 +290,11 @@ def _clean_document_path(path):
 
 
 def document_url(doc):
-    if doc.metadata.get("parents") == DocumentationCategory.WEBSITE:
+    try:
+        parents = doc.parents  # From a search()/search_results() annotation.
+    except AttributeError:
+        parents = doc.metadata.get("parents")
+    if parents == DocumentationCategory.WEBSITE:
         return doc.path
     elif doc.path:
         kwargs = {
@@ -413,14 +417,10 @@ class DocumentQuerySet(models.QuerySet):
                 ),
                 breadcrumbs=models.F("metadata__breadcrumbs"),
                 python_objects=models.F("metadata__python_objects"),
+                parents=KeyTextTransform("parents", "metadata"),
             )
             .select_related("release__release")
-            .only(
-                "metadata",
-                "path",
-                "release__lang",
-                "release__release__version",
-            )
+            .only("path", "release__lang", "release__release__version")
             .order_by("-rank", "pk")
         )
 


### PR DESCRIPTION
Noticed while doing bc56509502edb0d831ab8814b38447660141d6fb that we retrieve large JSON objects only for the sake of extracting the `"parents"` value.

This branch now only extracts that one value.

Maybe this is a "too small" optimization, but wanted to float it anyway. 