### PR TITLE
Ignored JS formatting changes in git blame.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Code formatting via Black
 3045b338de791118962df4db370411247413eca6
+# Run `prettier` on JavaScript via `pre-commit`
+6dc8f418e6b652863ccb16a3e2e01795e8a89d9f


### PR DESCRIPTION
Just like the black changes, it would be nice if the prettier changes could be excluded from the blame.

#### AI Assistance Disclosure (REQUIRED)

<!-- Select exactly ONE of the following: -->

- [x] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones and fully reviewed and verified their output.

<!-- If AI tools were used, provide which tools were used below. -->
