### PR TITLE
Fixed paginator orphans in search results.

### DIFF
--- a/docs/tests/test_views.py
+++ b/docs/tests/test_views.py
@@ -3,7 +3,7 @@ from operator import attrgetter
 
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.test import SimpleTestCase, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse, set_urlconf
 from django.utils.translation import activate, gettext as _
 from django_hosts.resolvers import reverse as reverse_with_host
@@ -14,6 +14,7 @@ from releases.models import Release
 from ..models import Document, DocumentRelease
 from ..search import DocumentationCategory
 from ..sitemaps import DocsSitemap
+from ..views import search_results
 
 
 class RedirectsTests(SimpleTestCase):
@@ -90,6 +91,14 @@ class SearchFormTestCase(TestCase):
         self.assertNotContains(response, '<li class="active">')
         # The search result page does not have the Documentation banner.
         self.assertNotContains(response, '<div class="copy-banner">')
+
+    def test_search_paginator_last_page(self):
+        request = RequestFactory().get("/en/5.1/search/?q=generic&page=last")
+        response = search_results(request, "en", 5.1, per_page=2, orphans=1)
+        self.assertContains(response, "5 results for <em>generic</em>", html=True)
+        self.assertContains(response, "Page 2 of 2", html=True)
+        # If orphans are not considered, there would be just two results here.
+        self.assertContains(response, '<h2 class="result-title">', count=3)
 
     def test_search_paginator_includes_pks_only(self):
         response = self.client.get(

--- a/docs/views.py
+++ b/docs/views.py
@@ -173,37 +173,29 @@ def search_results(request, lang, version, per_page=10, orphans=3):
 
             ranked = Document.objects.rank(q, release, document_category=doc_category)
             page_number = request.GET.get("page") or 1
+            paginator = Paginator(ranked, per_page=per_page, orphans=orphans)
 
             try:
                 page_number = int(page_number)
             except ValueError:
-                if page_number != "last":
+                if page_number == "last":
+                    page_number = paginator.num_pages
+                else:
                     raise Http404(
                         _("Page is not 'last', nor can it be converted to an int.")
                     )
-                page_results = Document.objects.annotate_search_results(
-                    ranked, q, uses_trigram=ranked.uses_trigram
-                )
-            else:
-                # Make the offset & limit calculation so that it can be used to
-                # limit the number of annotations.
-                start = (page_number - 1) * per_page
-                stop = start + per_page
-                page_results = Document.objects.annotate_search_results(
-                    ranked[start:stop], q, uses_trigram=ranked.uses_trigram
-                )
-            paginator = Paginator(ranked, per_page=per_page, orphans=orphans)
 
-            if page_number == "last":
-                page = paginator.page(paginator.num_pages)
-            else:
-                try:
-                    page = paginator.page(page_number)
-                except InvalidPage as e:
-                    raise Http404(
-                        _("Invalid page (%(page_number)s): %(message)s")
-                        % {"page_number": page_number, "message": str(e)}
-                    )
+            try:
+                page = paginator.page(page_number)
+            except InvalidPage as e:
+                raise Http404(
+                    _("Invalid page (%(page_number)s): %(message)s")
+                    % {"page_number": page_number, "message": str(e)}
+                )
+
+            page_results = Document.objects.annotate_search_results(
+                page.object_list, q, uses_trigram=ranked.uses_trigram
+            )
 
             context.update(
                 {


### PR DESCRIPTION
Follow-up to #2748.

There were two bugs stemming from manual start & stop calculations. Orphans were dropped on the floor, and requesting the "last" page didn't apply any limit at all, causing all results to render.

The prior implementation in b65382ab3bc970c358b8892fa5e8a5ad77198650 didn't realize that passing page.object_list to the outer query would be sufficient for limiting the annotations.

#### AI Assistance Disclosure (REQUIRED)

<!-- Select exactly ONE of the following: -->

- [ ] **No AI tools were used** in preparing this PR.
- [x] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

Codex drafted the initial fix; I adjusted it to maintain the smallest diff against the commit prior to 
b65382ab3bc970c358b8892fa5e8a5ad77198650. See:

git diff b65382ab3bc970c358b8892fa5e8a5ad77198650~1 docs/views.py
```diff
diff --git a/docs/views.py b/docs/views.py
index 03c53cf4..62427b3b 100644
--- a/docs/views.py
+++ b/docs/views.py
@@ -171,12 +171,9 @@ def search_results(request, lang, version, per_page=10, orphans=3):
             if exact is not None:
                 return redirect(exact)
 
-            results = Document.objects.search(
-                q, release, document_category=doc_category
-            )
-
+            ranked = Document.objects.rank(q, release, document_category=doc_category)
             page_number = request.GET.get("page") or 1
-            paginator = Paginator(results, per_page=per_page, orphans=orphans)
+            paginator = Paginator(ranked, per_page=per_page, orphans=orphans)
 
             try:
                 page_number = int(page_number)
@@ -185,7 +182,7 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                     page_number = paginator.num_pages
                 else:
                     raise Http404(
-                        _("Page is not 'last', " "nor can it be converted to an int.")
+                        _("Page is not 'last', nor can it be converted to an int.")
                     )
 
             try:
@@ -196,11 +193,16 @@ def search_results(request, lang, version, per_page=10, orphans=3):
                     % {"page_number": page_number, "message": str(e)}
                 )
 
+            page_results = Document.objects.annotate_search_results(
+                page.object_list, q, uses_trigram=ranked.uses_trigram
+            )
+
             context.update(
                 {
                     "query": q,
                     "page": page,
                     "paginator": paginator,
+                    "page_results": page_results,
                     "start_sel": START_SEL,
                     "DocumentationCategory": DocumentationCategory,
                 }

```