### PR TITLE
Fixed #2841 -- Handled an out-of-range days parameter in metric_json.

### DIFF
--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -71,6 +71,35 @@ class ViewTests(ReleaseMixin, TestCase):
         self.assertEqual(json.loads(response.content.decode())["data"][0][1], 42)
         self.assertEqual(response.status_code, 200)
 
+    def test_metric_json_days_out_of_range(self):
+        """A days value too large for a timedelta must not 500.
+
+        int() accepts it, so the existing guard passes it through, and the
+        failure happens later at the timedelta.
+        """
+        TracTicketMetric.objects.get(slug="new-tickets-week").data.create(
+            measurement=42
+        )
+        url = reverse("metric-json", args=["new-tickets-week"], host="dashboard")
+        for days in ["3652059", "999999999", "-999999999"]:
+            with self.subTest(days=days):
+                request = self.factory.get(f"{url}?days={days}")
+                response = metric_json(request, "new-tickets-week")
+                self.assertEqual(response.status_code, 200)
+
+    def test_metric_json_bad_days_falls_back(self):
+        """Unusable values keep the default window rather than erroring."""
+        TracTicketMetric.objects.get(slug="new-tickets-week").data.create(
+            measurement=42
+        )
+        url = reverse("metric-json", args=["new-tickets-week"], host="dashboard")
+        for days in ["abc", "", "1.5"]:
+            with self.subTest(days=days):
+                request = self.factory.get(f"{url}?days={days}")
+                self.assertEqual(
+                    metric_json(request, "new-tickets-week").status_code, 200
+                )
+
 
 class AbstractMetricTestCase(TestCase):
     @classmethod

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -53,16 +53,18 @@ def metric_json(request, metric_slug):
 
     try:
         daysback = int(request.GET["days"])
-    except (TypeError, KeyError, ValueError):
+        # int() accepts values a timedelta cannot represent, so the window has
+        # to be built here to find out whether the number is usable at all.
+        start_date = datetime.datetime.now() - datetime.timedelta(days=daysback)
+    except (TypeError, KeyError, ValueError, OverflowError):
         daysback = 30
+        start_date = datetime.datetime.now() - datetime.timedelta(days=daysback)
 
     generation = generation_key()
     key = f"dashboard:metric:{metric_slug}:{daysback}"
 
     doc = cache.get(key, version=generation)
     if doc is None:
-        start_date = datetime.datetime.now() - datetime.timedelta(days=daysback)
-
         doc = model_to_dict(metric)
         doc["data"] = metric.gather_data(since=start_date)
         cache.set(key, doc, 60 * 60, version=generation)


### PR DESCRIPTION
Fixes #2841.

`metric_json` guards the `days` parameter against parsing only:

```python
try:
    daysback = int(request.GET["days"])
except (TypeError, KeyError, ValueError):
    daysback = 30
```

`int("3652059")` succeeds, so the guard passes it through and the request fails further down at

```python
start_date = datetime.datetime.now() - datetime.timedelta(days=daysback)
OverflowError: date value out of range
```

Widening that `except` would not have helped — the error is raised outside the block. The window is now built inside the guard, so a value too large for a `timedelta` falls back to the same 30-day default an unparseable one already does. `start_date` is computed once and reused instead of being recomputed on a cache miss.

### Before and after, through the view

| `days` | before | after |
|---|---|---|
| `30` | 200 | 200 |
| `abc` | 200 | 200 |
| `` (empty) | 200 | 200 |
| `-5` | 200 | 200 |
| `3652059` | **OverflowError** | 200 |
| `999999999` | **OverflowError** | 200 |
| `-999999999` | **OverflowError** | 200 |

Everything that worked before still works; only the three that raised now return the default window.

### Tests

Written first and run before the fix — all three out-of-range values failed with the real `OverflowError` at `views.py:60`. `test_metric_json_bad_days_falls_back` covers the values that were already handled, so a future change cannot quietly regress them.

`python -m manage test dashboard docs` — **101 tests, OK**. `black` and `isort` clean on both changed files.

I did not send any of these to dashboard.djangoproject.com. The code path is identical and a live request would only have added noise to your error reporting.
